### PR TITLE
Enable additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,21 @@
 linters:
   disable-all: true
   enable:
+  - asasalint
   - asciicheck
   - bodyclose
+  - containedctx
+  - decorder
   - depguard
   - dogsled
   - errcheck
+  - errchkjson
+  - execinquery
   - exportloopref
   - gci
   - goconst
   - gocritic
+  - gocyclo
   - godot
   - gofmt
   - goimports
@@ -24,8 +30,10 @@ linters:
   - nilerr
   - noctx
   - nolintlint
+  - nosprintfhostport
   - prealloc
   - predeclared
+  - reassign
   - revive
   - rowserrcheck
   - staticcheck
@@ -35,6 +43,7 @@ linters:
   - unconvert
   - unparam
   - unused
+  - usestdlibvars
   - whitespace
 
 linters-settings:

--- a/pkg/cloud/services/utils/accounts.go
+++ b/pkg/cloud/services/utils/accounts.go
@@ -29,7 +29,7 @@ import (
 func GetAccount(auth core.Authenticator) (string, error) {
 	// fake request to get a barer token from the request header
 	ctx := context.TODO()
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", http.NoBody)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Enable additional linters (+13)
- Inline with list of linters used in CAPIAWS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #848 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable additional linters
```
