### PR TITLE
Explicitly set GVK for IBMPoweVSCluster resource

### DIFF
--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -300,6 +300,17 @@ func (r *IBMPowerVSClusterReconciler) deleteIBMPowerVSImage(ctx context.Context,
 		return reconcile.Result{}, err
 	}
 
+	// since we are avoiding using cache for IBMPowerVSCluster the Type meta of the retrieved object will be empty
+	// explicitly setting here to filter children
+	if gvk := cluster.GetObjectKind().GroupVersionKind(); gvk.Empty() {
+		gvk, err := r.GroupVersionKindFor(cluster)
+		if err != nil {
+			log.Error(err, "Failed to get GVK of cluster")
+			return reconcile.Result{}, err
+		}
+		cluster.SetGroupVersionKind(gvk)
+	}
+
 	children, err := descendants.filterOwnedDescendants(cluster)
 	if err != nil {
 		log.Error(err, "Failed to extract direct descendants")

--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -51,7 +51,6 @@ import (
 // IBMPowerVSClusterReconciler reconciles a IBMPowerVSCluster object.
 type IBMPowerVSClusterReconciler struct {
 	client.Client
-	UncachedClient  client.Client
 	Recorder        record.EventRecorder
 	ServiceEndpoint []endpoints.ServiceEndpoint
 	Scheme          *runtime.Scheme
@@ -66,7 +65,7 @@ func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Fetch the IBMPowerVSCluster instance.
 	ibmCluster := &infrav1beta2.IBMPowerVSCluster{}
-	err := r.UncachedClient.Get(ctx, req.NamespacedName, ibmCluster)
+	err := r.Get(ctx, req.NamespacedName, ibmCluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/ibmpowervscluster_controller_test.go
+++ b/controllers/ibmpowervscluster_controller_test.go
@@ -79,8 +79,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			reconciler := &IBMPowerVSClusterReconciler{
-				Client:         testEnv.Client,
-				UncachedClient: testEnv.Client,
+				Client: testEnv.Client,
 			}
 
 			ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("namespace-%s", util.RandomString(5)))
@@ -158,8 +157,7 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			reconciler := &IBMPowerVSClusterReconciler{
-				Client:         testEnv.Client,
-				UncachedClient: testEnv.Client,
+				Client: testEnv.Client,
 			}
 			_, _ = reconciler.reconcile(tc.powervsClusterScope)
 			g.Expect(tc.powervsClusterScope.IBMPowerVSCluster.Status.Ready).To(Equal(tc.clusterStatus))
@@ -174,8 +172,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 		clusterScope *scope.PowerVSClusterScope
 	)
 	reconciler = IBMPowerVSClusterReconciler{
-		Client:         testEnv.Client,
-		UncachedClient: testEnv.Client,
+		Client: testEnv.Client,
 	}
 	t.Run("Reconciling delete IBMPowerVSCluster", func(t *testing.T) {
 		t.Run("Should reconcile successfully if no descendants are found", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -130,6 +131,13 @@ func main() {
 			Port:    webhookPort,
 			CertDir: webhookCertDir,
 		}),
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&infrav1beta2.IBMPowerVSCluster{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -243,14 +242,8 @@ func setupReconcilers(mgr ctrl.Manager, serviceEndpoint []endpoints.ServiceEndpo
 		os.Exit(1)
 	}
 
-	cfg := ctrl.GetConfigOrDie()
-	uncachedClient, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
-	if err != nil {
-		setupLog.Error(err, "unable to set up uncached client")
-	}
 	if err := (&controllers.IBMPowerVSClusterReconciler{
 		Client:          mgr.GetClient(),
-		UncachedClient:  uncachedClient,
 		Recorder:        mgr.GetEventRecorderFor("ibmpowervscluster-controller"),
 		ServiceEndpoint: serviceEndpoint,
 		Scheme:          mgr.GetScheme(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Explicitly sets the GVK for IBMPowerVSCluster, Since we are excluding IBMPowerVSCluster object from cache, When we retrive the object we [wont get TypeMeta associated](https://github.com/kubernetes/kubernetes/issues/80609) with it because of it we are not able to filter out the childrens of the object , IBMPowerVSImage is one of them so it fails to delete it.

Also reverted the uncached client commit and updated the manager to exclude specifically IBMPowerVSCluster from cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1690

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
