### PR TITLE
Replace service with worskpace after power-iaas plugin update

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -39,7 +39,7 @@ mkdir -p "${ARTIFACTS}/logs/"
 
 ARCH=$(uname -m)
 OS=$(uname -s)
-IBMCLOUD_CLI_VERSION=${IBMCLOUD_CLI_VERSION:-"2.21.0"}
+IBMCLOUD_CLI_VERSION=${IBMCLOUD_CLI_VERSION:-"2.22.1"}
 E2E_FLAVOR=${E2E_FLAVOR:-}
 capibmadm=$(pwd)/bin/capibmadm
 
@@ -92,7 +92,7 @@ create_powervs_network_instance(){
     # Install power-iaas command-line plug-in and target the required service instance
     ibmcloud plugin install power-iaas -f
     CRN=$(ibmcloud resource service-instance ${IBMPOWERVS_SERVICE_INSTANCE_ID} --output json | jq -r '.[].crn')
-    ibmcloud pi service-target ${CRN}
+    ibmcloud pi workspace target ${CRN}
 
     # Create the network instance
     ${capibmadm} powervs network create --name ${IBMPOWERVS_NETWORK_NAME} --service-instance-id ${IBMPOWERVS_SERVICE_INSTANCE_ID} --zone ${ZONE}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
With the power-iaas plugin version update to 1.0.0, replace service-instance references with workspace. This PR fixes the below error.
```
Plug-in 'power-iaas 1.0.0' was successfully installed into /root/.bluemix/plugins/power-iaas. Use 'ibmcloud plugin show power-iaas' to show its details.
++ jq -r '.[].crn'
++ ibmcloud resource service-instance e7207381-53be-4a6a-b2c1-127580e97466 --output json
+ CRN=crn:v1:bluemix:public:power-iaas:syd04:a/7cfbd5381a434af7a09289e795840d4e:e7207381-53be-4a6a-b2c1-127580e97466::
+ ibmcloud pi service-target crn:v1:bluemix:public:power-iaas:syd04:a/7cfbd5381a434af7a09289e795840d4e:e7207381-53be-4a6a-b2c1-127580e97466::
Error: unknown command "service-target" for "pi"
Run 'pi --help' for usage.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace service with worskpace after power-iaas plugin update
```
