### PR TITLE
Enhance the print column for powervs resources

### DIFF
--- a/api/v1beta1/ibmpowervscluster_types.go
+++ b/api/v1beta1/ibmpowervscluster_types.go
@@ -53,9 +53,14 @@ type IBMPowerVSClusterStatus struct {
 	Ready bool `json:"ready"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:storageversion
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this IBMPowerVSCluster belongs"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IBMPowerVSCluster"
+// +kubebuilder:printcolumn:name="PowerVS Cloud Instance ID",type="string",priority=1,JSONPath=".spec.serviceInstanceID"
+// +kubebuilder:printcolumn:name="Endpoint",type="string",priority=1,JSONPath=".spec.controlPlaneEndpoint.host",description="Control Plane Endpoint"
+// +kubebuilder:printcolumn:name="Port",type="string",priority=1,JSONPath=".spec.controlPlaneEndpoint.port",description="Control Plane Port"
 
 // IBMPowerVSCluster is the Schema for the ibmpowervsclusters API.
 type IBMPowerVSCluster struct {

--- a/api/v1beta1/ibmpowervsmachine_types.go
+++ b/api/v1beta1/ibmpowervsmachine_types.go
@@ -167,11 +167,15 @@ type IBMPowerVSMachineStatus struct {
 	Zone *string `json:"zone,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:storageversion
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this IBMPowerVSMachine belongs"
+// +kubebuilder:printcolumn:name="Machine",type="string",priority=1,JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object to which this IBMPowerVSMachine belongs"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IBMPowerVSMachine"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for IBM PowerVS instances"
+// +kubebuilder:printcolumn:name="Internal-IP",type="string",priority=1,JSONPath=".status.addresses[?(@.type==\"InternalIP\")].address",description="Instance Internal Addresses"
+// +kubebuilder:printcolumn:name="External-IP",type="string",priority=1,JSONPath=".status.addresses[?(@.type==\"ExternalIP\")].address",description="Instance External Addresses"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="PowerVS instance state"
 // +kubebuilder:printcolumn:name="Health",type="string",JSONPath=".status.health",description="PowerVS instance health"
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -85,7 +85,30 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster to which this IBMPowerVSCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Time duration since creation of IBMPowerVSCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.serviceInstanceID
+      name: PowerVS Cloud Instance ID
+      priority: 1
+      type: string
+    - description: Control Plane Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Control Plane Port
+      jsonPath: .spec.controlPlaneEndpoint.port
+      name: Port
+      priority: 1
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IBMPowerVSCluster is the Schema for the ibmpowervsclusters API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -155,9 +155,28 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
+    - description: Machine object to which this IBMPowerVSMachine belongs
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    - description: Time duration since creation of IBMPowerVSMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: Cluster infrastructure is ready for IBM PowerVS instances
       jsonPath: .status.ready
       name: Ready
+      type: string
+    - description: Instance Internal Addresses
+      jsonPath: .status.addresses[?(@.type=="InternalIP")].address
+      name: Internal-IP
+      priority: 1
+      type: string
+    - description: Instance External Addresses
+      jsonPath: .status.addresses[?(@.type=="ExternalIP")].address
+      name: External-IP
+      priority: 1
       type: string
     - description: PowerVS instance state
       jsonPath: .status.instanceState


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

After the fix this is how the print table looks like:

```shell
$ k get ibmpowervsmachines -A
NAMESPACE   NAME                                CLUSTER         AGE    READY   STATE    HEALTH
default     ibm-powervs-1-control-plane-2w7l5   ibm-powervs-1   2d2h   true    ACTIVE   OK
default     ibm-powervs-1-md-0-fwhkc            ibm-powervs-1   2d1h   true    ACTIVE   OK
default     ibm-powervs-1-md-0-l5knj            ibm-powervs-1   2d1h   true    ACTIVE   OK

$ k get ibmpowervsmachines -A -o=wide
NAMESPACE   NAME                                CLUSTER         MACHINE                               AGE    READY   INTERNAL-IP       EXTERNAL-IP     STATE    HEALTH
default     ibm-powervs-1-control-plane-2w7l5   ibm-powervs-1   ibm-powervs-1-control-plane-4zswx     2d2h   true    192.168.166.132   163.68.64.132   ACTIVE   OK
default     ibm-powervs-1-md-0-fwhkc            ibm-powervs-1   ibm-powervs-1-md-0-546bd478c6-27sg7   2d1h   true    192.168.166.133   163.68.64.133   ACTIVE   OK
default     ibm-powervs-1-md-0-l5knj            ibm-powervs-1   ibm-powervs-1-md-0-546bd478c6-vj2mr   2d1h   true    192.168.166.130   163.68.64.130   ACTIVE   OK

$ k get ibmpowervsclusters
NAME            CLUSTER         AGE
ibm-powervs-1   ibm-powervs-1   2d2h

$ k get ibmpowervsclusters -o=wide
NAME            CLUSTER         AGE    POWERVS CLOUD INSTANCE ID              ENDPOINT        PORT
ibm-powervs-1   ibm-powervs-1   2d2h   3229a94c-af54-4212-bf60-6202b6fd0a07   163.68.64.131   6443
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #771 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
