### PR TITLE
E2E fixes

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -41,7 +41,6 @@ ARCH=$(uname -m)
 OS=$(uname -s)
 IBMCLOUD_CLI_VERSION=${IBMCLOUD_CLI_VERSION:-"2.16.0"}
 E2E_FLAVOR=${E2E_FLAVOR:-}
-REGION=${REGION:-"jp-osa"}
 capibmadm=$(pwd)/bin/capibmadm
 
 [ "${ARCH}" == "x86_64" ] && ARCH="amd64"
@@ -88,7 +87,7 @@ create_powervs_network_instance(){
 
     ibmcloud config --check-version=false
     # Login to IBM Cloud using the API Key
-    retry "ibmcloud login -a cloud.ibm.com -r ${REGION}"
+    retry "ibmcloud login -a cloud.ibm.com --no-region"
 
     # Install power-iaas command-line plug-in and target the required service instance
     ibmcloud plugin install power-iaas -f
@@ -184,10 +183,6 @@ main(){
     export DOCKER_BUILDKIT=1
     # Setting controller loglevel to allow debug logs from the VPC/PowerVS client
     export LOGLEVEL=5
-
-    if [ -n "${BOSKOS_REGION}" ]; then
-        REGION=${BOSKOS_REGION}
-    fi
 
     if [[ "${E2E_FLAVOR}" == "powervs" || "${E2E_FLAVOR}" == "powervs-md-remediation" ]]; then
         prerequisites_powervs

--- a/templates/addons/crs.yaml
+++ b/templates/addons/crs.yaml
@@ -253,4 +253,4 @@ data:
                 name: ibm-cloud-config
             - name: ibm-secret
               secret:
-                secretName: ibm-cloud-credentia
+                secretName: ibm-cloud-credential

--- a/templates/cluster-template-vpc-load-balancer.yaml
+++ b/templates/cluster-template-vpc-load-balancer.yaml
@@ -403,7 +403,7 @@ data:
                 name: ibm-cloud-config
             - name: ibm-secret
               secret:
-                secretName: ibm-cloud-credentia
+                secretName: ibm-cloud-credential
 kind: ConfigMap
 metadata:
   name: cloud-controller-manager-addon


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR
- Fixes a minor typo in the vpc-load-balancer-template
- Removes using region during IBM Cloud login: The PowerVS region naming which is set as BOSKOS_REGION doesn't match the region naming while IBM Cloud login

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
E2E fixes
```
