### PR TITLE
Fix the finalizer code

### DIFF
--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -108,8 +108,7 @@ func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 func (r *IBMPowerVSClusterReconciler) reconcile(clusterScope *scope.PowerVSClusterScope) ctrl.Result { //nolint:unparam
-	if !controllerutil.ContainsFinalizer(clusterScope.IBMPowerVSCluster, infrav1beta2.IBMPowerVSClusterFinalizer) {
-		controllerutil.AddFinalizer(clusterScope.IBMPowerVSCluster, infrav1beta2.IBMPowerVSClusterFinalizer)
+	if controllerutil.AddFinalizer(clusterScope.IBMPowerVSCluster, infrav1beta2.IBMPowerVSClusterFinalizer) {
 		return ctrl.Result{}
 	}
 

--- a/controllers/ibmpowervsimage_controller.go
+++ b/controllers/ibmpowervsimage_controller.go
@@ -100,7 +100,9 @@ func (r *IBMPowerVSImageReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 func (r *IBMPowerVSImageReconciler) reconcile(cluster *infrav1beta2.IBMPowerVSCluster, imageScope *scope.PowerVSImageScope) (ctrl.Result, error) {
-	controllerutil.AddFinalizer(imageScope.IBMPowerVSImage, infrav1beta2.IBMPowerVSImageFinalizer)
+	if controllerutil.AddFinalizer(imageScope.IBMPowerVSImage, infrav1beta2.IBMPowerVSImageFinalizer) {
+		return ctrl.Result{}, nil
+	}
 
 	// Create new labels section for IBMPowerVSImage metadata if nil.
 	if imageScope.IBMPowerVSImage.Labels == nil {

--- a/controllers/ibmpowervsimage_controller_test.go
+++ b/controllers/ibmpowervsimage_controller_test.go
@@ -192,6 +192,7 @@ func TestIBMPowerVSImageReconciler_reconcile(t *testing.T) {
 							UID:        "1",
 						},
 					},
+					Finalizers: []string{infrav1beta2.IBMPowerVSImageFinalizer},
 				},
 				Spec: infrav1beta2.IBMPowerVSImageSpec{
 					ClusterName: "capi-powervs-cluster",

--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -218,7 +218,9 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(machineScope *scope.PowerV
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
-	controllerutil.AddFinalizer(machineScope.IBMPowerVSMachine, infrav1beta2.IBMPowerVSMachineFinalizer)
+	if controllerutil.AddFinalizer(machineScope.IBMPowerVSMachine, infrav1beta2.IBMPowerVSMachineFinalizer) {
+		return ctrl.Result{}, nil
+	}
 
 	ins, err := r.getOrCreate(machineScope)
 	if err != nil {

--- a/controllers/ibmpowervsmachine_controller_test.go
+++ b/controllers/ibmpowervsmachine_controller_test.go
@@ -447,7 +447,8 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 				},
 				IBMPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: *pointer.String("capi-test-machine"),
+						Name:       *pointer.String("capi-test-machine"),
+						Finalizers: []string{infrav1beta2.IBMPowerVSMachineFinalizer},
 					},
 				},
 				IBMPowerVSImage: &infrav1beta2.IBMPowerVSImage{
@@ -484,7 +485,8 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 
 			pvsmachine := &infrav1beta2.IBMPowerVSMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: *pointer.String("capi-test-machine"),
+					Name:       *pointer.String("capi-test-machine"),
+					Finalizers: []string{infrav1beta2.IBMPowerVSMachineFinalizer},
 				},
 				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					MemoryGiB:  8,

--- a/controllers/ibmvpccluster_controller.go
+++ b/controllers/ibmvpccluster_controller.go
@@ -110,8 +110,8 @@ func (r *IBMVPCClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *IBMVPCClusterReconciler) reconcile(clusterScope *scope.ClusterScope) (ctrl.Result, error) {
-	if !controllerutil.ContainsFinalizer(clusterScope.IBMVPCCluster, infrav1beta2.ClusterFinalizer) {
-		controllerutil.AddFinalizer(clusterScope.IBMVPCCluster, infrav1beta2.ClusterFinalizer)
+	// If the IBMVPCCluster doesn't have our finalizer, add it.
+	if controllerutil.AddFinalizer(clusterScope.IBMVPCCluster, infrav1beta2.ClusterFinalizer) {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/ibmvpcmachine_controller.go
+++ b/controllers/ibmvpcmachine_controller.go
@@ -140,7 +140,9 @@ func (r *IBMVPCMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *IBMVPCMachineReconciler) reconcileNormal(machineScope *scope.MachineScope) (ctrl.Result, error) {
-	controllerutil.AddFinalizer(machineScope.IBMVPCMachine, infrav1beta2.MachineFinalizer)
+	if controllerutil.AddFinalizer(machineScope.IBMVPCMachine, infrav1beta2.MachineFinalizer) {
+		return ctrl.Result{}, nil
+	}
 
 	// Make sure bootstrap data is available and populated.
 	if machineScope.Machine.Spec.Bootstrap.DataSecretName == nil {

--- a/controllers/ibmvpcmachine_controller_test.go
+++ b/controllers/ibmvpcmachine_controller_test.go
@@ -233,6 +233,7 @@ func TestIBMVPCMachineReconciler_reconcile(t *testing.T) {
 					Labels: map[string]string{
 						capiv1beta1.MachineControlPlaneNameLabel: "capi-control-plane-machine",
 					},
+					Finalizers: []string{infrav1beta2.MachineFinalizer},
 				},
 			},
 			Machine: &capiv1beta1.Machine{
@@ -290,6 +291,7 @@ func TestIBMVPCMachineLBReconciler_reconcile(t *testing.T) {
 					Labels: map[string]string{
 						capiv1beta1.MachineControlPlaneNameLabel: "capi-control-plane-machine",
 					},
+					Finalizers: []string{infrav1beta2.MachineFinalizer},
 				},
 			},
 			Machine: &capiv1beta1.Machine{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR fixes following things:
- `controllerutil.AddFinalizer` already contains the logic for checking existing finilizer, hence the explicit check is removed
- Forcing the reconcile when the Finalizer gets add so that we don't leave behind any associated resources when delete triggers before the finalizer get added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1260 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
