### PR TITLE
Add validation for loadbalancer port against 6443 and to avoid duplicate names

### DIFF
--- a/api/v1beta2/ibmvpccluster_types.go
+++ b/api/v1beta2/ibmvpccluster_types.go
@@ -81,6 +81,7 @@ type VPCLoadBalancerSpec struct {
 	// +listType=map
 	// +listMapKey=port
 	// +optional
+	// ++kubebuilder:validation:UniqueItems=true
 	AdditionalListeners []AdditionalListenerSpec `json:"additionalListeners,omitempty"`
 }
 


### PR DESCRIPTION
Added validation for loadbalancer port against 6443 as its already used, kubebuilder tag to avoid duplicate ports and validation to avoid duplicate loadbalancer, vpcsubnet names.

Validation output:
```
The IBMPowerVSCluster "capi-powervs-keerthana" is invalid:
* spec.vpcSubnets[1]: Duplicate value: map[string]interface {}{"Name":"capi-powervs-keerthana-vpcsubnet"}
* spec.loadbalancers[2]: Duplicate value: map[string]interface {}{"Name":"capi-powervs-keerthana-loadbalancer2"}
* spec.loadbalancers[3]: Duplicate value: map[string]interface {}{"Name":"capi-powervs-keerthana-loadbalancer1"}
* spec.loadbalancers[0].additionalListeners[0].port: Invalid value: 6443: value of port should not be equal to APIServerPort (6443)
```
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1663

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation for loadbalancer port against 6443 and to avoid duplicate names.
```
