### PR TITLE
make SERVICE_ENDPOINT variable optional

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - "--leader-elect"
         - "--metrics-bind-addr=127.0.0.1:8080"
         - "--powervs-provider-id-fmt=${POWERVS_PROVIDER_ID_FORMAT:=v1}"
-        - "--service-endpoint=${SERVICE_ENDPOINT:=}"
+        - "--service-endpoint=${SERVICE_ENDPOINT:=none}"
         - "--v=${LOGLEVEL:=0}"
         image: controller:latest
         name: manager

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -57,7 +57,7 @@ var (
 // ParseServiceEndpointFlag parses the command line flag of service endpoint in the format ${ServiceRegion}:${ServiceID1}=${URL1},${ServiceID2}=${URL2...}
 // returning a list of ServiceEndpoint.
 func ParseServiceEndpointFlag(serviceEndpoints string) ([]ServiceEndpoint, error) {
-	if serviceEndpoints == "" {
+	if serviceEndpoints == "" || serviceEndpoints == "none" {
 		return nil, nil
 	}
 

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -36,6 +36,12 @@ func TestParseFlags(t *testing.T) {
 			expectedError:  nil,
 		},
 		{
+			name:           "none configuration",
+			flagToParse:    "none",
+			expectedOutput: nil,
+			expectedError:  nil,
+		},
+		{
 			name:        "single region, single vpc service",
 			flagToParse: "eu-gb:vpc=https://vpchost:8080",
 			expectedOutput: []ServiceEndpoint{


### PR DESCRIPTION
Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Assign default value to SERVICE_ENDPOINT to make it optional variable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #836

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
make SERVICE_ENDPOINT variable optional
```
