### PR TITLE
Update ccm dockerfile to remove building vpcctl binary

### DIFF
--- a/hack/ccm/Dockerfile
+++ b/hack/ccm/Dockerfile
@@ -18,15 +18,6 @@ ARG GOLANG_IMAGE=golang:1.17
 ARG TARGETPLATFORM=linux/amd64
 ARG ARCH=amd64
 
-# Build vpcctl binary
-FROM ${GOLANG_IMAGE} as vpc-builder
-ARG ARCH
-ARG VPC_CONTROLLER_COMMIT
-WORKDIR /build
-RUN git clone https://github.com/openshift/cloud-provider-vpc-controller
-RUN cd cloud-provider-vpc-controller/cmd && git checkout $VPC_CONTROLLER_COMMIT && CGO_ENABLED=0 GOARCH=$ARCH  go build \
-     -ldflags "-s -w" -o /build/vpcctl .
-
 # Build IBM cloud controller manager binary
 FROM ${GOLANG_IMAGE} AS ccm-builder
 ARG ARCH
@@ -39,6 +30,5 @@ RUN cd cloud-provider-powervs && git checkout $POWERVS_CLOUD_CONTROLLER_COMMIT &
 # Assemble the final image
 FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream8 AS centos-base
 LABEL description="IBM PowerVS Cloud Controller Manager"
-COPY --from=vpc-builder /build/vpcctl /bin/vpcctl
 COPY --from=ccm-builder /build/ibm-cloud-controller-manager /bin/ibm-cloud-controller-manager
 ENTRYPOINT [ "/bin/ibm-cloud-controller-manager" ]

--- a/hack/ccm/Makefile
+++ b/hack/ccm/Makefile
@@ -15,18 +15,16 @@
 REGISTRY=gcr.io/k8s-staging-capi-ibmcloud
 IMG=powervs-cloud-controller-manager
 
-# VPC_CONTROLLER_COMMIT can be fetched from here https://github.com/openshift/cloud-provider-vpc-controller/commits/master
-VPC_CONTROLLER_COMMIT?=9b99b4e
 # POWERVS_CLOUD_CONTROLLER_COMMIT can be fetched from here https://github.com/openshift/cloud-provider-powervs/commits/main
-POWERVS_CLOUD_CONTROLLER_COMMIT?=a6bfa07
-TAG?=$(VPC_CONTROLLER_COMMIT)_$(POWERVS_CLOUD_CONTROLLER_COMMIT)
+POWERVS_CLOUD_CONTROLLER_COMMIT?=0b18bec
+TAG?=$(POWERVS_CLOUD_CONTROLLER_COMMIT)
 
 build-image-and-push-linux-amd64: init-buildx
 	{                                                                   \
 	set -e ;                                                            \
 	docker buildx build \
 		--build-arg TARGETPLATFORM=linux/amd64 --build-arg ARCH=amd64 \
-		--build-arg VPC_CONTROLLER_COMMIT=$(VPC_CONTROLLER_COMMIT) --build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
+		--build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
 		-t $(REGISTRY)/$(IMG):$(TAG)_linux_amd64 . --push --target centos-base; \
 	}
 
@@ -35,7 +33,7 @@ build-image-and-push-linux-ppc64le: init-buildx
 	set -e ;                                                             \
 	docker buildx build \
 		--build-arg TARGETPLATFORM=linux/ppc64le --build-arg ARCH=ppc64le\
-		--build-arg VPC_CONTROLLER_COMMIT=$(VPC_CONTROLLER_COMMIT) --build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
+		--build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
 		-t $(REGISTRY)/$(IMG):$(TAG)_linux_ppc64le . --push --target centos-base; \
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR updates ccm dockerfile and makefile to remove building vpcctl binary as its been removed in latest update to powervs cloud provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
