### PR TITLE
Add steps of check kind for trouble-shooting 

### DIFF
--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -48,4 +48,4 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
 
 2. Check docker version.
-   kind v0.3.0 can work with docker 18.06.0 on ubuntu.
+   You may hit errors with kind v0.3.0 and docker 18.09.6 on ubuntu. Use docker version < 18.09.6.

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -49,7 +49,10 @@ This guide (based on minikube and others should be similar) explains general inf
 
 2. Check docker version.
 
-   You may hit errors as below with kind v0.3.0 and docker-ce 18.09.6 on ubuntu. Use docker-ce version < 18.09.6.
+   You may hit errors as below with kind v0.3.0 and docker-ce 18.09.6 on ubuntu.
+   Follow the tickets to solve the problem.
+   https://github.com/kubernetes-sigs/kind/issues/567
+   https://github.com/moby/moby/issues/1871
    ```
    Creating cluster "kind" ...
    ✓ Ensuring node image (kindest/node:v1.14.2) 🖼

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -47,8 +47,6 @@ This guide (based on minikube and others should be similar) explains general inf
    kubectl cluster-info
    ```
 
-2. Check docker version.
-
    You may hit errors as below with kind v0.3.0 and docker-ce 18.09.6 on ubuntu.
    Follow the tickets to solve the problem.
    - https://github.com/kubernetes-sigs/kind/issues/567

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -49,7 +49,7 @@ This guide (based on minikube and others should be similar) explains general inf
 
 2. Check docker version.
 
-   You may hit errors with kind v0.3.0 and docker-ce 18.09.6 on ubuntu. Use docker-ce version < 18.09.6.
+   You may hit errors as below with kind v0.3.0 and docker-ce 18.09.6 on ubuntu. Use docker-ce version < 18.09.6.
    ```
    Creating cluster "kind" ...
    ✓ Ensuring node image (kindest/node:v1.14.2) 🖼

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -48,4 +48,4 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
 
 2. Check docker version.
-   kind v0.3.0 cannot work with docker 18.09.6 on ubuntu.
+   kind v0.3.0 can work with docker 18.06.0 on ubuntu.

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -49,7 +49,7 @@ This guide (based on minikube and others should be similar) explains general inf
 
 2. Check docker version.
 
-   You may hit errors with kind v0.3.0 and docker 18.09.6 on ubuntu. Use docker version < 18.09.6.
+   You may hit errors with kind v0.3.0 and docker-ce 18.09.6 on ubuntu. Use docker-ce version < 18.09.6.
    ```
    Creating cluster "kind" ...
    ✓ Ensuring node image (kindest/node:v1.14.2) 🖼

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -52,7 +52,7 @@ This guide (based on minikube and others should be similar) explains general inf
    You may hit errors with kind v0.3.0 and docker 18.09.6 on ubuntu. Use docker version < 18.09.6.
    ```
    Creating cluster "kind" ...
- ✓ Ensuring node image (kindest/node:v1.14.2) 🖼
+   ✓ Ensuring node image (kindest/node:v1.14.2) 🖼
     ERRO[22:52:13] 0cd93e6e3b3a28c4216a3fa7b0d75337e83ca32f5e4095629c75a472b2ee89a6
     ERRO[22:52:13] docker: Error response from daemon: driver failed programming external connectivity on endpoint kind-control-plane (1229f3b0af4456532d4a8cf9ae274c0c03441da448de535ee94a1a6e25148d05):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 127.0.0.1 --dport 46796 -j DNAT --to-destination 172.17.0.2:6443 ! -i docker0: iptables: No chain/target/match by that name.
     ERRO[22:52:13]  (exit status 1)).

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -27,3 +27,24 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
    # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controller-0 -n ibmcloud-provider-system
    ```
