### PR TITLE
Extend supported service endpoints

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -47,7 +47,7 @@ it into a management cluster using `clusterctl`.
    > `${ServiceRegion1}:${ServiceID1}=${URL1},${ServiceID2}=${URL2};${ServiceRegion2}:${ServiceID1}=${URL1...}`.
    
 
-    Supported ServiceIDs include - `vpc, powervs, rc`
+    Supported ServiceIDs include - `CIS, COS, DNSServices, IAM, KeyProtect, ResourceManager, powervs, rc, vpc`
      ```console
       export SERVICE_ENDPOINT=us-south:vpc=https://us-south-stage01.iaasdev.cloud.ibm.com,powervs=https://dal.power-iaas.test.cloud.ibm.com,rc=https://resource-controller.test.cloud.ibm.com
      ```

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -27,17 +27,29 @@ import (
 var ServiceEndpointFormat string
 
 const (
-	// VPC used to identify VPC service.
-	VPC serviceID = "vpc"
+	// CIS used to identify Cloud Internet Services.
+	CIS serviceID = "CIS"
+	// COS used to identify Cloud Object Storage service.
+	COS serviceID = "COS"
+	// DNSServices used to identify DNS Services.
+	DNSServices serviceID = "DNSServices"
+	// IAM used to identify Identity and Management service.
+	IAM serviceID = "IAM"
+	// KeyProtect used to identify Key Protect service.
+	KeyProtect serviceID = "KeyProtect"
 	// PowerVS used to identify PowerVS service.
 	PowerVS serviceID = "powervs"
 	// RC used to identify Resource-Controller service.
 	RC serviceID = "rc"
+	// ResourceManager used to identify Resource Manager service.
+	ResourceManager serviceID = "ResourceManager"
+	// VPC used to identify VPC service.
+	VPC serviceID = "vpc"
 )
 
 type serviceID string
 
-var serviceIDs = []serviceID{VPC, PowerVS, RC}
+var serviceIDs = []serviceID{CIS, COS, DNSServices, IAM, KeyProtect, PowerVS, RC, ResourceManager, VPC}
 
 // ServiceEndpoint holds the Service endpoint specific information.
 type ServiceEndpoint struct {

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -144,6 +144,43 @@ func TestParseFlags(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name:        "single region, multiple restricted network required services",
+			flagToParse: "us-east:vpc=https://vpchost:8080,IAM=https://iamhost:8080,ResourceManager=https://rmhost:8080,DNSServices=https://dnsserviceshost:8080,rc=https://rchost:8080,KeyProtect=https://keyprotecthost:8080",
+			expectedOutput: []ServiceEndpoint{
+				{
+					ID:     "vpc",
+					URL:    "https://vpchost:8080",
+					Region: "us-east",
+				},
+				{
+					ID:     "IAM",
+					URL:    "https://iamhost:8080",
+					Region: "us-east",
+				},
+				{
+					ID:     "ResourceManager",
+					URL:    "https://rmhost:8080",
+					Region: "us-east",
+				},
+				{
+					ID:     "DNSServices",
+					URL:    "https://dnsserviceshost:8080",
+					Region: "us-east",
+				},
+				{
+					ID:     "rc",
+					URL:    "https://rchost:8080",
+					Region: "us-east",
+				},
+				{
+					ID:     "KeyProtect",
+					URL:    "https://keyprotecthost:8080",
+					Region: "us-east",
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name:           "invalid config",
 			flagToParse:    "eu-gb=localhost",
 			expectedOutput: nil,


### PR DESCRIPTION
Add additional services to endpoint override support for VPC related services.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:  Expands the supported IBM Cloud Services that can have endpoint overrides.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Extend supported IBM Cloud Service endpoint overrides
```
