### PR TITLE
Update base image to fix security issue

### DIFF
--- a/cmd/manager/Dockerfile
+++ b/cmd/manager/Dockerfile
@@ -11,8 +11,8 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/manager
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest
-RUN apt-get update && apt-get install -y ca-certificates
+FROM alpine:latest
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-ibmcloud/manager .
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Change base image to avoid security issues.

1) Tested image build.
2) Test create a cluster on SL.
3) Passed image security scan.

https://quay.io/repository/wanghh2000/cluster-api-provider-ibmcloud-controller/manifest/sha256:f22bb127d99eeab3e53741318fe0df5349e2a8cf66bc73aab895144934062f81?tab=vulnerabilities

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #115 

**Specify your PR reviewers**:

/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/sig ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No version change, and just change base image.
**Release note**:
NONE
