### PR TITLE
VPC: Relocate COS and VPC types into common

### DIFF
--- a/api/v1beta2/ibmpowervscluster_types.go
+++ b/api/v1beta2/ibmpowervscluster_types.go
@@ -250,42 +250,6 @@ type TransitGateway struct {
 	ID *string `json:"id,omitempty"`
 }
 
-// VPCResourceReference is a reference to a specific VPC resource by ID or Name
-// Only one of ID or Name may be specified. Specifying more than one will result in
-// a validation error.
-type VPCResourceReference struct {
-	// id of resource.
-	// +kubebuilder:validation:MinLength=1
-	// +optional
-	ID *string `json:"id,omitempty"`
-
-	// name of resource.
-	// +kubebuilder:validation:MinLength=1
-	// +optional
-	Name *string `json:"name,omitempty"`
-
-	// region of IBM Cloud VPC.
-	// when powervs.cluster.x-k8s.io/create-infra=true annotation is set on IBMPowerVSCluster resource,
-	// it is expected to set the region, not setting will result in webhook error.
-	Region *string `json:"region,omitempty"`
-}
-
-// CosInstance represents IBM Cloud COS instance.
-type CosInstance struct {
-	// name defines name of IBM cloud COS instance to be created.
-	// when IBMPowerVSCluster.Ignition is set
-	// +kubebuilder:validation:MinLength:=3
-	// +kubebuilder:validation:MaxLength:=63
-	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`
-	Name string `json:"name,omitempty"`
-
-	// bucketName is IBM cloud COS bucket name
-	BucketName string `json:"bucketName,omitempty"`
-
-	// bucketRegion is IBM cloud COS bucket region
-	BucketRegion string `json:"bucketRegion,omitempty"`
-}
-
 // GetConditions returns the observations of the operational state of the IBMPowerVSCluster resource.
 func (r *IBMPowerVSCluster) GetConditions() capiv1beta1.Conditions {
 	return r.Status.Conditions

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -140,6 +140,22 @@ var (
 	ResourceTypeResourceGroup = ResourceType("resourceGroup")
 )
 
+// CosInstance represents IBM Cloud COS instance.
+type CosInstance struct {
+	// name defines name of IBM cloud COS instance to be created.
+	// when IBMPowerVSCluster.Ignition is set
+	// +kubebuilder:validation:MinLength:=3
+	// +kubebuilder:validation:MaxLength:=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`
+	Name string `json:"name,omitempty"`
+
+	// bucketName is IBM cloud COS bucket name
+	BucketName string `json:"bucketName,omitempty"`
+
+	// bucketRegion is IBM cloud COS bucket region
+	BucketRegion string `json:"bucketRegion,omitempty"`
+}
+
 // NetworkInterface holds the network interface information like subnet id.
 type NetworkInterface struct {
 	// Subnet ID of the network interface.
@@ -162,4 +178,24 @@ type VPCEndpoint struct {
 	FIPID *string `json:"floatingIPID,omitempty"`
 	// +optional
 	LBID *string `json:"loadBalancerIPID,omitempty"`
+}
+
+// VPCResourceReference is a reference to a specific VPC resource by ID or Name
+// Only one of ID or Name may be specified. Specifying more than one will result in
+// a validation error.
+type VPCResourceReference struct {
+	// id of resource.
+	// +kubebuilder:validation:MinLength=1
+	// +optional
+	ID *string `json:"id,omitempty"`
+
+	// name of resource.
+	// +kubebuilder:validation:MinLength=1
+	// +optional
+	Name *string `json:"name,omitempty"`
+
+	// region of IBM Cloud VPC.
+	// when powervs.cluster.x-k8s.io/create-infra=true annotation is set on IBMPowerVSCluster resource,
+	// it is expected to set the region, not setting will result in webhook error.
+	Region *string `json:"region,omitempty"`
 }


### PR DESCRIPTION
Relocate the CosInstance and VPCResourceReference
types from PowerVS code into common types, to
prevent duplicate code and allow VPC safe reuse.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:  Resources that could be shared between PowerVS and VPC, shouldn't be located in PowerVS code. Moving it to a shared location.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
