### PR TITLE
Fix documents

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: clusterapi-controllers
+  name: clusterapi-controller
   namespace: ibmcloud-provider-system
   labels:
     control-plane: controller-manager

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -19,11 +19,11 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
    # kubectl --kubeconfig minikube.kubeconfig get pods -n ibmcloud-provider-system
    NAMESPACE                   NAME                                     READY   STATUS    RESTARTS   AGE
-   ibmcloud-provider-system    clusterapi-controller-xxxxxxxxx-xxxxx   1/1     Running   0          27m
+   ibmcloud-provider-system    clusterapi-controller-0                  1/1     Running   0          27m
    ```
 
-2. Get log of clusterapi-controller-xxxxxxxx-xxxxx
+2. Get log of clusterapi-controller-0
 
    ```
-   # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controller-xxxxxxxxx-xxxxx -n ibmcloud-provider-system
+   # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controller-0 -n ibmcloud-provider-system
    ```

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -3,7 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Trouble shooting](#trouble-shooting)
-  - [Get log of clusterapi-controllers containers](#get-log-of-clusterapi-controllers-containers)
+  - [Get log of clusterapi-controller containers](#get-log-of-clusterapi-controller-containers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -11,7 +11,7 @@
 
 This guide (based on minikube and others should be similar) explains general info on how to debug issues if cluster failed to create.
 
-## Get log of clusterapi-controllers containers
+## Get log of clusterapi-controller containers
 
 1. Get ibmcloud container name, the output depends on the system you are running.
    the `minikube.kubeconfig` which is bootstrap cluster's kubeconfig by default locates at `cmd/clusterctl` folder.
@@ -19,11 +19,11 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
    # kubectl --kubeconfig minikube.kubeconfig get pods -n ibmcloud-provider-system
    NAMESPACE                   NAME                                     READY   STATUS    RESTARTS   AGE
-   ibmcloud-provider-system    clusterapi-controllers-xxxxxxxxx-xxxxx   1/1     Running   0          27m
+   ibmcloud-provider-system    clusterapi-controller-xxxxxxxxx-xxxxx   1/1     Running   0          27m
    ```
 
-2. Get log of clusterapi-controllers-xxxxxxxx-xxxxx
+2. Get log of clusterapi-controller-xxxxxxxx-xxxxx
 
    ```
-   # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controllers-xxxxxxxxx-xxxxx -n ibmcloud-provider-system
+   # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controller-xxxxxxxxx-xxxxx -n ibmcloud-provider-system
    ```


### PR DESCRIPTION
 - rename : `s/clusterapi-controllers/clusterapi-controller/`
    There is no convention for `statefulset` to use plural names. And I checked several providers, they use "controller-manager" as name. As there is namespace name for indication in `ibmcloud-provider-system`, I think both `controller-manager` and `clusterapi-controller` are fine.
 - fix doc: statefulset controller only has postfix -0 as for cluster api provider controller