### PR TITLE
Refactor resource manager to use interface and override resource manager endpoint URL

### DIFF
--- a/pkg/cloud/services/resourcemanager/doc.go
+++ b/pkg/cloud/services/resourcemanager/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resourcemanager implements resourcemanager code.
+// Manage lifecycle of cloud resource groups using Resource Manager APIs.
+package resourcemanager

--- a/pkg/cloud/services/resourcemanager/resourcemanager.go
+++ b/pkg/cloud/services/resourcemanager/resourcemanager.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcemanager
+
+import (
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
+)
+
+// ResourceManager interface defines a method that a IBMCLOUD service object should implement in order to
+// use the manage lifecycle of cloud resource groups using Resource Manager APIs.
+type ResourceManager interface {
+	ListResourceGroups(*resourcemanagerv2.ListResourceGroupsOptions) (*resourcemanagerv2.ResourceGroupList, *core.DetailedResponse, error)
+}

--- a/pkg/cloud/services/resourcemanager/service.go
+++ b/pkg/cloud/services/resourcemanager/service.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcemanager
+
+import (
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
+
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
+)
+
+// Service holds the IBM Cloud Resource Manager Service specific information.
+type Service struct {
+	client *resourcemanagerv2.ResourceManagerV2
+}
+
+// NewService returns a new service for the resource manager.
+func NewService(options *resourcemanagerv2.ResourceManagerV2Options) (ResourceManager, error) {
+	if options == nil {
+		options = &resourcemanagerv2.ResourceManagerV2Options{}
+	}
+	if options.Authenticator == nil {
+		auth, err := authenticator.GetAuthenticator()
+		if err != nil {
+			return nil, err
+		}
+		options.Authenticator = auth
+	}
+	rmClient, err := resourcemanagerv2.NewResourceManagerV2(options)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		client: rmClient,
+	}, nil
+}
+
+// ListResourceGroups lists the resource groups.
+func (s *Service) ListResourceGroups(listResourceGroupsOptions *resourcemanagerv2.ListResourceGroupsOptions) (result *resourcemanagerv2.ResourceGroupList, response *core.DetailedResponse, err error) {
+	return s.client.ListResourceGroups(listResourceGroupsOptions)
+}

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -37,6 +37,8 @@ const (
 	TransitGateway serviceID = "transitgateway"
 	// COS service.
 	COS serviceID = "cos"
+	// RM used to identify Resource-Manager service.
+	RM serviceID = "rm"
 )
 
 type serviceID string


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR refactors to user interface for resource manager related operations, This will allow help us while implementing unit tests.
Also allows users to override the resource manager endpoint URL.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1731

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow users to override the resource manager endpoint URL
```
