### PR TITLE
README - add IBM Cloud VPC2 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
     ```
     ~ kubectl get clusters
     NAME         PHASE
-    ibm-vpc-0   Provisioned
+    ibm-vpc-0    Provisioned
     ```
 
     Kubeadm Control Plane

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
     - [Code of conduct](#code-of-conduct)
   - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
-    - [Cluster Creation](#cluster-creation)
+  - [How to provision a simple workload cluster in IBM Cloud VPC Gen2 from local bootstrap cluster](#how-to-provision-a-simple-workload-cluster-in-ibm-cloud-vpc-gen2-from-local-bootstrap-cluster)
+    - [Build workload cluster image:](#build-workload-cluster-image)
+    - [Provision local boostrap management cluster:](#provision-local-boostrap-management-cluster)
+    - [Provision Workload Cluster in IBM Cloud VPC](#provision-workload-cluster-in-ibm-cloud-vpc)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -55,20 +58,46 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 4. An appropriately configured [Go development environment](https://golang.org/doc/install)
 5. Install `clusterctl` tool (see [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl))
 
-### Cluster Creation
+## How to provision a simple workload cluster in IBM Cloud VPC Gen2 from local bootstrap cluster
 
-1. Create Management Cluster
+### Build workload cluster image:
 
-    Using kind:
+1. Build a qcow2 image suitable for use as a Kubernetes cluster machine as detailed in the image builder [book](https://image-builder.sigs.k8s.io/capi/providers/raw.html).
+
+2. Create a VPC Gen2 custom image based on the qcow2 image built in the previous step as detailed in the VPC [documentation](https://cloud.ibm.com/docs/vpc?topic=vpc-planning-custom-images).
+
+### Provision local boostrap management cluster:
+
+1. Create simple, local bootstrap cluster with a control-plane and worker node
+
+    Using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/):
 
     ```
-    kind create cluster
+    ~ kind create cluster --name my-bootstrap --config bootstrap.yaml
     ```
 
-2. Apply CRDs
+    Example bootstrap.yaml:
+    ```
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+       - role: control-plane
+       - role: worker
+    ```
+
+    Make sure the nodes are in `Ready` state before moving on.
 
     ```
-    kubectl apply -f config/crd/bases
+    ~ kubectl get nodes
+    NAME                         STATUS   ROLES                  AGE   VERSION
+    my-bootstrap-control-plane   Ready    control-plane,master   46h   v1.20.2
+    my-bootstrap-worker          Ready    <none>                 46h   v1.20.2
+    ```
+
+2. Apply IBM VPC CAPI CRDs
+
+    ```
+    ~ kubectl apply -f config/crd/bases
     ```
 
     Output:
@@ -78,10 +107,12 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
     customresourcedefinition.apiextensions.k8s.io/ibmvpcmachinetemplates.infrastructure.cluster.x-k8s.io created
     ```
 
-3. Initialize Management Cluster
+3. Initialize local bootstrap cluter as a management cluster
+
+    This cluster will be used to provision a workload cluster in IBM Cloud.
 
     ```
-    clusterctl init
+    ~ clusterctl init
     ```
 
     Output:
@@ -100,35 +131,41 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
       clusterctl config cluster [name] --kubernetes-version [version] | kubectl apply -f -
     ```
 
-4. Set Workload Cluster Environment Variables
+### Provision Workload Cluster in IBM Cloud VPC
 
-   ```
+1. Set workload cluster environment variables
 
-   export IAM_ENDPOINT=https://iam.test.cloud.ibm.com/identity/token
-   export SERVICE_ENDPOINT=https://us-east.iaas.cloud.ibm.com/v1
-   export API_KEY=<YOUR_API_KEY>
-
-   ```
-
-5. Run Provider Controllers
+    The sample IAM_ENDPOINT below points to Production and the SERVICE_ENDPOINT points to the `us-east` VPC region. Make sure these values reflect your target VPC environment in IBM Cloud.
 
     ```
-    make run
+    export IAM_ENDPOINT=https://iam.cloud.ibm.com/identity/token
+    export SERVICE_ENDPOINT=https://us-east.iaas.cloud.ibm.com/v1
+    export API_KEY=<YOUR_API_KEY>
     ```
 
-6. Create a cluster:
+2. Run IBM provider controllers
+
+    The controllers will run against your local management bootstrap cluster.
+
+    ```
+    ~ make run
+    ```
+
+3. Provision workload cluster in IBM Cloud
 
     You can use clusterctl to render the yaml through templates.
+
+    **Note:** the `IBMVPC_IMAGE_ID` value below should reflect the ID of the custom qcow2 image
 
     ```
     IBMVPC_REGION=us-south \
     IBMVPC_ZONE=us-south-1 \
     IBMVPC_RESOURCEGROUP=4f15679623607b855b1a27a67f20e1c7 \
-    IBMVPC_NAME=ibm-vpc-1 \
+    IBMVPC_NAME=ibm-vpc-0 \
     IBMVPC_IMAGE_ID=r134-ea84bbec-7986-4ff5-8489-d9ec34611dd4 \
     IBMVPC_PROFILE=bx2-4x16 \
     IBMVPC_SSHKEY_ID=r134-2a82b725-e570-43d3-8b23-9539e8641944 \
-    clusterctl config cluster ibm-vpc-1 --kubernetes-version v1.14.3 \
+    clusterctl config cluster ibm-vpc-0 --kubernetes-version v1.19.9 \
     --target-namespace default \
     --control-plane-machine-count=1 \
     --worker-machine-count=2 \
@@ -146,4 +183,60 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
     kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/ibm-vpc-5-md-0 created
     ```
 
-    **Note:** the image ID field above must currently reference a custom vm that gets imported as a custom image for VSI provisioning in IBM Cloud VPC2.
+4. Deploy Container Network Interface (CNI)
+
+    Example: calico
+    ```
+    kubectl apply -f https://docs.projectcalico.org/v3.15/manifests/calico.yaml
+    ```
+
+
+5. Check the state of the provisioned cluster and machine objects within the local management cluster
+
+    Clusters
+    ```
+    ~ kubectl get clusters
+    NAME         PHASE
+    ibm-vpc-0   Provisioned
+    ```
+
+    Kubeadm Control Plane
+    ```
+    ~ kubectl get kubeadmcontrolplane
+    NAME                       INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
+    ibm-vpc-0-control-plane    true          true                   v1.19.9   1          1       1
+    ```
+
+    Machines
+    ```
+    ~ kubectl get machines
+    ibm-vpc-0-control-plane-vzz47     ibmvpc://ibm-vpc-0/ibm-vpc-0-control-plane-rg6xv   Running        v1.19.9
+    ibm-vpc-0-md-0-5444cfcbcd-6gg5z   ibmvpc://ibm-vpc-0/ibm-vpc-0-md-0-dbxb7            Running        v1.19.9
+    ibm-vpc-0-md-0-5444cfcbcd-7kr9x   ibmvpc://ibm-vpc-0/ibm-vpc-0-md-0-k7blr            Running        v1.19.9
+    ```
+
+6.  Check the state of the newly provisioned cluster within IBM Cloud
+
+    ```
+    ~ clusterctl get kubeconfig ibm-vpc-0 > ~/.kube/ibm-vpc-0
+    ~ export KUBECONFIG=~/.kube/ibm-vpc-0
+    ~ kubectl get nodes
+    NAME                             STATUS   ROLES    AGE   VERSION
+    ibm-vpc-0-control-plane-rg6xv    Ready    master   41h   v1.18.15
+    ibm-vpc-0-md-0-4dc5c             Ready    <none>   41h   v1.18.15
+    ibm-vpc-0-md-0-dbxb7             Ready    <none>   20h   v1.18.15
+    ```
+
+7. Experiment with machinedeployment alterations in your management cluster
+
+    With your management *(local)* and workload *(IBM Cloud)* clusters successfully provisioned, you can now experiment with altering the number of machine deployment replicas in your management cluster and see the replica counts reconciled in your workload cluster.
+
+    ```
+    ~ kubectl get machinedeployments
+    NAME              PHASE       REPLICAS   READY   UPDATED   UNAVAILABLE
+    ibm-vpc-0-md-0    Running     2          2       2
+
+    ~ kubectl edit machinedeployment ibm-vpc-0-md-0
+    ```
+
+    Increase / decrease the `replicas: 2` count in the spec section to see the machine replicas reconciled within the workload cluster.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     Using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/):
 
-    ```
+    ```console
     ~ kind create cluster --name my-bootstrap --config bootstrap.yaml
     ```
 
     Example bootstrap.yaml:
-    ```
+    ```yaml
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
@@ -87,7 +87,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     Make sure the nodes are in `Ready` state before moving on.
 
-    ```
+    ```console
     ~ kubectl get nodes
     NAME                         STATUS   ROLES                  AGE   VERSION
     my-bootstrap-control-plane   Ready    control-plane,master   46h   v1.20.2
@@ -96,12 +96,12 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 2. Apply IBM VPC CAPI CRDs
 
-    ```
+    ```console
     ~ kubectl apply -f config/crd/bases
     ```
 
     Output:
-    ```
+    ```console
     customresourcedefinition.apiextensions.k8s.io/ibmvpcclusters.infrastructure.cluster.x-k8s.io created
     customresourcedefinition.apiextensions.k8s.io/ibmvpcmachines.infrastructure.cluster.x-k8s.io created
     customresourcedefinition.apiextensions.k8s.io/ibmvpcmachinetemplates.infrastructure.cluster.x-k8s.io created
@@ -111,12 +111,12 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     This cluster will be used to provision a workload cluster in IBM Cloud.
 
-    ```
+    ```console
     ~ clusterctl init
     ```
 
     Output:
-    ```
+    ```console
     Fetching providers
     Installing cert-manager Version="v1.1.0"
     Waiting for cert-manager to be available...
@@ -137,7 +137,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     The sample IAM_ENDPOINT below points to Production and the SERVICE_ENDPOINT points to the `us-east` VPC region. Make sure these values reflect your target VPC environment in IBM Cloud.
 
-    ```
+    ```console
     export IAM_ENDPOINT=https://iam.cloud.ibm.com/identity/token
     export SERVICE_ENDPOINT=https://us-east.iaas.cloud.ibm.com/v1
     export API_KEY=<YOUR_API_KEY>
@@ -147,7 +147,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     The controllers will run against your local management bootstrap cluster.
 
-    ```
+    ```console
     ~ make run
     ```
 
@@ -157,7 +157,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     **Note:** the `IBMVPC_IMAGE_ID` value below should reflect the ID of the custom qcow2 image
 
-    ```
+    ```console
     IBMVPC_REGION=us-south \
     IBMVPC_ZONE=us-south-1 \
     IBMVPC_RESOURCEGROUP=4f15679623607b855b1a27a67f20e1c7 \
@@ -173,7 +173,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
     ```
 
     Output:
-    ```
+    ```console
     cluster.cluster.x-k8s.io/ibm-vpc-5 created
     ibmvpccluster.infrastructure.cluster.x-k8s.io/ibm-vpc-5 created
     kubeadmcontrolplane.controlplane.cluster.x-k8s.io/ibm-vpc-5-control-plane created
@@ -186,7 +186,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 4. Deploy Container Network Interface (CNI)
 
     Example: calico
-    ```
+    ```console
     kubectl apply -f https://docs.projectcalico.org/v3.15/manifests/calico.yaml
     ```
 
@@ -194,21 +194,21 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 5. Check the state of the provisioned cluster and machine objects within the local management cluster
 
     Clusters
-    ```
+    ```console
     ~ kubectl get clusters
     NAME         PHASE
     ibm-vpc-0    Provisioned
     ```
 
     Kubeadm Control Plane
-    ```
+    ```console
     ~ kubectl get kubeadmcontrolplane
     NAME                       INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
     ibm-vpc-0-control-plane    true          true                   v1.19.9   1          1       1
     ```
 
     Machines
-    ```
+    ```console
     ~ kubectl get machines
     ibm-vpc-0-control-plane-vzz47     ibmvpc://ibm-vpc-0/ibm-vpc-0-control-plane-rg6xv   Running        v1.19.9
     ibm-vpc-0-md-0-5444cfcbcd-6gg5z   ibmvpc://ibm-vpc-0/ibm-vpc-0-md-0-dbxb7            Running        v1.19.9
@@ -217,7 +217,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 6.  Check the state of the newly provisioned cluster within IBM Cloud
 
-    ```
+    ```console
     ~ clusterctl get kubeconfig ibm-vpc-0 > ~/.kube/ibm-vpc-0
     ~ export KUBECONFIG=~/.kube/ibm-vpc-0
     ~ kubectl get nodes
@@ -231,7 +231,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     With your management *(local)* and workload *(IBM Cloud)* clusters successfully provisioned, you can now experiment with altering the number of machine deployment replicas in your management cluster and see the replica counts reconciled in your workload cluster.
 
-    ```
+    ```console
     ~ kubectl get machinedeployments
     NAME              PHASE       REPLICAS   READY   UPDATED   UNAVAILABLE
     ibm-vpc-0-md-0    Running     2          2       2

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
     ```console
     export IAM_ENDPOINT=https://iam.cloud.ibm.com/identity/token
-    export SERVICE_ENDPOINT=https://us-east.iaas.cloud.ibm.com/v1
+    export SERVICE_ENDPOINT=https://us-south.iaas.cloud.ibm.com/v1
     export API_KEY=<YOUR_API_KEY>
     ```
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
     NAME              PHASE       REPLICAS   READY   UPDATED   UNAVAILABLE
     ibm-vpc-0-md-0    Running     2          2       2
 
-    ~ kubectl edit machinedeployment ibm-vpc-0-md-0
+    ~ kubectl scale machinedeployment ibm-vpc-0-md-0 --replicas 3
     ```
 
     Increase / decrease the `replicas: 2` count in the spec section to see the machine replicas reconciled within the workload cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:

The README for this repo needs greater details for users looking to leverage the IBM CAPI Provider within an IBM Cloud VPC2 environment. I recently went through this process and the current README was insufficient. Having successfully provisioned a workload cluster in IBM Cloud VPC2, this PR contains the instructions necessary for other users to successfully accomplish that same task.

**Which issue(s) this PR fixes**

This PR fixes #317 

**Specify your PR reviewers**:
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```release-note
NONE
```
