### PR TITLE
fix provider ID can not be set

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -65,12 +65,18 @@ spec:
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
+        kubeletExtraArgs: 
+          cloud-provider: external
+          provider-id: ibmvpc://${CLUSTER_NAME}/'{{ v1.local_hostname }}'
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       discovery: {}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
+        kubeletExtraArgs: 
+          cloud-provider: external
+          provider-id: ibmvpc://${CLUSTER_NAME}/'{{ v1.local_hostname }}'
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 kind: IBMVPCMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -131,4 +137,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: ibmvpc://${CLUSTER_NAME}/'{{ v1.local_hostname }}'
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fixed issue about provider ID in node is empty.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/304
**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @jichenjc @xunpan

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