+
+## Cannot create bootstrap cluster if you are using kind.
+   
+1. Check if kind works well.
+
+   ```
+   # kind create cluster
+   Creating cluster "kind" ...
+   ✓ Ensuring node image (kindest/node:v1.14.2) 🖼
+   ✓ Preparing nodes 📦
+   ✓ Creating kubeadm config 📜
+   ✓ Starting control-plane 🕹️
+   ✓ Installing CNI 🔌
+   ✓ Installing StorageClass 💾
+   Cluster creation complete. You can now use the cluster with:
+
+   export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+   kubectl cluster-info
+   ```
+
+  

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -30,7 +30,7 @@ This guide (based on minikube and others should be similar) explains general inf
 
 ## Cannot create bootstrap cluster if you are using kind
    
-1. Check if kind works well.
+   Check if kind works well.
 
    ```
    # kind create cluster

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -48,4 +48,15 @@ This guide (based on minikube and others should be similar) explains general inf
    ```
 
 2. Check docker version.
+
    You may hit errors with kind v0.3.0 and docker 18.09.6 on ubuntu. Use docker version < 18.09.6.
+   ```
+   Creating cluster "kind" ...
+ ✓ Ensuring node image (kindest/node:v1.14.2) 🖼
+    ERRO[22:52:13] 0cd93e6e3b3a28c4216a3fa7b0d75337e83ca32f5e4095629c75a472b2ee89a6
+    ERRO[22:52:13] docker: Error response from daemon: driver failed programming external connectivity on endpoint kind-control-plane (1229f3b0af4456532d4a8cf9ae274c0c03441da448de535ee94a1a6e25148d05):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 127.0.0.1 --dport 46796 -j DNAT --to-destination 172.17.0.2:6443 ! -i docker0: iptables: No chain/target/match by that name.
+    ERRO[22:52:13]  (exit status 1)).
+    ✗ Preparing nodes 📦
+    ERRO[22:52:13] docker run error: exit status 125
+    Error: failed to create cluster: docker run error: exit status 125
+   ```

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -28,7 +28,7 @@ This guide (based on minikube and others should be similar) explains general inf
    # kubectl --kubeconfig minikube.kubeconfig log clusterapi-controller-0 -n ibmcloud-provider-system
    ```
 
-## Cannot create bootstrap cluster if you are using kind.
+## Cannot create bootstrap cluster if you are using kind
    
 1. Check if kind works well.
 
@@ -47,4 +47,5 @@ This guide (based on minikube and others should be similar) explains general inf
    kubectl cluster-info
    ```
 
-  
+2. Check docker version.
+   kind v0.3.0 cannot work with docker 18.09.6 on ubuntu.

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -51,8 +51,8 @@ This guide (based on minikube and others should be similar) explains general inf
 
    You may hit errors as below with kind v0.3.0 and docker-ce 18.09.6 on ubuntu.
    Follow the tickets to solve the problem.
-   https://github.com/kubernetes-sigs/kind/issues/567
-   https://github.com/moby/moby/issues/1871
+   - https://github.com/kubernetes-sigs/kind/issues/567
+   - https://github.com/moby/moby/issues/1871
    ```
    Creating cluster "kind" ...
    ✓ Ensuring node image (kindest/node:v1.14.2) 🖼

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -4,6 +4,7 @@
 
 - [Trouble shooting](#trouble-shooting)
   - [Get log of clusterapi-controller containers](#get-log-of-clusterapi-controller-containers)
+  - [Cannot create bootstrap cluster if you are using kind](#cannot-create-bootstrap-cluster-if-you-are-using-kind)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
**What this PR does / why we need it**:
kind 0.3.0 cannot work with docker 18.09.6 on ubuntu
Append some steps to check if kind works with docker for trouble-shooting before user create k8s cluster on ibmcloud.

**Which issue(s) this PR fixes**:
Fixes #186 

**Specify your PR reviewers**:
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:
Log kind issue for docker 18.09.6。
https://github.com/kubernetes-sigs/kind/issues/567

/sig ibmcloud

No any change on images.

**Release note**:
```release-note
NONE
```

