### PR TITLE
Add unit test code of GO/Shell functions for custom SSH key file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ vet: depend generate
 ############################################################
 # test section
 ############################################################
-test: unit functional fmt vet generate_yaml_test
+test: unit functional fmt vet generate_yaml_test 
 
 unit: depend generate check
 	go test -tags=unit $(shell go list ./...) $(TESTARGS)
@@ -125,11 +125,24 @@ kubectl:
 # Generate manifests e.g. CRD, RBAC etc.
 generate_yaml_test: kubectl
 	# Create a dummy file for test only
-	echo 'clouds' > cmd/clusterctl/examples/ibmcloud/dummy-clouds-test.yaml
-	$(GENERATE_YAML_PATH)/$(GENERATE_YAML_EXEC) -f dummy-clouds-test.yaml ubuntu $(GENERATE_YAML_TEST_FOLDER)
 	# the folder will be generated under same folder of $(GENERATE_YAML_PATH)
-	rm -fr $(GENERATE_YAML_PATH)/$(GENERATE_YAML_TEST_FOLDER)
-	rm -f cmd/clusterctl/examples/ibmcloud/dummy-clouds-test.yaml
+
+	# "" is to test default value
+	# "id_userCustomKey" is to test custom SSH Key
+	
+	for KeyFile in "" "id_userCustomKey"; \
+	do \
+		if [ "x$${KeyFile}" != "x" ]; then \
+			export IBMCLOUD_HOST_SSH_PRIVATE_FILE=$${KeyFile}; \
+		fi; \
+		echo 'clouds' > cmd/clusterctl/examples/ibmcloud/dummy-clouds-test.yaml; \
+		$(GENERATE_YAML_PATH)/$(GENERATE_YAML_EXEC) -f dummy-clouds-test.yaml ubuntu $(GENERATE_YAML_TEST_FOLDER); \
+		rm -fr $(GENERATE_YAML_PATH)/$(GENERATE_YAML_TEST_FOLDER); \
+		rm -f cmd/clusterctl/examples/ibmcloud/dummy-clouds-test.yaml; \
+		if [ "x$${KeyFile}" != "x" ]; then \
+			unset IBMCLOUD_HOST_SSH_PRIVATE_FILE; \
+		fi; \
+	done
 
 ############################################################
 # build section

--- a/pkg/cloud/ibmcloud/deployer_test.go
+++ b/pkg/cloud/ibmcloud/deployer_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ibmcloud
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetSSHKeyFile(t *testing.T) {
+	// default case
+	homeDir, ok := os.LookupEnv("HOME")
+	if !ok {
+		t.Errorf("Unable to use HOME environment variable to find SSH key")
+	}
+	defaultKey := homeDir + "/.ssh/id_ibmcloud"
+	targetKeyfile := getSSHKeyFile(homeDir)
+	if 0 != strings.Compare(targetKeyfile, defaultKey) {
+		t.Errorf("Unexpected output: %s, expect output: %s", targetKeyfile, defaultKey)
+	}
+
+	// custom case
+	customKey := "examples/ibmcloud/mykey"
+	err := os.Setenv("IBMCLOUD_HOST_SSH_PRIVATE_FILE", customKey)
+	if err != nil {
+		t.Errorf("Can not set environment variable IBMCLOUD_HOST_SSH_PRIVATE_FILE")
+	}
+	targetKeyfile = getSSHKeyFile(homeDir)
+	if 0 != strings.Compare(targetKeyfile, customKey) {
+		t.Errorf("Unexpected output: %s, expect output: %s", targetKeyfile, customKey)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add unit test code for custom SSH key file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #256 

```
?       sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud     [no test files]
=== RUN   TestGetSSHKeyFile
--- PASS: TestGetSSHKeyFile (0.00s)
PASS
ok      sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud    (cached)


Generating SSH key files for IBM cloud machine access.
Generating public/private rsa key pair.
Your identification has been saved in /root/.ssh/id_ibmcloud.
Your public key has been saved in /root/.ssh/id_ibmcloud.pub.
The key fingerprint is:
SHA256:Ki+jgTbHDs/W99lAMthpqK7u7nAXmn44D1li5h/6ugI root@gummite1.fyre.ibm.com
The key's randomart image is:
+---[RSA 2048]----+
|                 |
|                 |
|                 |
|      + .        |
|  + oo *S.       |
|E=.*....+        |
|++O== .  .       |
|+o@B+= .  +      |
|=BO&+oo .o .     |
+----[SHA256]-----+
Generating SSH key files for IBM cloud machine access.
Generating public/private rsa key pair.
Your identification has been saved in id_userCustomKey.
Your public key has been saved in id_userCustomKey.pub.
The key fingerprint is:
SHA256:oOARD5xy0iH3fY+LjTa5PEJLIFVGVrmyVnGgvX4JLjA root@gummite1.fyre.ibm.com
The key's randomart image is:
+---[RSA 2048]----+
|.o===.oo         |
|oo*B +o .        |
| =o + ++.        |
|...o..o+ o       |
| .E..+o S .      |
|   o=o * o       |
|   +..O =        |
|    o+.+         |
|     .o.         |
+----[SHA256]-----+

```

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/sig ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No image change.

**Release note**:
```release-note
NONE
```
