### PR TITLE
Refactor IsPowerVSZoneSupportsPER() code to use interface

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/ibm-cos-sdk-go/aws"
@@ -593,17 +592,12 @@ func (s *PowerVSClusterScope) IsPowerVSZoneSupportsPER() error {
 		return fmt.Errorf("powervs zone is not set")
 	}
 	// fetch the datacenter capabilities for zone.
-	// though the function name is WithDatacenterRegion it takes zone as parameter
-	params := datacenters.NewV1DatacentersGetParamsWithContext(context.TODO()).WithDatacenterRegion(*zone)
-	datacenter, err := s.session.Power.Datacenters.V1DatacentersGet(params)
+	datacenter, err := s.IBMPowerVSClient.GetDatacenters(*zone)
 	if err != nil {
-		return fmt.Errorf("failed to get datacenter details for zone: %s err:%w", *zone, err)
-	}
-	if datacenter == nil || datacenter.Payload == nil || datacenter.Payload.Capabilities == nil {
-		return fmt.Errorf("failed to get datacenter capabilities for zone: %s", *zone)
+		return err
 	}
 	// check for the PER support in datacenter capabilities.
-	perAvailable, ok := datacenter.Payload.Capabilities[powerEdgeRouter]
+	perAvailable, ok := datacenter.Capabilities[powerEdgeRouter]
 	if !ok {
 		return fmt.Errorf("%s capability unknown for zone: %s", powerEdgeRouter, *zone)
 	}

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -592,12 +592,12 @@ func (s *PowerVSClusterScope) IsPowerVSZoneSupportsPER() error {
 		return fmt.Errorf("powervs zone is not set")
 	}
 	// fetch the datacenter capabilities for zone.
-	datacenter, err := s.IBMPowerVSClient.GetDatacenters(*zone)
+	datacenterCapabilities, err := s.IBMPowerVSClient.GetDatacenterCapabilities(*zone)
 	if err != nil {
 		return err
 	}
 	// check for the PER support in datacenter capabilities.
-	perAvailable, ok := datacenter.Capabilities[powerEdgeRouter]
+	perAvailable, ok := datacenterCapabilities[powerEdgeRouter]
 	if !ok {
 		return fmt.Errorf("%s capability unknown for zone: %s", powerEdgeRouter, *zone)
 	}

--- a/pkg/cloud/services/powervs/mock/powervs_generated.go
+++ b/pkg/cloud/services/powervs/mock/powervs_generated.go
@@ -246,6 +246,21 @@ func (mr *MockPowerVSMockRecorder) GetDHCPServer(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPServer", reflect.TypeOf((*MockPowerVS)(nil).GetDHCPServer), id)
 }
 
