### PR TITLE
fix: issue#306: support provision specified kube version cluster

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 commonLabels:
   cluster.x-k8s.io/v1alpha3: v1alpha3
   
@@ -8,6 +10,7 @@ commonLabels:
 resources:
 - bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
 - bases/infrastructure.cluster.x-k8s.io_ibmvpcmachines.yaml
+- bases/infrastructure.cluster.x-k8s.io_ibmvpcmachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -52,6 +52,7 @@ spec:
     namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
+      kubernetesVersion: ${KUBERNETES_VERSION}
       controllerManager:
         extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:


### PR DESCRIPTION
**What this PR does / why we need it**:
2 fixes included:
- the `--kubernetes-version` passed in during `clusterctl init` is not respecte, and the reason is because it's not properly set in the template. Added that variable to kubeadmconfig, so it can be picked up and passed in to kubeadm init
- added missing `ibmvpcmachinetemplates` to kustomize 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #306

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan @wentao-zh 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
