### PR TITLE
Add support to override service endpoints

### DIFF
--- a/api/v1beta2/ibmpowervscluster_webhook.go
+++ b/api/v1beta2/ibmpowervscluster_webhook.go
@@ -121,6 +121,10 @@ func (r *IBMPowerVSCluster) validateIBMPowerVSClusterCreateInfraPrereq() *field.
 		return field.Invalid(field.NewPath("spec.zone"), r.Spec.Zone, "value of zone is empty")
 	}
 
+	if r.Spec.VPC == nil {
+		return field.Invalid(field.NewPath("spec.vpc"), r.Spec.VPC, "value of VPC is empty")
+	}
+
 	if r.Spec.VPC.Region == nil {
 		return field.Invalid(field.NewPath("spec.vpc.region"), r.Spec.VPC.Region, "value of VPC region is empty")
 	}

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -28,7 +28,9 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/ibm-cos-sdk-go/aws"
 	"github.com/IBM/ibm-cos-sdk-go/aws/awserr"
+	cosSession "github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
 	tgapiv1 "github.com/IBM/networking-go-sdk/transitgatewayapisv1"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
@@ -130,7 +132,15 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 
 	// if Spec.ServiceInstanceID is set fetch zone associated with it or else use Spec.Zone.
 	if params.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-		rc, err := resourcecontroller.NewService(resourcecontroller.ServiceOptions{})
+		// Create Resource Controller client.
+		var serviceOption resourcecontroller.ServiceOptions
+		// Fetch the resource controller endpoint.
+		rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
+		if rcEndpoint != "" {
+			serviceOption.URL = rcEndpoint
+			params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
+		}
+		rc, err := resourcecontroller.NewService(serviceOption)
 		if err != nil {
 			return nil, err
 		}
@@ -138,6 +148,7 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 		// Fetch the resource controller endpoint.
 		if rcEndpoint := endpoints.FetchRCEndpoint(params.ServiceEndpoint); rcEndpoint != "" {
 			if err := rc.SetServiceURL(rcEndpoint); err != nil {
+				params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
 				return nil, fmt.Errorf("failed to set resource controller endpoint: %w", err)
 			}
 		}
@@ -156,6 +167,13 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 		options.Zone = *params.IBMPowerVSCluster.Spec.Zone
 	}
 
+	// Fetch the PowerVS service endpoint.
+	powerVSServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.PowerVS), params.ServiceEndpoint)
+	if powerVSServiceEndpoint != "" {
+		params.Logger.V(3).Info("Overriding the default PowerVS endpoint", "powerVSEndpoint", powerVSServiceEndpoint)
+		options.IBMPIOptions.URL = powerVSServiceEndpoint
+	}
+
 	// TODO(karhtik-k-n): may be optimize NewService to use the session created here
 	powerVSClient, err := powervs.NewService(options)
 	if err != nil {
@@ -170,11 +188,15 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 	if err != nil {
 		return nil, fmt.Errorf("error failed to get account details %w", err)
 	}
-	// TODO(Karthik-k-n): Handle dubug and URL options.
+
 	sessionOptions := &ibmpisession.IBMPIOptions{
 		Authenticator: auth,
 		UserAccount:   account,
 		Zone:          options.Zone,
+		Debug:         params.Logger.V(DEBUGLEVEL).Enabled(),
+	}
+	if powerVSServiceEndpoint != "" {
+		sessionOptions.URL = powerVSServiceEndpoint
 	}
 	session, err := ibmpisession.NewIBMPISession(sessionOptions)
 	if err != nil {
@@ -210,13 +232,35 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 		return nil, fmt.Errorf("error failed to create IBM VPC client: %w", err)
 	}
 
-	tgClient, err := transitgateway.NewService()
+	// Create TransitGateway client
+	tgOptions := &tgapiv1.TransitGatewayApisV1Options{
+		Authenticator: auth,
+	}
+	// Fetch the TransitGateway service endpoint.
+	tgServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.TransitGateway), params.ServiceEndpoint)
+	if tgServiceEndpoint != "" {
+		params.Logger.V(3).Info("Overriding the default TransitGateway endpoint", "transitGatewayEndpoint", tgServiceEndpoint)
+		tgOptions.URL = tgServiceEndpoint
+	}
+
+	tgClient, err := transitgateway.NewService(tgOptions)
 	if err != nil {
 		return nil, fmt.Errorf("error failed to create tranist gateway client: %w", err)
 	}
 
