### PR TITLE
add unit test for all functions of deployer.go

### DIFF
--- a/pkg/cloud/ibmcloud/deployer_test.go
+++ b/pkg/cloud/ibmcloud/deployer_test.go
@@ -20,7 +20,96 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	ibmcloudv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/apis/ibmcloud/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	yaml "sigs.k8s.io/yaml"
 )
+
+func TestGetIP(t *testing.T) {
+	// exist IP case
+	testIP := "10.0.0.1"
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCluster",
+			Namespace: "testNamespace",
+		},
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testMachine",
+			Namespace: "testNamespace",
+			Annotations: map[string]string{
+				IBMCloudIPAnnotationKey: testIP,
+			},
+		},
+	}
+
+	deploy := NewDeploymentClient()
+	ip, err := deploy.GetIP(cluster, machine)
+	if err != nil || ip != testIP {
+		t.Errorf("Unable to get right machine IP %s", testIP)
+	}
+}
+
+func TestGetKubeConfig(t *testing.T) {
+	// test IP
+	testIP := "127.0.0.1"
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCluster",
+			Namespace: "testNamespace",
+		},
+	}
+	// ssh user name
+	tmpConfig := ibmcloudv1.IBMCloudMachineProviderSpec{
+		SshUserName: "testUser",
+	}
+
+	bytes, err := yaml.Marshal(tmpConfig)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testMachine",
+			Namespace: "testNamespace",
+			Annotations: map[string]string{
+				IBMCloudIPAnnotationKey: testIP,
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ProviderSpec: clusterv1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					Raw: bytes,
+				},
+			},
+		},
+	}
+
+	// test providerSpec
+	_, err = ibmcloudv1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	deploy := NewDeploymentClient()
+	config, err := deploy.GetKubeConfig(cluster, machine)
+	if err != nil {
+		t.Error(err)
+	}
+	if config != "" {
+		t.Logf("Found kubeconfig: %s", config)
+	}
+
+}
 
 func TestGetSSHKeyFile(t *testing.T) {
 	// default case


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Add unit test for all functions of deployer.go and it can go through code logic of fun `GetKubeConfig`, then return "" since fake IP and ssh user name for `util.ExecCommand`.

```
ok      sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/bootstrap (cached)
?       sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud     [no test files]
=== RUN   TestGetIP
--- PASS: TestGetIP (0.00s)
=== RUN   TestGetKubeConfig
--- PASS: TestGetKubeConfig (0.15s)
=== RUN   TestGetSSHKeyFile
--- PASS: TestGetSSHKeyFile (0.00s)
PASS
ok      sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud    0.643s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/sig ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No image change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