+// GetDatacenters mocks base method.
+func (m *MockPowerVS) GetDatacenters(zone string) (*models.Datacenter, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatacenters", zone)
+	ret0, _ := ret[0].(*models.Datacenter)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDatacenters indicates an expected call of GetDatacenters.
+func (mr *MockPowerVSMockRecorder) GetDatacenters(zone any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenters", reflect.TypeOf((*MockPowerVS)(nil).GetDatacenters), zone)
+}
+
 // GetImage mocks base method.
 func (m *MockPowerVS) GetImage(id string) (*models.Image, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/services/powervs/mock/powervs_generated.go
+++ b/pkg/cloud/services/powervs/mock/powervs_generated.go
@@ -246,19 +246,19 @@ func (mr *MockPowerVSMockRecorder) GetDHCPServer(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPServer", reflect.TypeOf((*MockPowerVS)(nil).GetDHCPServer), id)
 }
 
-// GetDatacenters mocks base method.
-func (m *MockPowerVS) GetDatacenters(zone string) (*models.Datacenter, error) {
+// GetDatacenterCapabilities mocks base method.
+func (m *MockPowerVS) GetDatacenterCapabilities(zone string) (map[string]bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDatacenters", zone)
-	ret0, _ := ret[0].(*models.Datacenter)
+	ret := m.ctrl.Call(m, "GetDatacenterCapabilities", zone)
+	ret0, _ := ret[0].(map[string]bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDatacenters indicates an expected call of GetDatacenters.
-func (mr *MockPowerVSMockRecorder) GetDatacenters(zone any) *gomock.Call {
+// GetDatacenterCapabilities indicates an expected call of GetDatacenterCapabilities.
+func (mr *MockPowerVSMockRecorder) GetDatacenterCapabilities(zone any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenters", reflect.TypeOf((*MockPowerVS)(nil).GetDatacenters), zone)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenterCapabilities", reflect.TypeOf((*MockPowerVS)(nil).GetDatacenterCapabilities), zone)
 }
 
 // GetImage mocks base method.

--- a/pkg/cloud/services/powervs/powervs.go
+++ b/pkg/cloud/services/powervs/powervs.go
@@ -44,4 +44,5 @@ type PowerVS interface {
 	DeleteDHCPServer(id string) error
 	WithClients(options ServiceOptions) *Service
 	GetNetworkByName(networkName string) (*models.NetworkReference, error)
+	GetDatacenters(zone string) (*models.Datacenter, error)
 }

--- a/pkg/cloud/services/powervs/powervs.go
+++ b/pkg/cloud/services/powervs/powervs.go
@@ -44,5 +44,5 @@ type PowerVS interface {
 	DeleteDHCPServer(id string) error
 	WithClients(options ServiceOptions) *Service
 	GetNetworkByName(networkName string) (*models.NetworkReference, error)
-	GetDatacenters(zone string) (*models.Datacenter, error)
+	GetDatacenterCapabilities(zone string) (map[string]bool, error)
 }

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -18,6 +18,8 @@ package powervs
 
 import (
 	"context"
+	"fmt"
+	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
@@ -184,4 +186,18 @@ func (s *Service) GetNetworkByName(networkName string) (*models.NetworkReference
 	}
 
 	return network, nil
+}
+
+func (s *Service) GetDatacenters(zone string) (*models.Datacenter, error) {
+	// fetch the datacenter capabilities for zone.
+	// though the function name is WithDatacenterRegion it takes zone as parameter
+	params := datacenters.NewV1DatacentersGetParamsWithContext(context.TODO()).WithDatacenterRegion(zone)
+	datacenter, err := s.session.Power.Datacenters.V1DatacentersGet(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get datacenter details for zone: %s err:%w", zone, err)
+	}
+	if datacenter == nil || datacenter.Payload == nil || datacenter.Payload.Capabilities == nil {
+		return nil, fmt.Errorf("failed to get datacenter capabilities for zone: %s", zone)
+	}
+	return datacenter.Payload, nil
 }

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -188,8 +188,8 @@ func (s *Service) GetNetworkByName(networkName string) (*models.NetworkReference
 	return network, nil
 }
 
-// GetDatacenters fetches the datacenter capabilities for the given zone.
-func (s *Service) GetDatacenters(zone string) (*models.Datacenter, error) {
+// GetDatacenterCapabilities fetches the datacenter capabilities for the given zone.
+func (s *Service) GetDatacenterCapabilities(zone string) (map[string]bool, error) {
 	// though the function name is WithDatacenterRegion it takes zone as parameter
 	params := datacenters.NewV1DatacentersGetParamsWithContext(context.TODO()).WithDatacenterRegion(zone)
 	datacenter, err := s.session.Power.Datacenters.V1DatacentersGet(params)
@@ -199,5 +199,5 @@ func (s *Service) GetDatacenters(zone string) (*models.Datacenter, error) {
 	if datacenter == nil || datacenter.Payload == nil || datacenter.Payload.Capabilities == nil {
 		return nil, fmt.Errorf("failed to get datacenter capabilities for zone: %s", zone)
 	}
-	return datacenter.Payload, nil
+	return datacenter.Payload.Capabilities, nil
 }

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -19,10 +19,10 @@ package powervs
 import (
 	"context"
 	"fmt"
-	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 
@@ -188,8 +188,8 @@ func (s *Service) GetNetworkByName(networkName string) (*models.NetworkReference
 	return network, nil
 }
 
+// GetDatacenters fetches the datacenter capabilities for the given zone.
 func (s *Service) GetDatacenters(zone string) (*models.Datacenter, error) {
-	// fetch the datacenter capabilities for zone.
 	// though the function name is WithDatacenterRegion it takes zone as parameter
 	params := datacenters.NewV1DatacentersGetParamsWithContext(context.TODO()).WithDatacenterRegion(zone)
 	datacenter, err := s.session.Power.Datacenters.V1DatacentersGet(params)


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently IsPowerVSZoneSupportsPER() uses a get call directly to fetch datacenter information, this might be a problem to mock when we have to add unit tests, hence refactoring the code to use interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1774 

