### PR TITLE
Update loadbalancer spec to configure private loadbalncer

### DIFF
--- a/api/v1beta2/ibmvpccluster_types.go
+++ b/api/v1beta2/ibmvpccluster_types.go
@@ -70,7 +70,7 @@ type VPCLoadBalancerSpec struct {
 	// public indicates that load balancer is public or private
 	// +kubebuilder:default=true
 	// +optional
-	Public bool `json:"public,omitempty"`
+	Public *bool `json:"public,omitempty"`
 
 	// AdditionalListeners sets the additional listeners for the control plane load balancer.
 	// +listType=map

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -1414,6 +1414,11 @@ func (in *VPCLoadBalancerSpec) DeepCopyInto(out *VPCLoadBalancerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Public != nil {
+		in, out := &in.Public, &out.Public
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalListeners != nil {
 		in, out := &in.AdditionalListeners, &out.AdditionalListeners
 		*out = make([]AdditionalListenerSpec, len(*in))

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -439,11 +439,11 @@ func (s *PowerVSClusterScope) PublicLoadBalancer() *infrav1beta2.VPCLoadBalancer
 	if len(s.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
 		return &infrav1beta2.VPCLoadBalancerSpec{
 			Name:   *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer),
-			Public: true,
+			Public: pointer.Bool(true),
 		}
 	}
 	for _, lb := range s.IBMPowerVSCluster.Spec.LoadBalancers {
-		if lb.Public {
+		if lb.Public != nil && *lb.Public {
 			return &lb
 		}
 	}
@@ -1213,7 +1213,7 @@ func (s *PowerVSClusterScope) ReconcileLoadBalancer() error {
 	if len(s.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
 		loadBalancer := infrav1beta2.VPCLoadBalancerSpec{
 			Name:   *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer),
-			Public: true,
+			Public: pointer.Bool(true),
 		}
 		loadBalancers = append(loadBalancers, loadBalancer)
 	}
@@ -1296,8 +1296,12 @@ func (s *PowerVSClusterScope) createLoadBalancer(lb infrav1beta2.VPCLoadBalancer
 		return nil, fmt.Errorf("error getting resource group id for resource group %v, id is empty", s.ResourceGroup())
 	}
 
+	var isPublic bool
+	if lb.Public != nil && *lb.Public {
+		isPublic = true
+	}
+	options.SetIsPublic(isPublic)
 	options.SetName(lb.Name)
-	options.SetIsPublic(lb.Public)
 	options.SetResourceGroup(&vpcv1.ResourceGroupIdentity{
 		ID: &resourceGroupID,
 	})

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -921,7 +921,7 @@ func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember() (*vpcv1.LoadBala
 	if len(m.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
 		loadBalancer := infrav1beta2.VPCLoadBalancerSpec{
 			Name:   fmt.Sprintf("%s-loadbalancer", m.IBMPowerVSCluster.Name),
-			Public: true,
+			Public: pointer.Bool(true),
 		}
 		loadBalancers = append(loadBalancers, loadBalancer)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Since Public is boolean variable , once we set it to false to create a private loadbalancer as false is unset value of boolean variable and using kubebuilder tag we are setting it default to true, so its making it not possible to create a private loadabalancer.

Now changing data type to boolean pointer so we can differentiate between unset value and false value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
