### PR TITLE
Fix inbound rule to allow only APIServerPort

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -186,8 +186,10 @@ func (s *ClusterScope) updateDefaultSG(sgID string) error {
 	options.SetSecurityGroupID(sgID)
 	options.SetSecurityGroupRulePrototype(&vpcv1.SecurityGroupRulePrototype{
 		Direction: core.StringPtr("inbound"),
-		Protocol:  core.StringPtr("all"),
+		Protocol:  core.StringPtr("tcp"),
 		IPVersion: core.StringPtr("ipv4"),
+		PortMin:   core.Int64Ptr(int64(s.APIServerPort())),
+		PortMax:   core.Int64Ptr(int64(s.APIServerPort())),
 	})
 	_, _, err := s.IBMVPCClient.CreateSecurityGroupRule(options)
 	if err != nil {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -522,3 +522,11 @@ func (m *MachineScope) SetProviderID(id *string) error {
 	}
 	return nil
 }
+
+// APIServerPort returns the APIServerPort.
+func (m *MachineScope) APIServerPort() int32 {
+	if m.Cluster.Spec.ClusterNetwork != nil && m.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
+		return *m.Cluster.Spec.ClusterNetwork.APIServerPort
+	}
+	return 6443
+}

--- a/controllers/ibmvpcmachine_controller.go
+++ b/controllers/ibmvpcmachine_controller.go
@@ -190,7 +190,7 @@ func (r *IBMVPCMachineReconciler) reconcileNormal(machineScope *scope.MachineSco
 					return ctrl.Result{}, fmt.Errorf("invalid primary ip address")
 				}
 				internalIP := instance.PrimaryNetworkInterface.PrimaryIP.Address
-				port := int64(6443)
+				port := int64(machineScope.APIServerPort())
 				poolMember, err := machineScope.CreateVPCLoadBalancerPoolMember(internalIP, port)
 				if err != nil {
 					return ctrl.Result{}, errors.Wrapf(err, "failed to bind port %d to control plane %s/%s", port, machineScope.IBMVPCMachine.Namespace, machineScope.IBMVPCMachine.Name)

--- a/controllers/ibmvpcmachine_controller_test.go
+++ b/controllers/ibmvpcmachine_controller_test.go
@@ -356,6 +356,7 @@ func TestIBMVPCMachineLBReconciler_reconcile(t *testing.T) {
 					},
 				},
 			},
+			Cluster:      &capiv1beta1.Cluster{},
 			IBMVPCClient: mockvpc,
 		}
 		return gomock.NewController(t), mockvpc, machineScope, reconciler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Fix inbound rule to allow only APIServerPort

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #964 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix inbound rule to allow only APIServerPort
```
