### PR TITLE
Replace k8s.gcr.io references with registry.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SETUP_ENVTEST := $(TOOLS_BIN_DIR)/setup-envtest
 STAGING_REGISTRY ?= gcr.io/k8s-staging-capi-ibmcloud
 STAGING_BUCKET ?= artifacts.k8s-staging-capi-ibmcloud.appspot.com
 BUCKET ?= $(STAGING_BUCKET)
-PROD_REGISTRY := k8s.gcr.io/capi-ibmcloud
+PROD_REGISTRY := registry.k8s.io/capi-ibmcloud
 REGISTRY ?= $(STAGING_REGISTRY)
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 PULL_BASE_REF ?= $(RELEASE_TAG) # PULL_BASE_REF will be provided by Prow

--- a/docs/book/src/developer/release.md
+++ b/docs/book/src/developer/release.md
@@ -41,7 +41,7 @@
   $ manifest-tool inspect --raw gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller:v0.1.0 | jq '.[0].Digest'
   "sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363"
   ```
-  - In your `kubernetes/k8s.io` branch edit `registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml` and add an entry for the version using the sha256 value got from the above command. For example: `"sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]`
+  - In your `kubernetes/k8s.io` branch edit `k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml` and add an entry for the version using the sha256 value got from the above command. For example: `"sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]`
   - You can use [this PR](https://github.com/kubernetes/k8s.io/pull/3185) as example 
   - Wait for the PR to be approved and merged
   - Run `make release` command

--- a/docs/book/src/developer/release.md
+++ b/docs/book/src/developer/release.md
@@ -32,7 +32,7 @@
     ```
 - Wait for the google cloud build to be finished
 - Create a draft release with release notes for the tag
-- Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter):
+- Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io#image-promoter):
   - Clone and pull down the latest from [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io)
   - Create a new branch in your fork of `kubernetes/k8s.io`. 
   - The staging repository is [here](https://console.cloud.google.com/gcr/images/k8s-staging-capi-ibmcloud/GLOBAL).
@@ -41,7 +41,7 @@
   $ manifest-tool inspect --raw gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller:v0.1.0 | jq '.[0].Digest'
   "sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363"
   ```
-  - In your `kubernetes/k8s.io` branch edit `k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml` and add an entry for the version using the sha256 value got from the above command. For example: `"sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]`
+  - In your `kubernetes/k8s.io` branch edit `registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml` and add an entry for the version using the sha256 value got from the above command. For example: `"sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]`
   - You can use [this PR](https://github.com/kubernetes/k8s.io/pull/3185) as example 
   - Wait for the PR to be approved and merged
   - Run `make release` command

--- a/docs/book/src/developer/release.md
+++ b/docs/book/src/developer/release.md
@@ -32,7 +32,7 @@
     ```
 - Wait for the google cloud build to be finished
 - Create a draft release with release notes for the tag
-- Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io#image-promoter):
+- Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter):
   - Clone and pull down the latest from [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io)
   - Create a new branch in your fork of `kubernetes/k8s.io`. 
   - The staging repository is [here](https://console.cloud.google.com/gcr/images/k8s-staging-capi-ibmcloud/GLOBAL).


### PR DESCRIPTION
Replace k8s.gcr.io references with registry.k8s.io

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
