### PR TITLE
Changes to support ibmpowervs image deletion without cluster reference

### DIFF
--- a/cloud/scope/powervs_image.go
+++ b/cloud/scope/powervs_image.go
@@ -46,11 +46,10 @@ const BucketAccess = "public"
 
 // PowerVSImageScopeParams defines the input parameters used to create a new PowerVSImageScope.
 type PowerVSImageScopeParams struct {
-	Client            client.Client
-	Logger            logr.Logger
-	IBMPowerVSImage   *infrav1beta1.IBMPowerVSImage
-	IBMPowerVSCluster *infrav1beta1.IBMPowerVSCluster
-	ServiceEndpoint   []endpoints.ServiceEndpoint
+	Client          client.Client
+	Logger          logr.Logger
+	IBMPowerVSImage *infrav1beta1.IBMPowerVSImage
+	ServiceEndpoint []endpoints.ServiceEndpoint
 }
 
 // PowerVSImageScope defines a scope defined around a Power VS Cluster.
@@ -59,10 +58,9 @@ type PowerVSImageScope struct {
 	Client      client.Client
 	patchHelper *patch.Helper
 
-	IBMPowerVSClient  powervs.PowerVS
-	IBMPowerVSImage   *infrav1beta1.IBMPowerVSImage
-	IBMPowerVSCluster *infrav1beta1.IBMPowerVSCluster
-	ServiceEndpoint   []endpoints.ServiceEndpoint
+	IBMPowerVSClient powervs.PowerVS
+	IBMPowerVSImage  *infrav1beta1.IBMPowerVSImage
+	ServiceEndpoint  []endpoints.ServiceEndpoint
 }
 
 // NewPowerVSImageScope creates a new PowerVSImageScope from the supplied parameters.
@@ -124,12 +122,6 @@ func NewPowerVSImageScope(params PowerVSImageScopeParams) (scope *PowerVSImageSc
 		},
 		CloudInstanceID: spec.ServiceInstanceID,
 	}
-
-	if params.IBMPowerVSCluster == nil {
-		err = errors.New("failed to generate new scope from nil IBMPowerVSCluster")
-		return
-	}
-	scope.IBMPowerVSCluster = params.IBMPowerVSCluster
 
 	// Fetch the service endpoint.
 	if svcEndpoint := endpoints.FetchPVSEndpoint(endpoints.CostructRegionFromZone(*res.RegionID), params.ServiceEndpoint); svcEndpoint != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This change removes the need of cluster reference while deleting the ibmpowervsimage resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
