### PR TITLE
fix machine reconciliation bug

### DIFF
--- a/api/v1beta2/conditions_consts.go
+++ b/api/v1beta2/conditions_consts.go
@@ -36,8 +36,11 @@ const (
 	// InstanceErroredReason instance is in a errored state.
 	InstanceErroredReason = "InstanceErrored"
 
-	// InstanceNotReadyReason used when the instance is in a pending state.
+	// InstanceNotReadyReason used when the instance is in a not ready state.
 	InstanceNotReadyReason = "InstanceNotReady"
+
+	// InstanceStateUnknownReason used when the instance is in a unknown state.
+	InstanceStateUnknownReason = "InstanceStateUnknown"
 )
 
 const (

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -202,6 +202,15 @@ func (m *PowerVSMachineScope) CreateMachine() (*models.PVMInstanceReference, err
 		// TODO need a reasonable wrapped error.
 		return instanceReply, nil
 	}
+
+	// Check if create request has been already triggered.
+	// If InstanceReadyCondition is Unknown then return and wait for it to get updated.
+	for _, con := range m.IBMPowerVSMachine.Status.Conditions {
+		if con.Type == infrav1beta2.InstanceReadyCondition && con.Status == corev1.ConditionUnknown {
+			return nil, nil
+		}
+	}
+
 	cloudInitData, err := m.GetBootstrapData()
 	if err != nil {
 		return nil, err

--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -262,6 +262,9 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(machineScope *scope.PowerV
 			machineScope.Info("PowerVS instance state is undefined", "state", *instance.Status, "instance-id", machineScope.GetInstanceID())
 			conditions.MarkUnknown(machineScope.IBMPowerVSMachine, infrav1beta2.InstanceReadyCondition, "", "")
 		}
+	} else {
+		machineScope.SetNotReady()
+		conditions.MarkUnknown(machineScope.IBMPowerVSMachine, infrav1beta2.InstanceReadyCondition, infrav1beta2.InstanceStateUnknownReason, "")
 	}
 
 	// Requeue after 2 minute if machine is not ready to update status of the machine properly.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR will fix the error: "server name already exist"

As observed once the Post request to create a instance is sent, the instance obj returned is NIL and takes time to get updated due to delay in PowerVS response. This results in parallel reconciliation being triggered by changes in machine obj to resend the post request again resulting in conflict and error "server name already exist"

The fix would ensure we mark the instance state as unknown when obj returned is NIL post the create instance request is sent and check for the same conditions before sending duplicate post requests.

- fix machine reconciliation bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix machine reconciliation bug
```
