### PR TITLE
[release-0.5] Bump golang to v1.20.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.20.11 as toolchain
+FROM golang:1.20.12 as toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org,direct

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ROOT_DIR_RELATIVE := .
 
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GO_VERSION ?= 1.20.11
+GO_VERSION ?= 1.20.12
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/hack/ccm/Dockerfile
+++ b/hack/ccm/Dockerfile
@@ -18,7 +18,7 @@ ARG TARGETPLATFORM=linux/amd64
 ARG ARCH=amd64
 
 # Build IBM cloud controller manager binary
-FROM golang:1.20.11 AS ccm-builder
+FROM golang:1.20.12 AS ccm-builder
 ARG ARCH
 ARG POWERVS_CLOUD_CONTROLLER_COMMIT
 WORKDIR /build


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Bump golang to v1.20.12

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump golang to v1.20.12
```
