### PR TITLE
Add environmetal variable to set providerID format

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -437,7 +437,7 @@ func (m *PowerVSMachineScope) GetZone() string {
 // SetProviderID will set the provider id for the machine.
 func (m *PowerVSMachineScope) SetProviderID(id *string) {
 	// Based on the ProviderIDFormat version the providerID format will be decided.
-	if options.PowerVSProviderIDFormat == options.PowerVSProviderIDFormatV2 {
+	if options.PowerVSProviderIDFormatType(options.PowerVSProviderIDFormat) == options.PowerVSProviderIDFormatV2 {
 		if id != nil {
 			m.IBMPowerVSMachine.Spec.ProviderID = pointer.StringPtr(fmt.Sprintf("ibmpowervs://%s/%s/%s/%s", m.GetRegion(), m.GetZone(), m.IBMPowerVSMachine.Spec.ServiceInstanceID, *id))
 		}

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--metrics-bind-addr=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - "--leader-elect"
         - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--powervs-provider-id-fmt=${POWERVS_PROVIDER_ID_FORMAT:=v1}"
         image: controller:latest
         name: manager
         ports:

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -55,6 +55,21 @@ Add following extra_args to log Power VS REST API Requests/Responses
    }
 }
 ```
+
+To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage, Set `POWERVS_PROVIDER_ID_FORMAT` to `v2` under kustomize_substitutions.
+
+```json
+{
+   "default_registry": "gcr.io/you-project-name-here",
+   "provider_repos": ["../cluster-api-provider-ibmcloud"],
+   "enable_providers": ["ibmcloud", "kubeadm-bootstrap", "kubeadm-control-plane"],
+   "kustomize_substitutions": {
+      "IBMCLOUD_API_KEY": "XXXXXXXXXXXXXXXXXX",
+      "POWERVS_PROVIDER_ID_FORMAT": "v2"
+   }
+}
+```
+
 **NOTE**: For information about all the fields that can be used in the `tilt-settings.json` file, check them [here](https://cluster-api.sigs.k8s.io/developer/tilt.html#tilt-settingsjson-fields).
 
 ## Run Tilt

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -44,9 +44,14 @@ it into a management cluster using `clusterctl`.
 
     > Note: Refer [Regions-Zones Mapping](/reference/regions-zones-mapping.html) for more information.
 
-3. Initialize local bootstrap cluter as a management cluster
+   > Note: To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage. Set the `POWERVS_PROVIDER_ID_FORMAT` environmental variable
+    ```console
+      export POWERVS_PROVIDER_ID_FORMAT=v2
+    ```
+
+2. Initialize local bootstrap cluster as a management cluster
     
-    When executed for the first time, the following command accepts the infrasturcture provider as an input to install. `clusterctl init` automatically adds to the list the cluster-api core provider, and if unspecified, it also adds the kubeadm bootstrap and kubeadm control-plane providers, thereby converting it into a management cluster which will be used to provision a workload cluster in IBM Cloud.   
+    When executed for the first time, the following command accepts the infrastructure provider as an input to install. `clusterctl init` automatically adds to the list the cluster-api core provider, and if unspecified, it also adds the kubeadm bootstrap and kubeadm control-plane providers, thereby converting it into a management cluster which will be used to provision a workload cluster in IBM Cloud.
 
     ```console
     ~ clusterctl init --infrastructure ibmcloud:<TAG>

--- a/main.go
+++ b/main.go
@@ -220,13 +220,13 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(
 		&options.PowerVSProviderIDFormat,
 		"powervs-provider-id-fmt",
-		options.PowerVSProviderIDFormatV1,
+		string(options.PowerVSProviderIDFormatV1),
 		"ProviderID format is used set the Provider ID format for Machine",
 	)
 }
 
 func validateFlags() error {
-	switch options.PowerVSProviderIDFormat {
+	switch options.PowerVSProviderIDFormatType(options.PowerVSProviderIDFormat) {
 	case options.PowerVSProviderIDFormatV1:
 		setupLog.Info("Using v1 version of ProviderID format")
 	case options.PowerVSProviderIDFormatV2:

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -16,11 +16,16 @@ limitations under the License.
 
 package options
 
+// PowerVSProviderIDFormatType enum attribute to identify Power VS ProviderID format.
+type PowerVSProviderIDFormatType string
+
+const (
+	// PowerVSProviderIDFormatV1 will set provider id to machine as ibmpowervs://<cluster_name>/<vm_hostname>
+	PowerVSProviderIDFormatV1 PowerVSProviderIDFormatType = "v1"
+
+	// PowerVSProviderIDFormatV2 will set provider id to machine as ibmpowervs://<region>/<zone>/<service_instance_id>/<powervs_machine_id>
+	PowerVSProviderIDFormatV2 PowerVSProviderIDFormatType = "v2"
+)
+
 // PowerVSProviderIDFormat is used to identify the Provider ID format for Machine.
 var PowerVSProviderIDFormat string
-
-// PowerVSProviderIDFormatV2 will set provider id to machine as ibmpowervs://<region>/<zone>/<service_instance_id>/<powervs_machine_id>
-const PowerVSProviderIDFormatV2 = "v2"
-
-// PowerVSProviderIDFormatV1 will set provider id to machine as ibmpowervs://<cluster_name>/<vm_hostname>
-const PowerVSProviderIDFormatV1 = "v1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR contains the changes to set the ProviderID format for Power VS
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
