### PR TITLE
fix PVS e2e - introduce ginkgo timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,10 @@ test: generate fmt vet setup-envtest $(GOTESTSUM) ## Run tests
 GINKGO_FOCUS ?= Workload cluster creation
 GINKGO_NODES ?= 3
 GINKGO_NOCOLOR ?= false
+GINKGO_TIMEOUT ?= 2h
 E2E_FLAVOR ?= powervs-md-remediation
 JUNIT_FILE ?= junit.e2e_suite.1.xml
-GINKGO_ARGS ?= -v --trace --tags=e2e --focus=$(GINKGO_FOCUS) --nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) --output-dir="$(ARTIFACTS)" --junit-report="$(JUNIT_FILE)"
+GINKGO_ARGS ?= -v --trace --tags=e2e --timeout=$(GINKGO_TIMEOUT) --focus=$(GINKGO_FOCUS) --nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) --output-dir="$(ARTIFACTS)" --junit-report="$(JUNIT_FILE)"
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts
 SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,7 +36,7 @@ mkdir -p "${ARTIFACTS}/logs/"
 
 ARCH=$(uname -m)
 OS=$(uname -s)
-IBMCLOUD_CLI_VERSION=${IBMCLOUD_CLI_VERSION:-"2.13.0"}
+IBMCLOUD_CLI_VERSION=${IBMCLOUD_CLI_VERSION:-"2.14.0"}
 PVSADM_VERSION=${PVSADM_VERSION:-"v0.1.9"}
 E2E_FLAVOR=${E2E_FLAVOR:-}
 REGION=${REGION:-"jp-osa"}
@@ -74,11 +74,12 @@ install_ibmcloud_cli(){
 create_powervs_network_instance(){
     install_ibmcloud_cli
 
+    ibmcloud config --check-version=false
     # Login to IBM Cloud using the API Key
     ibmcloud login -a cloud.ibm.com -r ${REGION}
 
     # Install power-iaas command-line plug-in and target the required service instance
-    ibmcloud plugin install power-iaas
+    ibmcloud plugin install power-iaas -f
     CRN=$(ibmcloud resource service-instance ${IBMPOWERVS_SERVICE_INSTANCE_ID} --output json | jq -r '.[].crn')
     ibmcloud pi service-target ${CRN}
 

--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -60,8 +60,8 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["60m", "10s"]
-  default/wait-worker-nodes: ["60m", "10s"]
+  default/wait-control-plane: ["40m", "10s"]
+  default/wait-worker-nodes: ["40m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
   default/wait-machine-upgrade: ["50m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]


### PR DESCRIPTION
Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Introduce ginkgo timeout

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce ginkgo timeout
```
