### PR TITLE
PROVIDER_ID_FORMAT references replacement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/kubernetes-sigs/cluster-api-provider-ibmcloud?label=version)
 [![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/cluster-api-provider-ibmcloud)](https://goreportcard.com/report/sigs.k8s.io/cluster-api-provider-ibmcloud)
 
-# Kubernetes Cluster API Provider IBM Cloud
+# Kubernetes Cluster API Provider IBM Cloud (CAPIBM)
 
 <a href="https://github.com/kubernetes-sigs/cluster-api"><img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png"  width="100"></a><a href="https://www.ibm.com/cloud/"><img hspace="90px" src="./docs/images/ibm-cloud.svg" alt="Powered by IBM Cloud" height="100"></a>
 
@@ -27,11 +27,11 @@ cluster on IBM Cloud.
 
 This provider's versions are compatible with the following versions of Cluster API:
 
-|                                            | v1alpha4 (v0.4) | v1beta1 (v1.x) |
-|--------------------------------------------|-----------------|----------------|
-| IBMCloud Provider v1alpha4 (v0.1.x)        | ✓               |                |
-| IBMCloud Provider v1beta1 (v0.2.x, v0.3.x) |                 | ✓              |
-| IBMCloud Provider v1beta2 (v0.4.x, v0.5.x, v0.6.x, main) |                 | ✓              |
+|                                         |Cluster API v1alpha4 (v0.4) |Cluster API v1beta1 (v1.x) |
+|:----------------------------------------|:---------------:|:--------------:|
+| CAPIBM v1alpha4 (v0.1.x)                  | ✓               |                |
+| CAPIBM v1beta1 (v0.2.x, v0.3.x)           |                 | ✓              |
+| CAPIBM v1beta2 (v0.[4-6].x, main)         |                 | ✓              |
 
 
 (See [Kubernetes support matrix][cluster-api-supported-v] of Cluster API versions).

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -57,7 +57,7 @@ extra_args:
 
 ### 1.  Configuration to deploy PowerVS workload cluster with external cloud controller manager
 
-To deploy workload cluster with [PowerVS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage, Set `POWERVS_PROVIDER_ID_FORMAT` to `v2` and enable cluster resourceset feature gate under kustomize_substitutions.
+To deploy workload cluster with [PowerVS cloud controller manager](/topics/powervs/external-cloud-provider.html) which is currently in experimental stage, Set `PROVIDER_ID_FORMAT` to `v2` and enable cluster resourceset feature gate under kustomize_substitutions.
 Currently, [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) is experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET` variable under kustomize_substitutions.
 
 ```yaml
@@ -70,7 +70,7 @@ enable_providers:
 - kubeadm-control-plane
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
-  POWERVS_PROVIDER_ID_FORMAT: "v2"
+  PROVIDER_ID_FORMAT: "v2"
   EXP_CLUSTER_RESOURCE_SET: "true"
 ```
 
@@ -95,7 +95,7 @@ kustomize_substitutions:
 
 ### 3.  Configuration to deploy workload cluster from ClusterClass template
 
-To deploy workload cluster with [clusterclass-template](/topics/powervs/clusterclass-cluster.html) under kustomize_substitutions set `POWERVS_PROVIDER_ID_FORMAT` to `v2`.
+To deploy workload cluster with [clusterclass-template](/topics/powervs/clusterclass-cluster.html) under kustomize_substitutions set `PROVIDER_ID_FORMAT` to `v2`.
 Currently, both [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html) and [ClusterResourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) are experimental feature so we need to enable the feature gate by setting `EXP_CLUSTER_RESOURCE_SET`, `CLUSTER_TOPOLOGY` variable under kustomize_substitutions.
 
 ```yaml
@@ -108,7 +108,7 @@ enable_providers:
 - kubeadm-control-plane
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
-  POWERVS_PROVIDER_ID_FORMAT: "v2"
+  PROVIDER_ID_FORMAT: "v2"
   EXP_CLUSTER_RESOURCE_SET: "true"
   CLUSTER_TOPOLOGY: "true"
 ```

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -99,9 +99,9 @@ it into a management cluster using `clusterctl`.
       export EXP_CLUSTER_RESOURCE_SET=true
       ```
 
-   2. To deploy workload cluster with [PowerVS cloud controller manager](/topics/powervs/external-cloud-provider.html), set the `POWERVS_PROVIDER_ID_FORMAT` environmental variable.
+   2. To deploy workload cluster with [PowerVS cloud controller manager](/topics/powervs/external-cloud-provider.html), set the `PROVIDER_ID_FORMAT` environmental variable.
       ```console
-      export POWERVS_PROVIDER_ID_FORMAT=v2
+      export PROVIDER_ID_FORMAT=v2
       export EXP_CLUSTER_RESOURCE_SET=true
       ```
    > Note: `EXP_CLUSTER_RESOURCE_SET` should be set for deploying workload cluster with Cloud Controller manager.
@@ -111,7 +111,7 @@ it into a management cluster using `clusterctl`.
    To deploy workload cluster with [PowerVS clusterclass-template](/topics/powervs/clusterclass-cluster.html). Set the following environmental variables.
 
    ```console
-   export POWERVS_PROVIDER_ID_FORMAT=v2
+   export PROVIDER_ID_FORMAT=v2
    export EXP_CLUSTER_RESOURCE_SET=true
    export CLUSTER_TOPOLOGY=true
    ```

--- a/docs/book/src/topics/powervs/clusterclass-cluster.md
+++ b/docs/book/src/topics/powervs/clusterclass-cluster.md
@@ -2,7 +2,7 @@
 ## Steps
 
 - To deploy PowerVS workload cluster using [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html), create a cluster configuration from the [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml)
-- The PowerVS cluster will use [external cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/). As a prerequisite set the `powervs-provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/64c9e1d17f1733c721f45a559edba3f4b712bcb0/main.go#L220) with value v2
+- The PowerVS cluster will use [external cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/). As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/5e7f80878f2252c6ab13c16102de90c784a2624d/main.go#L168-L173) with value v2
 - The [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
 
 ### Deploy PowerVS cluster with IBM PowerVS cloud provider

--- a/docs/book/src/topics/powervs/external-cloud-provider.md
+++ b/docs/book/src/topics/powervs/external-cloud-provider.md
@@ -5,7 +5,7 @@
 
 - To deploy a PowerVS workload cluster with IBM PowerVS external [cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/), create a cluster configuration with the [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-powervs-cloud-provider.yaml)
 - The [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-powervs-cloud-provider.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
-- As a prerequisite set the `powervs-provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/64c9e1d17f1733c721f45a559edba3f4b712bcb0/main.go#L220) with value v2
+- As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/5e7f80878f2252c6ab13c16102de90c784a2624d/main.go#L168-L173) with value v2
 
 ### Deploy PowerVS cluster with IBM PowerVS cloud provider
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR contains the changes to point to the correct usage of PROVIDER_ID_FORMAT in the .md files of the CAPI book, updated references to keep documents inline with the intended usage.

Also contains a change in table's format and alignment, to adapt to a smaller space.

**Which issue(s) this PR fixes**
Fixes #1471 

**Special notes for your reviewer**:

/area provider/ibmcloud

