### PR TITLE
Fix E2E job failure

### DIFF
--- a/hack/boskos.sh
+++ b/hack/boskos.sh
@@ -42,7 +42,6 @@ checkout_account(){
         echo "export BOSKOS_RESOURCE_NAME=$(echo ${output} | jq -r '.name')"
         echo "export BOSKOS_RESOURCE_ID=$(echo ${output} | jq -r '.userdata["service-instance-id"]')"
         echo "export IBMCLOUD_API_KEY=$(echo ${output} | jq -r '.userdata["api-key"]')"
-        echo "export RESOURCE_GROUP=$(echo ${output} | jq -r '.userdata["resource-group"]')"
     else
         echo "Got invalid response- ${status_code}"
         exit 1

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -34,7 +34,7 @@ ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 mkdir -p "${ARTIFACTS}/logs/"
 
 ARCH=$(uname -m)
-PVSADM_VERSION=${PVSADM_VERSION:-"v0.1.4-alpha.3"}
+PVSADM_VERSION=${PVSADM_VERSION:-"v0.1.7"}
 E2E_FLAVOR=${E2E_FLAVOR:-}
 REGION=${REGION:-"us-south"}
 
@@ -58,7 +58,7 @@ create_powervs_network_instance(){
     curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
 
     # Login to IBM Cloud using the API Key
-    ibmcloud login -a cloud.ibm.com -r ${REGION} -g ${RESOURCE_GROUP}
+    ibmcloud login -a cloud.ibm.com -r ${REGION}
 
     # Install power-iaas command-line plug-in and target the required service instance
     ibmcloud plugin install power-iaas


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The API Key used by an e2e test is given restricted access based on the necessary operations. Using resource-group while logging into IBM Cloud account can be ignored as it would require giving additional resource-group permissions which might not be needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
