### PR TITLE
Streamline the vpc cluster deletion process

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -131,6 +131,10 @@ func (s *ClusterScope) CreateVPC() (*vpcv1.VPC, error) {
 
 // DeleteVPC deletes IBM VPC associated with a VPC id.
 func (s *ClusterScope) DeleteVPC() error {
+	if s.IBMVPCCluster.Status.VPC.ID == "" {
+		return nil
+	}
+
 	deleteVpcOptions := &vpcv1.DeleteVPCOptions{}
 	deleteVpcOptions.SetID(s.IBMVPCCluster.Status.VPC.ID)
 	_, err := s.IBMVPCClient.DeleteVPC(deleteVpcOptions)
@@ -267,6 +271,10 @@ func (s *ClusterScope) ensureFIPUnique(fipName string) (*vpcv1.FloatingIP, error
 
 // DeleteFloatingIP deletes a Floating IP associated with floating ip id.
 func (s *ClusterScope) DeleteFloatingIP() error {
+	if s.IBMVPCCluster.Status.VPCEndpoint.FIPID == nil {
+		return nil
+	}
+
 	if fipID := *s.IBMVPCCluster.Status.VPCEndpoint.FIPID; fipID != "" {
 		deleteFIPOption := &vpcv1.DeleteFloatingIPOptions{}
 		deleteFIPOption.SetID(fipID)
@@ -410,6 +418,10 @@ func (s *ClusterScope) ensureSubnetUnique(subnetName string) (*vpcv1.Subnet, err
 
 // DeleteSubnet deletes a subnet associated with subnet id.
 func (s *ClusterScope) DeleteSubnet() error {
+	if s.IBMVPCCluster.Status.Subnet.ID == nil {
+		return nil
+	}
+
 	subnetID := *s.IBMVPCCluster.Status.Subnet.ID
 
 	// Lists the subnet available and compare before deleting to avoid any failure(404) later
@@ -703,6 +715,10 @@ func (s *ClusterScope) SetLoadBalancerID(id *string) {
 
 // GetLoadBalancerID will get the id for the load balancer.
 func (s *ClusterScope) GetLoadBalancerID() string {
+	if s.IBMVPCCluster.Status.VPCEndpoint.LBID == nil {
+		return ""
+	}
+
 	return *s.IBMVPCCluster.Status.VPCEndpoint.LBID
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Streamline the vpc cluster deletion process

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1386 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Streamline the vpc cluster deletion process
```
