### PR TITLE
Update PortRange and ICMP types for Security Groups

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -260,12 +260,12 @@ type PortRange struct {
 	// maximumPort is the inclusive upper range of ports.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
-	MaximumPort int `json:"maximumPort,omitempty"`
+	MaximumPort int64 `json:"maximumPort,omitempty"`
 
 	// minimumPort is the inclusive lower range of ports.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
-	MinimumPort int `json:"minimumPort,omitempty"`
+	MinimumPort int64 `json:"minimumPort,omitempty"`
 }
 
 // SecurityGroup defines a VPC Security Group that should exist or be created within the specified VPC, with the specified Security Group Rules.
@@ -361,12 +361,12 @@ type SecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.
 	// Only used when Protocol is SecurityGroupProtocolICMP.
 	// +optional
-	ICMPCode *string `json:"icmpCode,omitempty"`
+	ICMPCode *int64 `json:"icmpCode,omitempty"`
 
 	// icmpType is the ICMP type for the Rule.
 	// Only used when Protocol is SecurityGroupProtocolICMP.
 	// +optional
-	ICMPType *string `json:"icmpType,omitempty"`
+	ICMPType *int64 `json:"icmpType,omitempty"`
 
 	// portRange is a range of ports allowed for the Rule's remote.
 	// +optional

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -1408,12 +1408,12 @@ func (in *SecurityGroupRulePrototype) DeepCopyInto(out *SecurityGroupRulePrototy
 	*out = *in
 	if in.ICMPCode != nil {
 		in, out := &in.ICMPCode, &out.ICMPCode
-		*out = new(string)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ICMPType != nil {
 		in, out := &in.ICMPType, &out.ICMPType
-		*out = new(string)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortRange != nil {


### PR DESCRIPTION
Update the types for PortRange fields and for ICMP fields in the Security Groups, to make setting and checking easier.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Convert certain fields to types more in line with API fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Converted PortRange and ICMP fields for Security Group Rules to be more in line with API
```
