### PR TITLE
Increase test/e2e timeouts of ginkgo and powervs machines

### DIFF
--- a/hack/boskos.sh
+++ b/hack/boskos.sh
@@ -56,7 +56,7 @@ checkout_account(){
 heartbeat_account(){
     count=0
     url="http://${BOSKOS_HOST}/update?name=${BOSKOS_RESOURCE_NAME}&state=busy&owner=${USER}"
-    while [ ${count} -lt 120 ]
+    while [ ${count} -lt 180 ]
     do
         status_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST ${url})
         if [[ ${status_code} != 200 ]]; then

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -43,6 +43,8 @@ E2E_FLAVOR=${E2E_FLAVOR:-}
 REGION=${REGION:-"jp-osa"}
 capibmadm=$(pwd)/bin/capibmadm
 
+GINKGO_TIMEOUT=${GINKGO_TIMEOUT:-"2h"}
+
 [ "${ARCH}" == "x86_64" ] && ARCH="amd64"
 
 trap cleanup EXIT
@@ -172,6 +174,7 @@ main(){
     if [[ "${E2E_FLAVOR}" == "powervs" || "${E2E_FLAVOR}" == "powervs-md-remediation" ]]; then
         prerequisites_powervs
         init_network_powervs
+        GINKGO_TIMEOUT=3h
     fi
 
     if [[ "${E2E_FLAVOR}" == "vpc"* ]]; then
@@ -183,7 +186,7 @@ main(){
     fi
 
     # Run the e2e tests
-    make test-e2e E2E_FLAVOR=${E2E_FLAVOR}
+    make test-e2e E2E_FLAVOR=${E2E_FLAVOR} GINKGO_TIMEOUT=${GINKGO_TIMEOUT}
     test_status="${?}"
     echo TESTSTATUS="${test_status}"
 

--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -60,8 +60,8 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["40m", "10s"]
-  default/wait-worker-nodes: ["40m", "10s"]
+  default/wait-control-plane: ["60m", "10s"]
+  default/wait-worker-nodes: ["60m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
   default/wait-machine-upgrade: ["50m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Increase test/e2e timeouts of ginkgo and powervs machines

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase test/e2e timeouts of ginkgo and powervs machines
```
