### PR TITLE
Add build image targets in ccm Makefile

### DIFF
--- a/hack/ccm/Makefile
+++ b/hack/ccm/Makefile
@@ -19,6 +19,24 @@ IMG=powervs-cloud-controller-manager
 POWERVS_CLOUD_CONTROLLER_COMMIT?=07d19bf
 TAG?=$(POWERVS_CLOUD_CONTROLLER_COMMIT)
 
+build-image-linux-amd64: init-buildx
+	{                                                                   \
+        set -e ;                                                            \
+        docker buildx build \
+                --build-arg TARGETPLATFORM=linux/amd64 --build-arg ARCH=amd64 \
+                --build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
+                -t $(REGISTRY)/$(IMG):$(TAG)_linux_amd64 . --target centos-base; \
+        }
+
+build-image-linux-ppc64le: init-buildx
+	{                                                                    \
+        set -e ;                                                             \
+        docker buildx build \
+                --build-arg TARGETPLATFORM=linux/ppc64le --build-arg ARCH=ppc64le\
+                --build-arg POWERVS_CLOUD_CONTROLLER_COMMIT=$(POWERVS_CLOUD_CONTROLLER_COMMIT)\
+                -t $(REGISTRY)/$(IMG):$(TAG)_linux_ppc64le . --target centos-base; \
+        }
+
 build-image-and-push-linux-amd64: init-buildx
 	{                                                                   \
 	set -e ;                                                            \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

To add build image targets in ccm Makefile. This is needed for presubmit job to ccm Dockerfile.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/870
