### PR TITLE
Update machine cpu to 4

### DIFF
--- a/cmd/clusterctl/examples/ibmcloud/machines.yaml.template
+++ b/cmd/clusterctl/examples/ibmcloud/machines.yaml.template
@@ -42,7 +42,7 @@ items:
         kind: "IbmcloudMachineProviderSpec"
         domain: <domain name>
         maxMemory: 4096
-        startCpus: 1
+        startCpus: 4
         dataCenter: <datacenter name>
         osReferenceCode: <the operating system selection>
         localDiskFlag: true

--- a/cmd/clusterctl/examples/ibmcloud/machines.yaml.template
+++ b/cmd/clusterctl/examples/ibmcloud/machines.yaml.template
@@ -15,7 +15,7 @@ items:
         kind: "IbmcloudMachineProviderSpec"
         domain: <domain name>
         maxMemory: 4096
-        startCpus: 1
+        startCpus: 4
         dataCenter: <datacenter name>
         osReferenceCode: <the operating system selection>
         localDiskFlag: true


### PR DESCRIPTION
Change the default value to 4 for cpu to avoid such error occurs:
```
root@ibmcloud-master-rcgs5:/var/log# tail cloud-init-output.log
I0524 06:15:17.046374    4466 checks.go:131] validating if the service is enabled and active
I0524 06:15:17.072787    4466 checks.go:209] validating availability of port 10250
I0524 06:15:17.072863    4466 checks.go:209] validating availability of port 2379
I0524 06:15:17.072892    4466 checks.go:209] validating availability of port 2380
I0524 06:15:17.072922    4466 checks.go:254] validating the existence and emptiness of directory /var/lib/etcd
error execution phase preflight: [preflight] Some fatal errors occurred:
	[ERROR NumCPU]: the number of available CPUs 1 is less than the required 2
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
Cloud-init v. 18.5-45-g3554ffe8-0ubuntu1~18.04.1 running 'modules:final' at Fri, 24 May 2019 06:14:00 +0000. Up 26.89 seconds.
```

