### PR TITLE
Fix gcloud auth required for image push

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230424-910a2a439d'
-    entrypoint: make
+    entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - TAG=$_GIT_TAG
@@ -12,7 +12,10 @@ steps:
       - DOCKER_BUILDKIT=1
       - HOME=/root
     args:
-      - release-staging
+    - -c
+    - |
+      gcloud auth configure-docker \
+      && make release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -47,5 +47,5 @@ if [ "$(uname)" == 'Linux' ]; then
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)
-docker buildx rm capibm || true
+docker buildx rm capibm >/dev/null 2>&1 || true
 docker buildx create --use --name=capibm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Fix gcloud auth required for image push

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix gcloud auth required for image push
```
