### PR TITLE
use simple image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ TAGS      :=
 LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
 
 # Image URL to use all building/pushing image targets
-CONTROLLER_IMG ?= ibmcloud-cluster-api-controller
-CLUSTERCTL_IMG ?= ibmcloud-cluster-api-clusterctl
+CONTROLLER_IMG ?= controller
+CLUSTERCTL_IMG ?= clusterctl
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 REGISTRY ?= quay.io/cluster-api-provider-ibmcloud

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: k8scloudprovider/ibmcloud-cluster-api-controller:latest
+      - image: quay.io/cluster-api-provider-ibmcloud/controller:latest
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
         operator: Exists
       containers:
       - name: ibmcloud-machine-controller
-        image: quay.io/cluster-api-provider-ibmcloud/ibmcloud-cluster-api-controller:latest
+        image: quay.io/cluster-api-provider-ibmcloud/controller:latest
         env:
           - name: POD_NAMESPACE
             valueFrom:


### PR DESCRIPTION
as discussed in #116, we use simple name instead of full name because it is already under ibm account.