### PR TITLE
Fix e2e hostname length

### DIFF
--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -1,4 +1,4 @@
-managementClusterName: capi-ibmcloud-e2e
+managementClusterName: capibm-e2e
 
 images:
   # Use local built images for e2e tests

--- a/test/e2e/config/ibmcloud-e2e-vpc.yaml
+++ b/test/e2e/config/ibmcloud-e2e-vpc.yaml
@@ -1,4 +1,4 @@
-managementClusterName: capi-ibmcloud-e2e
+managementClusterName: capibm-e2e
 
 images:
   # Use local built images for e2e tests

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
 
-		clusterName = fmt.Sprintf("capi-ibmcloud-e2e-%s", util.RandomString(6))
+		clusterName = fmt.Sprintf("capibm-e2e-%s", util.RandomString(6))
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -94,7 +94,7 @@ func init() {
 func TestE2E(t *testing.T) {
 	ctrl.SetLogger(klog.Background())
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "capi-ibmcloud-e2e")
+	RunSpecs(t, "capibm-e2e")
 }
 
 // Using a SynchronizedBeforeSuite for controlling how to create resources shared across ParallelNodes (~ginkgo threads).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Fix e2e hostname length

Error observed in e2e
```
ubelet_pods.go:414] "Hostname for pod was too long, truncated it" podName="kube-controller-manager-capi-ibmcloud-e2e-kth5c9-control-plane-p8lh9" hostnameMaxLen=63 truncatedHostname="kube-controller-manager-capi-ib>
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix e2e hostname length
```
