### PR TITLE
Added documentaion for usage of ClusterClass to create Power VS cluster

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -15,6 +15,7 @@
     - [Prerequisites](./topics/powervs/prerequisites.md)
     - [Creating a cluster](./topics/powervs/creating-a-cluster.md)
     - [Creating a cluster with External Cloud Provider](./topics/powervs/external-cloud-provider.md)
+    - [Creating a cluster from ClusterClass](./topics/powervs/clusterclass-cluster.md)
     - [Using autoscaler with scaling from 0 machine](./topics/powervs/autoscaler-scalling-from-0.md)
 - [Developer Guide](./developer/index.md)
   - [Rapid iterative development with Tilt](./developer/tilt.md)

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -55,7 +55,10 @@ extra_args:
     - '-v=5'
 ```
 
-To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage, Set `POWERVS_PROVIDER_ID_FORMAT` to `v2` under kustomize_substitutions.
+### 1.  Configuration to deploy workload cluster with external cloud controller manager
+
+To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage, Set `POWERVS_PROVIDER_ID_FORMAT` to `v2` and enable cluster resourceset feature gateunder kustomize_substitutions.
+Currently, [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) is experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET` variable under kustomize_substitutions.
 
 ```yaml
 default_registry: "gcr.io/you-project-name-here"
@@ -68,7 +71,30 @@ enable_providers:
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
   POWERVS_PROVIDER_ID_FORMAT: "v2"
+  EXP_CLUSTER_RESOURCE_SET: "true"
 ```
+
+### 2.  Configuration to deploy workload cluster from ClusterClass template
+
+To deploy workload cluster with [clusterclass-template](/topics/powervs/clusterclass-cluster.html) under kustomize_substitutions set `POWERVS_PROVIDER_ID_FORMAT` to `v2`.
+Currently, both [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html) and [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) are experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET`, `CLUSTER_TOPOLOGY` variable under kustomize_substitutions.
+
+```yaml
+default_registry: "gcr.io/you-project-name-here"
+provider_repos:
+- ../cluster-api-provider-ibmcloud
+enable_providers:
+- ibmcloud
+- kubeadm-bootstrap
+- kubeadm-control-plane
+kustomize_substitutions:
+  IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
+  POWERVS_PROVIDER_ID_FORMAT: "v2"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+  CLUSTER_TOPOLOGY: "true"
+```
+
+### 3.  Configuration to deploy workload cluster with Custom Service Endpoint
 
 To deploy workload cluster with Custom Service Endpoint, Set `SERVICE_ENDPOINT` environmental variable in semi-colon separated format: `${ServiceRegion}:${ServiceID1}=${URL1},${ServiceID2}=${URL2...}`
 ```yaml

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -48,9 +48,18 @@ it into a management cluster using `clusterctl`.
 
     > Note: Refer [Regions-Zones Mapping](/reference/regions-zones-mapping.html) for more information.
 
