### PR TITLE
enable metrics scraping via prometheus

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: "https"
   labels:
     control-plane: controller-manager
   name: controller-manager-metrics-service


### PR DESCRIPTION
**What this PR does / why we need it**:

prometheus as the defacto standard for monitoring in a kubernetes
environment is generally configured to scrape metrics only if the
observed targets (pods, service, endpoints) has set proper annotations.

- [related PR with documentation on `cluster-api`](https://github.com/kubernetes-sigs/cluster-api/pull/4247)
- [official prometheus config example](https://github.com/prometheus/prometheus/blob/release-2.25/documentation/examples/prometheus-kubernetes.yml#L143-L183)
- corresponding implementation on other providers (all others didn't set the annotation yet - i'm on it)
  - [AWS](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/config/rbac/auth_proxy_service.yaml)
  - [Metal3](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/config/rbac/auth_proxy_service.yaml)
  - [GCP](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/master/config/rbac/auth_proxy_service.yaml)
  - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/config/rbac/auth_proxy_service.yaml)
  - [vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/config/rbac/auth_proxy_service.yaml)

Signed-off-by: Constanti, Mario <mario.constanti@daimler.com>

> Mario Constanti [mario.constanti@daimler.com](mailto:mario.constanti@daimler.com), Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md) 

**Release note**:
```release-note
NONE
```