-	// TODO(karthik-k-n): consider passing auth in options to resource controller
-	resourceClient, err := resourcecontroller.NewService(resourcecontroller.ServiceOptions{})
+	// Create Resource Controller client.
+	serviceOption := resourcecontroller.ServiceOptions{
+		ResourceControllerV2Options: &resourcecontrollerv2.ResourceControllerV2Options{
+			Authenticator: auth,
+		},
+	}
+	// Fetch the resource controller endpoint.
+	rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
+	if rcEndpoint != "" {
+		serviceOption.URL = rcEndpoint
+		params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
+	}
+	resourceClient, err := resourcecontroller.NewService(serviceOption)
 	if err != nil {
 		return nil, fmt.Errorf("error failed to create resource client: %w", err)
 	}
@@ -298,6 +342,7 @@ func (s *PowerVSClusterScope) GetServiceInstanceID() string {
 
 // SetStatus set the IBMPowerVSCluster status for provided ResourceType.
 func (s *PowerVSClusterScope) SetStatus(resourceType infrav1beta2.ResourceType, resource infrav1beta2.ResourceReference) {
+	s.V(3).Info("Setting status", "resourceType", resourceType, "resource", resource)
 	switch resourceType {
 	case infrav1beta2.ResourceTypeServiceInstance:
 		if s.IBMPowerVSCluster.Status.ServiceInstance == nil {
@@ -1404,9 +1449,34 @@ func (s *PowerVSClusterScope) ReconcileCOSInstance() error {
 	if !ok {
 		return fmt.Errorf("ibmcloud api key is not provided, set %s environmental variable", "IBMCLOUD_API_KEY")
 	}
+	region := s.IBMPowerVSCluster.Spec.CosInstance.BucketRegion
+	// if the bucket region is not set, use vpc region
+	if region == "" {
+		vpcDetails := s.VPC()
+		if vpcDetails == nil || vpcDetails.Region == nil {
+			return fmt.Errorf("failed to determine cos bucket region, both buckeet region and vpc region not set")
+		}
+		region = *vpcDetails.Region
+	}
 
-	// TODO: if bucket region is not set, fetch associated vpc region
-	cosClient, err := cos.NewService(cos.ServiceOptions{}, s.IBMPowerVSCluster.Spec.CosInstance.BucketRegion, apiKey, *cosServiceInstanceStatus.GUID)
+	serviceEndpoint := fmt.Sprintf("s3.%s.%s", region, cosURLDomain)
+	// Fetch the COS service endpoint.
+	cosServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.COS), s.ServiceEndpoint)
+	if cosServiceEndpoint != "" {
+		s.Logger.V(3).Info("Overriding the default COS endpoint", "cosEndpoint", cosServiceEndpoint)
+		serviceEndpoint = cosServiceEndpoint
+	}
+
+	cosOptions := cos.ServiceOptions{
+		Options: &cosSession.Options{
+			Config: aws.Config{
+				Endpoint: &serviceEndpoint,
+				Region:   &region,
+			},
+		},
+	}
+
+	cosClient, err := cos.NewService(cosOptions, apiKey, *cosServiceInstanceStatus.GUID)
 	if err != nil {
 		s.Error(err, "error creating cosClient")
 		return fmt.Errorf("failed to create cos client: %w", err)

--- a/cloud/scope/powervs_image.go
+++ b/cloud/scope/powervs_image.go
@@ -91,17 +91,18 @@ func NewPowerVSImageScope(params PowerVSImageScopeParams) (scope *PowerVSImageSc
 	}
 	scope.patchHelper = helper
 
-	rc, err := resourcecontroller.NewService(resourcecontroller.ServiceOptions{})
-	if err != nil {
-		return nil, err
+	// Create Resource Controller client.
+	var serviceOption resourcecontroller.ServiceOptions
+	// Fetch the resource controller endpoint.
+	rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
+	if rcEndpoint != "" {
+		serviceOption.URL = rcEndpoint
+		params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
 	}
 
-	// Fetch the resource controller endpoint.
-	if rcEndpoint := endpoints.FetchRCEndpoint(params.ServiceEndpoint); rcEndpoint != "" {
-		if err := rc.SetServiceURL(rcEndpoint); err != nil {
-			return nil, fmt.Errorf("failed to set resource controller endpoint: %w", err)
-		}
-		scope.Logger.V(3).Info("Overriding the default resource controller endpoint")
+	rc, err := resourcecontroller.NewService(serviceOption)
+	if err != nil {
+		return nil, err
 	}
 
 	var serviceInstanceID string

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -38,6 +38,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/ibm-cos-sdk-go/aws"
+	cosSession "github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
@@ -146,7 +147,16 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	}
 	scope.patchHelper = helper
 
-	rc, err := resourcecontroller.NewService(resourcecontroller.ServiceOptions{})
+	// Create Resource Controller client.
+	var serviceOption resourcecontroller.ServiceOptions
+	// Fetch the resource controller endpoint.
+	rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
+	if rcEndpoint != "" {
+		serviceOption.URL = rcEndpoint
+		params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
+	}
+
+	rc, err := resourcecontroller.NewService(serviceOption)
 	if err != nil {
 		return nil, err
 	}
@@ -577,12 +587,38 @@ func (m *PowerVSMachineScope) createCOSClient() (*cos.Service, error) {
 		fmt.Printf("ibmcloud api key is not provided, set %s environmental variable", "IBMCLOUD_API_KEY")
 	}
 
-	cosClient, err := cos.NewService(cos.ServiceOptions{}, m.IBMPowerVSCluster.Spec.CosInstance.BucketRegion, apiKey, *serviceInstance.GUID)
+	region := m.IBMPowerVSCluster.Spec.CosInstance.BucketRegion
+	// if the bucket region is not set, use vpc region
+	if region == "" {
+		vpcDetails := m.IBMPowerVSCluster.Spec.VPC
+		if vpcDetails == nil || vpcDetails.Region == nil {
+			return nil, fmt.Errorf("failed to determine cos bucket region, both buckeet region and vpc region not set")
+		}
+		region = *vpcDetails.Region
+	}
+
+	serviceEndpoint := fmt.Sprintf("s3.%s.%s", region, cosURLDomain)
+	// Fetch the COS service endpoint.
+	cosServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.COS), m.ServiceEndpoint)
+	if cosServiceEndpoint != "" {
+		m.Logger.V(3).Info("Overriding the default COS endpoint", "cosEndpoint", cosServiceEndpoint)
+		serviceEndpoint = cosServiceEndpoint
+	}
+
+	cosOptions := cos.ServiceOptions{
+		Options: &cosSession.Options{
+			Config: aws.Config{
+				Endpoint: &serviceEndpoint,
+				Region:   &region,
+			},
+		},
+	}
+
+	cosClient, err := cos.NewService(cosOptions, apiKey, *serviceInstance.GUID)
 	if err != nil {
 		m.Error(err, "failed to create cos client")
 		return nil, fmt.Errorf("failed to create cos client: %w", err)
 	}
-
 	return cosClient, nil
 }
 

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -47,7 +47,7 @@ it into a management cluster using `clusterctl`.
    > `${ServiceRegion1}:${ServiceID1}=${URL1},${ServiceID2}=${URL2};${ServiceRegion2}:${ServiceID1}=${URL1...}`.
    
 
-    Supported ServiceIDs include - `vpc, powervs, rc`
+    Supported ServiceIDs include - `vpc, powervs, rc, cos, transitgateway`
      ```console
       export SERVICE_ENDPOINT=us-south:vpc=https://us-south-stage01.iaasdev.cloud.ibm.com,powervs=https://dal.power-iaas.test.cloud.ibm.com,rc=https://resource-controller.test.cloud.ibm.com
      ```

--- a/pkg/cloud/services/resourcecontroller/service.go
+++ b/pkg/cloud/services/resourcecontroller/service.go
@@ -192,11 +192,13 @@ func NewService(options ServiceOptions) (*Service, error) {
 	if options.ResourceControllerV2Options == nil {
 		options.ResourceControllerV2Options = &resourcecontrollerv2.ResourceControllerV2Options{}
 	}
-	auth, err := authenticator.GetAuthenticator()
-	if err != nil {
-		return nil, err
+	if options.Authenticator == nil {
+		auth, err := authenticator.GetAuthenticator()
+		if err != nil {
+			return nil, err
+		}
+		options.Authenticator = auth
 	}
-	options.Authenticator = auth
 	service, err := resourcecontrollerv2.NewResourceControllerV2(options.ResourceControllerV2Options)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/services/transitgateway/service.go
+++ b/pkg/cloud/services/transitgateway/service.go
@@ -37,15 +37,19 @@ type Service struct {
 }
 
 // NewService returns a new service for the IBM Cloud Transit Gateway api client.
-func NewService() (TransitGateway, error) {
-	auth, err := authenticator.GetAuthenticator()
-	if err != nil {
-		return nil, err
+func NewService(options *tgapiv1.TransitGatewayApisV1Options) (TransitGateway, error) {
+	if options == nil {
+		options = &tgapiv1.TransitGatewayApisV1Options{}
 	}
-	tgClient, err := tgapiv1.NewTransitGatewayApisV1(&tgapiv1.TransitGatewayApisV1Options{
-		Authenticator: auth,
-		Version:       pointer.String(currentDate),
-	})
+	if options.Authenticator == nil {
+		auth, err := authenticator.GetAuthenticator()
+		if err != nil {
+			return nil, err
+		}
+		options.Authenticator = auth
+	}
+	options.Version = pointer.String(currentDate)
+	tgClient, err := tgapiv1.NewTransitGatewayApisV1(options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -33,11 +33,15 @@ const (
 	PowerVS serviceID = "powervs"
 	// RC used to identify Resource-Controller service.
 	RC serviceID = "rc"
+	// TransitGateway  service.
+	TransitGateway serviceID = "transitgateway"
+	// COS service.
+	COS serviceID = "cos"
 )
 
 type serviceID string
 
-var serviceIDs = []serviceID{VPC, PowerVS, RC}
+var serviceIDs = []serviceID{VPC, PowerVS, RC, TransitGateway, COS}
 
 // ServiceEndpoint holds the Service endpoint specific information.
 type ServiceEndpoint struct {
@@ -125,6 +129,7 @@ func FetchVPCEndpoint(region string, serviceEndpoint []ServiceEndpoint) string {
 }
 
 // FetchPVSEndpoint will return PowerVS service endpoint.
+// Deprecated: User FetchEndpoints instead.
 func FetchPVSEndpoint(region string, serviceEndpoint []ServiceEndpoint) string {
 	for _, powervsEndpoint := range serviceEndpoint {
 		if powervsEndpoint.Region == region && powervsEndpoint.ID == string(PowerVS) {
@@ -135,10 +140,21 @@ func FetchPVSEndpoint(region string, serviceEndpoint []ServiceEndpoint) string {
 }
 
 // FetchRCEndpoint will return resource controller endpoint.
+// Deprecated: User FetchEndpoints instead.
 func FetchRCEndpoint(serviceEndpoint []ServiceEndpoint) string {
 	for _, rcEndpoint := range serviceEndpoint {
 		if rcEndpoint.ID == string(RC) {
 			return rcEndpoint.URL
+		}
+	}
+	return ""
+}
+
+// FetchEndpoints returns the endpoint associated with serviceID otherwise empty string.
+func FetchEndpoints(serviceID string, serviceEndpoint []ServiceEndpoint) string {
+	for _, endpoint := range serviceEndpoint {
+		if endpoint.ID == serviceID {
+			return endpoint.URL
 		}
 	}
 	return ""

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -262,6 +262,68 @@ func TestFetchRCEndpoint(t *testing.T) {
 	}
 }
 
+func TestFetchEndpoints(t *testing.T) {
+	testCases := []struct {
+		name            string
+		serviceEndpoint []ServiceEndpoint
+		serviceID       string
+		expectedOutput  string
+	}{
+		{
+			name:            "With empty service endpoints",
+			serviceEndpoint: []ServiceEndpoint{},
+			expectedOutput:  "",
+		},
+		{
+			name:      "With invalid service id",
+			serviceID: "abc",
+			serviceEndpoint: []ServiceEndpoint{
+				{
+					ID:     "rc",
+					URL:    "https://rchost:8080",
+					Region: "us-south",
+				},
+			},
+			expectedOutput: "",
+		},
+		{
+			name:      "With service id not preset in service endpoints",
+			serviceID: "powervs",
+			serviceEndpoint: []ServiceEndpoint{
+				{
+					ID:     "rc",
+					URL:    "https://rchost:8080",
+					Region: "us-south",
+				},
+			},
+			expectedOutput: "",
+		},
+		{
+			name:      "With valid service id",
+			serviceID: "rc",
+			serviceEndpoint: []ServiceEndpoint{
+				{
+					ID:     "rc",
+					URL:    "https://rchost:8080",
+					Region: "us-south",
+				},
+				{
+					ID:  "powervs",
+					URL: "https://powervs:8081",
+				},
+			},
+			expectedOutput: "https://rchost:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := FetchEndpoints(tc.serviceID, tc.serviceEndpoint)
+			require.Equal(t, tc.expectedOutput, out)
+		})
+	}
+}
+
 func TestCostructRegionFromZone(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds support to override service endpoints for cos, transitgateway, resourcecontroller, powervs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1646

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to override service endpoints.
```
