### PR TITLE
Proposal 🏃 dockerFile: bump builder to use go 1.13.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: go
 
 go:
-  - "1.12"
+  - "1.13"
 
 branches:
   only:
@@ -34,7 +34,7 @@ before_install:
 install: true
 
 before_script:
-  - docker login -u ${QUAY_USER} -p ${QUAY_KEY} ${QUAY_REPO} 
+  - docker login -u ${QUAY_USER} -p ${QUAY_KEY} ${QUAY_REPO}
 
 script:
   - make images

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 # Build the cluster binary
-FROM golang:1.12.5 as builder
+FROM golang:1.13.8 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-ibmcloud

--- a/cmd/manager/Dockerfile
+++ b/cmd/manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.13.8 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-ibmcloud


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump dockerfiles to builder use go 1.13.8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
dockerFile: bump builder to use go 1.13.8
```
