### PR TITLE
add command line options for ibm cloud operation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,7 @@ import (
 	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/apis"
+	_ "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/controller"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
 )

--- a/pkg/cloud/ibmcloud/actuators/machine/actuator.go
+++ b/pkg/cloud/ibmcloud/actuators/machine/actuator.go
@@ -38,14 +38,13 @@ import (
 	bootstrap "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/bootstrap"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud"
 	ibmcloudclients "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud/clients"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
 )
 
 const (
 	ProviderName = "ibmcloud"
 	UserDataKey  = "userData"
-
-	TokenTTL = 60 * time.Minute
 
 	MachinePending  string = "Pending"
 	MachineCreating string = "Creating"
@@ -356,7 +355,7 @@ func (ic *IBMCloudClient) createBootstrapToken() (string, error) {
 		return "", err
 	}
 
-	expiration := time.Now().UTC().Add(TokenTTL)
+	expiration := time.Now().UTC().Add(options.TokenTTL)
 	tokenSecret, err := bootstrap.GenerateTokenSecret(token, expiration)
 	if err != nil {
 		klog.Fatalf("Unable to create token: %v", err)

--- a/pkg/cloud/ibmcloud/options/options.go
+++ b/pkg/cloud/ibmcloud/options/options.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"time"
+)
+
+var (
+	TokenTTL time.Duration
+)
+
+func init() {
+	flag.DurationVar(&TokenTTL, "token_ttl", 60*time.Minute, "TTL for kubeadm bootstrap token of the target Kubernetes cluster")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is not the perfect solution but a better way in my thought.

The `options` package with `init()` function to register flags to controller to avoid deeply passing arguments in a framework. This is not what I like but suitable in this case.

Make `options` under `ibmcloud` because most of configurable items should for ibmcloud.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/sig ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
