### PR TITLE
UBUNTU_LATEST does not work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,16 @@ generate_yaml_test: kubectl
 ############################################################
 build: manager clusterctl
 
-manager: depend generate check
+manager: depend generate check mgr
+
+clusterctl: depend generate check cmd
+
+mgr:
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o bin/manager \
 		cmd/manager/main.go
-
-clusterctl: depend generate check
+cmd:
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o bin/clusterctl \
@@ -196,8 +199,8 @@ push-images: push-clusterctl-image push-controller-image
 build-push-images: images push-images
 
 # quickly get target image
-new-controller: controller-image push-controller-image
-new-clusterctl: clusterctl-image push-clusterctl-image
+mgr-img: controller-image push-controller-image
+cmd-img: clusterctl-image push-clusterctl-image
 
 ############################################################
 # clean section

--- a/cmd/clusterctl/examples/ibmcloud/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/ibmcloud/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -43,9 +43,7 @@ function install_configure_docker () {
     chmod +x /usr/sbin/policy-rc.d
     trap "rm /usr/sbin/policy-rc.d" RETURN
 
-    # TODO: remove the version after kubeadm dependency fixed
-    docker_version=$(apt-cache policy docker.io | grep 18.06 | awk '{print $1}' | head -n1)
-    apt-get install -y docker.io=${docker_version}
+    apt-get install -y docker.io
 
     echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
 

--- a/cmd/clusterctl/examples/ibmcloud/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/ibmcloud/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -33,9 +33,7 @@ function install_configure_docker () {
     chmod +x /usr/sbin/policy-rc.d
     trap "rm /usr/sbin/policy-rc.d" RETURN
 
-    # TODO: remove the version after kubeadm dependency fixed
-    docker_version=$(apt-cache policy docker.io | grep 18.06 | awk '{print $1}' | head -n 1)
-    apt-get install -y docker.io=${docker_version}
+    apt-get install -y docker.io
 
     echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
 


### PR DESCRIPTION
1. The old code hardcoded docker version. But it does not exist now. Just removed and tested fine.
2. Make file change. There is no need to check and generate before build a binary. It wastes time for waiting this.