### PR TITLE
Validate DHCP network id 

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -840,6 +840,10 @@ func (m *PowerVSMachineScope) SetAddresses(instance *models.PVMInstance) { //nol
 	// Get the Details of DHCP server associated with the network
 	var dhcpServerDetails *models.DHCPServerDetail
 	for _, server := range dhcpServer {
+		if server.Network == nil || server.Network.ID == nil {
+			m.V(3).Info("Skipping the DHCP server as its network details is nil", "DHCP server", *server.ID)
+			continue
+		}
 		if *server.Network.ID == *networkID {
 			m.Info("found DHCP server for network", "DHCP server ID", *server.ID, "network ID", *networkID)
 			dhcpServerDetails, err = m.IBMPowerVSClient.GetDHCPServer(*server.ID)

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When the workspace has multiple DHCP servers and one of them is in building, The network id will be nil
Example
```
[{"id":"35bee472-f363-4921-b116-7d98b1711899","network":{"id":null,"name":null},"status":"BUILD"},{"id":"0303c8e5-2805-4afd-bf4d-bfbaad93056f","network":{"id":"8bab36e6-c655-46fa-bbc7-c7a7cfadc937","name":"DHCPSERVERcapi-uncache-karthik_Private"},"status":"ACTIVE"}]
```

This PR adds a check against network id before dereferencing it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Check for DHCP Network id to be not nil to avoid panic
```
