### PR TITLE
Bugfix - update gcr.io/k8s-staging-test-infra/gcb-docker-gcloud to latest version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220617-174ad91c3a'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
…test version

Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Bugfix - update gcr.io/k8s-staging-test-infra/gcb-docker-gcloud to latest version

Post updating golang, it has been observed that the post-merge prow job for pushing capi image is failing. The prow job is using image with go version 1.16.2 which is causing the issue. Updating it to new image having go version 1.18.3

Ref job log - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-provider-ibmcloud-push-images/1549655520623726592

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix - update gcr.io/k8s-staging-test-infra/gcb-docker-gcloud to latest version
```
