### PR TITLE
Add debug loglevel for E2E runs

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
         - "--leader-elect"
         - "--metrics-bind-addr=127.0.0.1:8080"
         - "--powervs-provider-id-fmt=${POWERVS_PROVIDER_ID_FORMAT:=v1}"
+        - "--v=${LOGLEVEL:=0}"
         image: controller:latest
         name: manager
         ports:

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -94,6 +94,8 @@ prerequisites_powervs(){
     export IBMPOWERVS_IMAGE_NAME=${IBMPOWERVS_IMAGE_NAME:-"capibm-powervs-centos-streams8-1-22-4"}
     export IBMPOWERVS_SERVICE_INSTANCE_ID=${IBMPOWERVS_SERVICE_INSTANCE_ID:-"0f28d13a-6e33-4d86-b6d7-a9b46ff7659e"}
     export IBMPOWERVS_NETWORK_NAME=${BOSKOS_RESOURCE_NAME:-"capi-e2e-test"}
+    # Setting controller loglevel to allow debug logs from the PowerVS client
+    export LOGLEVEL=5
 }
 
 main(){


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Sets loglevel to 5 for allowing debug logs from controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #617 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
