### PR TITLE
Replaced pvsadm image import reference with capibmadm powervs image import

### DIFF
--- a/docs/book/src/topics/capibmadm/index.md
+++ b/docs/book/src/topics/capibmadm/index.md
@@ -9,17 +9,17 @@ If you are unsure you can determine your computers architecture by running `unam
 
 Download for AMD64:
 ```bash
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-linux-amd64 -o capibmadm
+curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-linux-amd64 -o capibmadm
 ```
 
 Download for ARM64:
 ```bash
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-linux-arm64 -o capibmadm
+curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-linux-arm64 -o capibmadm
 ```
 
 Download for PPC64LE:
 ```bash
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-linux-ppc64le -o capibmadm
+curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-linux-ppc64le -o capibmadm
 ```
 
 Make the capibmadm binary executable.
@@ -40,12 +40,12 @@ If you are unsure you can determine your computers architecture by running `unam
 
 Download for AMD64:
 ```bash
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-darwin-amd64 -o capibmadm
+curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-darwin-amd64 -o capibmadm
 ```
 
 Download for M1 CPU ("Apple Silicon") / ARM64:
 ```bash
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-darwin-arm64 -o capibmadm
+curl -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-darwin-arm64 -o capibmadm
 ```
 
 Make the capibmadm binary executable.
@@ -66,13 +66,13 @@ Go to the working directory where you want capibmadm downloaded.
 
 Download the latest release on AMD64; on Windows, type:
 ```powershell
-curl.exe -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-windows-amd64.exe -o capibmadm.exe
+curl.exe -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-windows-amd64.exe -o capibmadm.exe
 ```
 Append or prepend the path of that directory to the `PATH` environment variable.
 
 Download the latest release on ARM64; on Windows, type:
 ```powershell
-curl.exe -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.5.0-alpha.1/capibmadm-windows-arm64.exe -o capibmadm.exe
+curl.exe -L https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/download/v0.7.0/capibmadm-windows-arm64.exe -o capibmadm.exe
 ```
 Append or prepend the path of that directory to the `PATH` environment variable.
 

--- a/docs/book/src/topics/powervs/prerequisites.md
+++ b/docs/book/src/topics/powervs/prerequisites.md
@@ -50,12 +50,12 @@ A public network is required for your kubernetes cluster. Perform the following 
 
 ```shell
 $ export IBMCLOUD_API_KEY=<API_KEY>
-$ pvsadm image import --pvs-instance-id <SERVICE_INSTANCE_ID> -b <BUCKETNAME> --object <OBJECT> --pvs-image-name <POWERVS_IMAGE_NAME> --bucket-region <REGION> --public-bucket
+$ capibmadm powervs image import --service-instance-id <SERVICE_INSTANCE_ID>  --zone <ZONE> --bucket-region <BUCKET_REGION> --object <OBJECT>  --name <POWERVS_IMAGE_NAME> --bucket <BUCKETNAME> --public-bucket
 ```
 
 e.g:
 ```shell
-$ pvsadm image import --pvs-instance-id 6d892c30-5387-4685-85d0-4999d9c22a8c -b power-oss-bucket --object capibm-powervs-centos-streams8-1-24-2.ova.gz --pvs-image-name capibm-powervs-centos-streams8-1-24-2 --bucket-region us-south --public-bucket
+$ capibmadm powervs image import --service-instance-id 3229a94c-af54-4212-bf60-6202b6fd0a07  --zone osa21 --bucket-region jp-tok --object RHEL9.0-image.ova.gz  --name powervs_image --bucket  ocp-development-public-bucket --public-bucket
 ```
 
 For more information about the images can be found at [machine-images](../../machine-images/powervs.md) section


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
In this PR, reference of `pvsadm image import` are replaced with the new CLI command to import images - `powervs image import`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1583

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
 NO
 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
