### PR TITLE
Add rtheis

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,6 +29,7 @@ aliases:
     - khahmed
     - mdelder
     - spzala
+    - rtheis
   cluster-api-ibmcloud-maintainers:
     - gyliu513
     - jichenjc


### PR DESCRIPTION
rtheis is one of the sig ibm cloud leads representing IKS.
