### PR TITLE
add shorthand for output flag in cmd

### DIFF
--- a/cmd/capibmadm/options/options.go
+++ b/cmd/capibmadm/options/options.go
@@ -42,5 +42,5 @@ type options struct {
 // AddCommonFlags will add common flags to the cli.
 func AddCommonFlags(cmd *cobra.Command) {
 	GlobalOptions.Output = printer.PrinterTypeTable
-	cmd.Flags().Var(&GlobalOptions.Output, "output", "The output format of the results. Supported printer types: table, json")
+	cmd.Flags().VarP(&GlobalOptions.Output, "output", "o", "The output format of the results. Supported printer types: table, json")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Add shorthand "o" for output flag in cmd. This is just a minor accessibility enhancement.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
