### PR TITLE
User defined port for the control plane for vpc

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -421,7 +421,7 @@ func (s *ClusterScope) CreateLoadBalancer() (*vpcv1.LoadBalancer, error) {
 	options.SetListeners([]vpcv1.LoadBalancerListenerPrototypeLoadBalancerContext{
 		{
 			Protocol: core.StringPtr("tcp"),
-			Port:     core.Int64Ptr(6443),
+			Port:     core.Int64Ptr(int64(s.APIServerPort())),
 			DefaultPool: &vpcv1.LoadBalancerPoolIdentityByName{
 				Name: core.StringPtr(s.IBMVPCCluster.Spec.ControlPlaneLoadBalancer.Name + "-pool"),
 			},
@@ -523,4 +523,12 @@ func (s *ClusterScope) PatchObject() error {
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *ClusterScope) Close() error {
 	return s.PatchObject()
+}
+
+// APIServerPort returns the APIServerPort to use when creating the ControlPlaneEndpoint.
+func (s *ClusterScope) APIServerPort() int32 {
+	if s.Cluster.Spec.ClusterNetwork != nil && s.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
+		return *s.Cluster.Spec.ClusterNetwork.APIServerPort
+	}
+	return 6443
 }

--- a/controllers/ibmvpccluster_controller.go
+++ b/controllers/ibmvpccluster_controller.go
@@ -129,7 +129,7 @@ func (r *IBMVPCClusterReconciler) reconcile(clusterScope *scope.ClusterScope) (c
 		if fip != nil {
 			clusterScope.IBMVPCCluster.Spec.ControlPlaneEndpoint = capiv1beta1.APIEndpoint{
 				Host: *fip.Address,
-				Port: 6443,
+				Port: clusterScope.APIServerPort(),
 			}
 
 			clusterScope.IBMVPCCluster.Status.VPCEndpoint = infrav1beta1.VPCEndpoint{
@@ -169,8 +169,7 @@ func (r *IBMVPCClusterReconciler) reconcile(clusterScope *scope.ClusterScope) (c
 
 			clusterScope.IBMVPCCluster.Spec.ControlPlaneEndpoint = capiv1beta1.APIEndpoint{
 				Host: *loadBalancer.Hostname,
-				// TODO: Support usage of user supplied port.
-				Port: 6443,
+				Port: clusterScope.APIServerPort(),
 			}
 
 			clusterScope.IBMVPCCluster.Status.VPCEndpoint = infrav1beta1.VPCEndpoint{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #842 

**Special notes for your reviewer**:

Template which contains the user defined port for the Apiserver:

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: ibm-vpc-1
  name: ibm-vpc-1
  namespace: default
spec:
  clusterNetwork:
    apiServerPort: 443
    pods:
      cidrBlocks:
      - 192.168.0.0/16
    serviceDomain: cluster.local
    services:
      cidrBlocks:
      - 10.128.0.0/12
```

`spec->clusterNetwork->apiServerPort`

Deployed cluster:
```yaml
k cluster-info
Kubernetes control plane is running at https://8c6cb435-us-east.lb.appdomain.cloud:443
CoreDNS is running at https://8c6cb435-us-east.lb.appdomain.cloud:443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
```

IBM Cloud Backend pool

<img width="784" alt="image" src="https://user-images.githubusercontent.com/12646029/189593413-70bc6f00-2eec-4978-a664-89d66aa796ee.png">


1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