-   > Note: To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage. Set the `POWERVS_PROVIDER_ID_FORMAT` environmental variable
+   > Note: To deploy workload cluster with [Power VS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage. Set the `POWERVS_PROVIDER_ID_FORMAT` environmental variable.
+   Currently, [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) is experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET` environmental variables.
+   ```console
+      export POWERVS_PROVIDER_ID_FORMAT=v2
+      export EXP_CLUSTER_RESOURCE_SET=true
+    ```
+   > Note: To deploy workload cluster with [Power VS clusterclass-template](/topics/powervs/clusterclass-cluster.html). Set the `POWERVS_PROVIDER_ID_FORMAT` environmental variable.
+     Currently, both [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html) and [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) are experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET`, `CLUSTER_TOPOLOGY` environmental variables.
     ```console
       export POWERVS_PROVIDER_ID_FORMAT=v2
+      export EXP_CLUSTER_RESOURCE_SET=true
+      export CLUSTER_TOPOLOGY=true
     ```
 
    > Note: To deploy workload cluster with Custom Service Endpoint, Set `SERVICE_ENDPOINT` environmental variable in semi-colon separated format:

--- a/docs/book/src/topics/powervs/clusterclass-cluster.md
+++ b/docs/book/src/topics/powervs/clusterclass-cluster.md
@@ -1,0 +1,28 @@
+# Create IBM Power VS Cluster Using ClusterClass
+## Steps
+
+- To deploy Power VS workload cluster using [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html), create a cluster configuration from the [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml)
+- The Power VS cluster will use [external cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/). As a prerequisite set the `powervs-provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/64c9e1d17f1733c721f45a559edba3f4b712bcb0/main.go#L220) with value v2
+- The [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
+
+### Deploy Power VS cluster with IBM Power VS cloud provider
+
+  ```
+  IBMPOWERVS_CLUSTER_CLASS_NAME="powervs-cc" \
+  IBMPOWERVS_SSHKEY_NAME="my-pub-key" \
+  IBMPOWERVS_VIP="192.168.151.22" \
+  IBMPOWERVS_VIP_EXTERNAL="158.175.162.22" \
+  IBMPOWERVS_VIP_CIDR="29" \
+  IBMPOWERVS_IMAGE_NAME="capibm-powervs-centos-8-1-22-4" \
+  IBMPOWERVS_SERVICE_INSTANCE_ID="7845d372-d4e1-46b8-91fc-41051c984601" \
+  IBMPOWERVS_NETWORK_NAME="capi-test-3" \
+  IBMACCOUNT_ID="ibm-accountid" \
+  IBMPOWERVS_REGION="powervs-region" \
+  IBMPOWERVS_ZONE="powervs-zone" \
+  BASE64_API_KEY=$(echo -n $IBMCLOUD_API_KEY | base64) \
+  clusterctl generate cluster ibm-powervs-1 --kubernetes-version v1.22.4 \
+  --target-namespace default \
+  --control-plane-machine-count=3 \
+  --worker-machine-count=1 \
+  --flavor=simple-powervs-clusterclass | kubectl apply -f -
+  ```

--- a/docs/book/src/topics/powervs/index.md
+++ b/docs/book/src/topics/powervs/index.md
@@ -4,4 +4,5 @@
 - [Prerequisites](/topics/powervs/prerequisites.html)
 - [Creating a cluster](/topics/powervs/creating-a-cluster.html)
 - [Creating a cluster with external cloud provider](/topics/powervs/external-cloud-provider.html)
+- [Creating a cluster from ClusterClass](/topics/powervs/clusterclass-cluster.html)
 - [Using autoscaler with scaling from 0 machine](/topics/powervs/autoscaler-scalling-from-0.html)

--- a/templates/cluster-template-simple-powervs-clusterclass.yaml
+++ b/templates/cluster-template-simple-powervs-clusterclass.yaml
@@ -15,7 +15,7 @@ spec:
       cidrBlocks:
         - ${SERVICE_CIDR:="10.128.0.0/12"}
   topology:
-    class: "${CLUSTER_CLASS_NAME}"
+    class: "${IBMPOWERVS_CLUSTER_CLASS_NAME}"
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
@@ -28,23 +28,23 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: ${CLUSTER_CLASS_NAME:="powervs-cc"}
+  name: ${IBMPOWERVS_CLUSTER_CLASS_NAME:="powervs-cc"}
 spec:
   controlPlane:
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: IBMPowerVSMachineTemplate
-        name: "${CLUSTER_CLASS_NAME}-control-plane-machinetemplate"
+        name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane-machinetemplate"
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: "${CLUSTER_CLASS_NAME}-control-plane"
+      name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane"
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: IBMPowerVSClusterTemplate
-      name: "${CLUSTER_CLASS_NAME}-cluster-template"
+      name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-cluster-template"
   workers:
     machineDeployments:
       - class: default-worker
@@ -53,17 +53,17 @@ spec:
             ref:
               apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
               kind: KubeadmConfigTemplate
-              name:  "${CLUSTER_CLASS_NAME}-md-0"
+              name:  "${IBMPOWERVS_CLUSTER_CLASS_NAME}-md-0"
           infrastructure:
             ref:
               apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
               kind: IBMPowerVSMachineTemplate
-              name:  "${CLUSTER_CLASS_NAME}-worker-machinetemplate"
+              name:  "${IBMPOWERVS_CLUSTER_CLASS_NAME}-worker-machinetemplate"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: IBMPowerVSClusterTemplate
 metadata:
-  name: "${CLUSTER_CLASS_NAME}-cluster-template"
+  name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-cluster-template"
 spec:
   template:
     spec:
@@ -77,7 +77,7 @@ spec:
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
-  name: "${CLUSTER_CLASS_NAME}-control-plane"
+  name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane"
 spec:
   template:
     spec:
@@ -192,7 +192,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cluster.x-k8s.io/control-plane: ""
-  name: "${CLUSTER_CLASS_NAME}-md-0"
+  name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-md-0"
 spec:
   template:
     spec:
@@ -219,7 +219,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: IBMPowerVSMachineTemplate
 metadata:
-  name: "${CLUSTER_CLASS_NAME}-control-plane-machinetemplate"
+  name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane-machinetemplate"
 spec:
   template:
     spec:
@@ -237,7 +237,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: IBMPowerVSMachineTemplate
 metadata:
-  name: "${CLUSTER_CLASS_NAME}-worker-machinetemplate"
+  name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-worker-machinetemplate"
 spec:
   template:
     spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
ClusterClass support for Power VS was added with the [PR](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/967): , This PR adds the documentation on how to create cluster using ClusterClass

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added documentation on how to use ClusterClass template to create Power VS cluster
```
