### PR TITLE
User klog.Background() instead of textlogger

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -26,7 +26,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -74,7 +74,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	}
 
 	if params.Logger == (logr.Logger{}) {
-		params.Logger = textlogger.NewLogger(textlogger.NewConfig())
+		params.Logger = klog.Background()
 	}
 
 	helper, err := patch.NewHelper(params.IBMVPCCluster, params.Client)

--- a/cloud/scope/cluster_test.go
+++ b/cloud/scope/cluster_test.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -47,7 +47,7 @@ func setupClusterScope(clusterName string, mockvpc *mock.MockVpc) *ClusterScope 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(initObjects...).Build()
 	return &ClusterScope{
 		Client:        client,
-		Logger:        textlogger.NewLogger(textlogger.NewConfig()),
+		Logger:        klog.Background(),
 		IBMVPCClient:  mockvpc,
 		Cluster:       cluster,
 		IBMVPCCluster: vpcCluster,

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,7 +80,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 	}
 
 	if params.Logger == (logr.Logger{}) {
-		params.Logger = textlogger.NewLogger(textlogger.NewConfig())
+		params.Logger = klog.Background()
 	}
 
 	helper, err := patch.NewHelper(params.IBMVPCMachine, params.Client)

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -66,7 +66,7 @@ func setupMachineScope(clusterName string, machineName string, mockvpc *mock.Moc
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(initObjects...).Build()
 	return &MachineScope{
 		Client:        client,
-		Logger:        textlogger.NewLogger(textlogger.NewConfig()),
+		Logger:        klog.Background(),
 		IBMVPCClient:  mockvpc,
 		Cluster:       cluster,
 		Machine:       machine,

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -37,7 +37,7 @@ import (
 	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,7 +117,7 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 		return nil, err
 	}
 	if params.Logger == (logr.Logger{}) {
-		params.Logger = textlogger.NewLogger(textlogger.NewConfig())
+		params.Logger = klog.Background()
 	}
 
 	helper, err := patch.NewHelper(params.IBMPowerVSCluster, params.Client)

--- a/cloud/scope/powervs_image.go
+++ b/cloud/scope/powervs_image.go
@@ -28,7 +28,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -80,7 +80,7 @@ func NewPowerVSImageScope(params PowerVSImageScopeParams) (scope *PowerVSImageSc
 	scope.IBMPowerVSImage = params.IBMPowerVSImage
 
 	if params.Logger == (logr.Logger{}) {
-		params.Logger = textlogger.NewLogger(textlogger.NewConfig())
+		params.Logger = klog.Background()
 	}
 	scope.Logger = params.Logger
 

--- a/cloud/scope/powervs_image_test.go
+++ b/cloud/scope/powervs_image_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -63,7 +63,7 @@ func setupPowerVSImageScope(imageName string, mockpowervs *mock.MockPowerVS) *Po
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(initObjects...).Build()
 	return &PowerVSImageScope{
 		Client:           client,
-		Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+		Logger:           klog.Background(),
 		IBMPowerVSClient: mockpowervs,
 		IBMPowerVSImage:  powervsImage,
 	}

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,7 +133,7 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	scope.IBMPowerVSImage = params.IBMPowerVSImage
 
 	if params.Logger == (logr.Logger{}) {
-		params.Logger = textlogger.NewLogger(textlogger.NewConfig())
+		params.Logger = klog.Background()
 	}
 	if params.Logger.V(DEBUGLEVEL).Enabled() {
 		core.SetLoggingLevel(core.LevelDebug)

--- a/cloud/scope/powervs_machine_test.go
+++ b/cloud/scope/powervs_machine_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,7 +89,7 @@ func setupPowerVSMachineScope(clusterName string, machineName string, imageID *s
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(initObjects...).Build()
 	return &PowerVSMachineScope{
 		Client:            client,
-		Logger:            textlogger.NewLogger(textlogger.NewConfig()),
+		Logger:            klog.Background(),
 		IBMPowerVSClient:  mockpowervs,
 		Cluster:           cluster,
 		Machine:           machine,

--- a/controllers/ibmpowervscluster_controller_test.go
+++ b/controllers/ibmpowervscluster_controller_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -178,7 +178,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 		t.Run("Should reconcile successfully if no descendants are found", func(t *testing.T) {
 			g := NewWithT(t)
 			clusterScope = &scope.PowerVSClusterScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "IBMPowerVSCluster",
@@ -200,7 +200,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 		t.Run("Should reconcile with requeue by deleting the cluster descendants", func(t *testing.T) {
 			g := NewWithT(t)
 			clusterScope = &scope.PowerVSClusterScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "IBMPowerVSCluster",

--- a/controllers/ibmpowervsimage_controller_test.go
+++ b/controllers/ibmpowervsimage_controller_test.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -151,7 +151,7 @@ func TestIBMPowerVSImageReconciler_reconcile(t *testing.T) {
 					Name: "capi-powervs-cluster"},
 			}
 			imageScope := &scope.PowerVSImageScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				IBMPowerVSImage: &infrav1beta2.IBMPowerVSImage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "capi-image",
@@ -204,7 +204,7 @@ func TestIBMPowerVSImageReconciler_reconcile(t *testing.T) {
 
 			mockclient := fake.NewClientBuilder().WithObjects([]client.Object{powervsCluster, powervsImage}...).Build()
 			imageScope := &scope.PowerVSImageScope{
-				Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+				Logger:           klog.Background(),
 				Client:           mockclient,
 				IBMPowerVSImage:  powervsImage,
 				IBMPowerVSClient: mockpowervs,
@@ -337,7 +337,7 @@ func TestIBMPowerVSImageReconciler_delete(t *testing.T) {
 			Recorder: recorder,
 		}
 		imageScope = &scope.PowerVSImageScope{
-			Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+			Logger:           klog.Background(),
 			IBMPowerVSImage:  &infrav1beta2.IBMPowerVSImage{},
 			IBMPowerVSClient: mockpowervs,
 		}

--- a/controllers/ibmpowervsmachine_controller_test.go
+++ b/controllers/ibmpowervsmachine_controller_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -192,7 +192,7 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 			g := NewWithT(t)
 			reconciler := &IBMPowerVSMachineReconciler{
 				Client: testEnv.Client,
-				Log:    textlogger.NewLogger(textlogger.NewConfig()),
+				Log:    klog.Background(),
 			}
 			ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("namespace-%s", util.RandomString(5)))
 			g.Expect(err).To(BeNil())
@@ -262,7 +262,7 @@ func TestIBMPowerVSMachineReconciler_Delete(t *testing.T) {
 		recorder := record.NewFakeRecorder(2)
 		reconciler = IBMPowerVSMachineReconciler{
 			Client:   testEnv.Client,
-			Log:      textlogger.NewLogger(textlogger.NewConfig()),
+			Log:      klog.Background(),
 			Recorder: recorder,
 		}
 	}
@@ -276,7 +276,7 @@ func TestIBMPowerVSMachineReconciler_Delete(t *testing.T) {
 			setup(t)
 			t.Cleanup(teardown)
 			machineScope = &scope.PowerVSMachineScope{
-				Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+				Logger:           klog.Background(),
 				IBMPowerVSClient: mockpowervs,
 				IBMPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -294,7 +294,7 @@ func TestIBMPowerVSMachineReconciler_Delete(t *testing.T) {
 			setup(t)
 			t.Cleanup(teardown)
 			machineScope = &scope.PowerVSMachineScope{
-				Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+				Logger:           klog.Background(),
 				IBMPowerVSClient: mockpowervs,
 				IBMPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -330,7 +330,7 @@ func TestIBMPowerVSMachineReconciler_Delete(t *testing.T) {
 			mockClient := fake.NewClientBuilder().WithObjects([]client.Object{secret}...).Build()
 			machineScope = &scope.PowerVSMachineScope{
 				Client:           mockClient,
-				Logger:           textlogger.NewLogger(textlogger.NewConfig()),
+				Logger:           klog.Background(),
 				IBMPowerVSClient: mockpowervs,
 				IBMPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -377,7 +377,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 		recorder := record.NewFakeRecorder(2)
 		reconciler = IBMPowerVSMachineReconciler{
 			Client:   testEnv.Client,
-			Log:      textlogger.NewLogger(textlogger.NewConfig()),
+			Log:      klog.Background(),
 			Recorder: recorder,
 		}
 	}
@@ -390,7 +390,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 			setup(t)
 			t.Cleanup(teardown)
 			machineScope = &scope.PowerVSMachineScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				Cluster: &capiv1beta1.Cluster{
 					Status: capiv1beta1.ClusterStatus{
 						InfrastructureReady: false,
@@ -408,7 +408,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 			setup(t)
 			t.Cleanup(teardown)
 			machineScope = &scope.PowerVSMachineScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				Cluster: &capiv1beta1.Cluster{
 					Status: capiv1beta1.ClusterStatus{
 						InfrastructureReady: true,
@@ -431,7 +431,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 			setup(t)
 			t.Cleanup(teardown)
 			machineScope = &scope.PowerVSMachineScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				Cluster: &capiv1beta1.Cluster{
 					Status: capiv1beta1.ClusterStatus{
 						InfrastructureReady: true,
@@ -457,7 +457,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 			var instances = &models.PVMInstances{}
 			mockclient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build()
 			machineScope = &scope.PowerVSMachineScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				Client: mockclient,
 				Cluster: &capiv1beta1.Cluster{
 					Status: capiv1beta1.ClusterStatus{
@@ -540,7 +540,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 
 			mockclient := fake.NewClientBuilder().WithObjects([]client.Object{secret, pvsmachine, machine}...).Build()
 			machineScope = &scope.PowerVSMachineScope{
-				Logger: textlogger.NewLogger(textlogger.NewConfig()),
+				Logger: klog.Background(),
 				Client: mockclient,
 				Cluster: &capiv1beta1.Cluster{
 					Status: capiv1beta1.ClusterStatus{

--- a/controllers/ibmvpccluster_controller_test.go
+++ b/controllers/ibmvpccluster_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -91,7 +91,7 @@ func TestIBMVPCClusterReconciler_Reconcile(t *testing.T) {
 			g := NewWithT(t)
 			reconciler := &IBMVPCClusterReconciler{
 				Client: testEnv.Client,
-				Log:    textlogger.NewLogger(textlogger.NewConfig()),
+				Log:    klog.Background(),
 			}
 
 			ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("namespace-%s", util.RandomString(5)))
@@ -154,12 +154,12 @@ func TestIBMVPCClusterReconciler_reconcile(t *testing.T) {
 		mockvpc = mock.NewMockVpc(mockCtrl)
 		reconciler = IBMVPCClusterReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		clusterScope = &scope.ClusterScope{
 			IBMVPCClient: mockvpc,
 			Cluster:      &capiv1beta1.Cluster{},
-			Logger:       textlogger.NewLogger(textlogger.NewConfig()),
+			Logger:       klog.Background(),
 			IBMVPCCluster: &infrav1beta2.IBMVPCCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vpc-cluster",
@@ -291,12 +291,12 @@ func TestIBMVPCClusterLBReconciler_reconcile(t *testing.T) {
 		mockvpc := mock.NewMockVpc(gomock.NewController(t))
 		reconciler := IBMVPCClusterReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		clusterScope := &scope.ClusterScope{
 			IBMVPCClient: mockvpc,
 			Cluster:      &capiv1beta1.Cluster{},
-			Logger:       textlogger.NewLogger(textlogger.NewConfig()),
+			Logger:       klog.Background(),
 			IBMVPCCluster: &infrav1beta2.IBMVPCCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vpc-cluster",
@@ -448,11 +448,11 @@ func TestIBMVPCClusterReconciler_delete(t *testing.T) {
 		mockvpc = mock.NewMockVpc(mockCtrl)
 		reconciler = IBMVPCClusterReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		clusterScope = &scope.ClusterScope{
 			IBMVPCClient: mockvpc,
-			Logger:       textlogger.NewLogger(textlogger.NewConfig()),
+			Logger:       klog.Background(),
 			IBMVPCCluster: &infrav1beta2.IBMVPCCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{infrav1beta2.ClusterFinalizer},
@@ -558,11 +558,11 @@ func TestIBMVPCClusterLBReconciler_delete(t *testing.T) {
 		mockvpc := mock.NewMockVpc(gomock.NewController(t))
 		reconciler := IBMVPCClusterReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		clusterScope := &scope.ClusterScope{
 			IBMVPCClient: mockvpc,
-			Logger:       textlogger.NewLogger(textlogger.NewConfig()),
+			Logger:       klog.Background(),
 			IBMVPCCluster: &infrav1beta2.IBMVPCCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{infrav1beta2.ClusterFinalizer},

--- a/controllers/ibmvpcmachine_controller_test.go
+++ b/controllers/ibmvpcmachine_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2/textlogger"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -154,7 +154,7 @@ func TestIBMVPCMachineReconciler_Reconcile(t *testing.T) {
 			g := NewWithT(t)
 			reconciler := &IBMVPCMachineReconciler{
 				Client: testEnv.Client,
-				Log:    textlogger.NewLogger(textlogger.NewConfig()),
+				Log:    klog.Background(),
 			}
 			ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("namespace-%s", util.RandomString(5)))
 			g.Expect(err).To(BeNil())
@@ -223,10 +223,10 @@ func TestIBMVPCMachineReconciler_reconcile(t *testing.T) {
 		mockvpc = mock.NewMockVpc(mockCtrl)
 		reconciler = IBMVPCMachineReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		machineScope = &scope.MachineScope{
-			Logger: textlogger.NewLogger(textlogger.NewConfig()),
+			Logger: klog.Background(),
 			IBMVPCMachine: &infrav1beta2.IBMVPCMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "capi-machine",
@@ -281,10 +281,10 @@ func TestIBMVPCMachineLBReconciler_reconcile(t *testing.T) {
 		mockvpc := mock.NewMockVpc(gomock.NewController(t))
 		reconciler := IBMVPCMachineReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		machineScope := &scope.MachineScope{
-			Logger: textlogger.NewLogger(textlogger.NewConfig()),
+			Logger: klog.Background(),
 			IBMVPCMachine: &infrav1beta2.IBMVPCMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "capi-machine",
@@ -433,10 +433,10 @@ func TestIBMVPCMachineReconciler_Delete(t *testing.T) {
 		mockvpc = mock.NewMockVpc(mockCtrl)
 		reconciler = IBMVPCMachineReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		machineScope = &scope.MachineScope{
-			Logger: textlogger.NewLogger(textlogger.NewConfig()),
+			Logger: klog.Background(),
 			IBMVPCMachine: &infrav1beta2.IBMVPCMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "capi-machine",
@@ -483,10 +483,10 @@ func TestIBMVPCMachineLBReconciler_Delete(t *testing.T) {
 		mockvpc := mock.NewMockVpc(gomock.NewController(t))
 		reconciler := IBMVPCMachineReconciler{
 			Client: testEnv.Client,
-			Log:    textlogger.NewLogger(textlogger.NewConfig()),
+			Log:    klog.Background(),
 		}
 		machineScope := &scope.MachineScope{
-			Logger: textlogger.NewLogger(textlogger.NewConfig()),
+			Logger: klog.Background(),
 			IBMVPCMachine: &infrav1beta2.IBMVPCMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "capi-machine",

--- a/main.go
+++ b/main.go
@@ -31,7 +31,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	cgrecord "k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -152,7 +151,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	ctrl.SetLogger(klog.Background())
 
 	// Parse service endpoints.
 	serviceEndpoint, err := endpoints.ParseServiceEndpointFlag(endpoints.ServiceEndpointFormat)

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,7 +64,7 @@ var (
 func init() {
 	klog.InitFlags(nil)
 
-	logger := textlogger.NewLogger(textlogger.NewConfig())
+	logger := klog.Background()
 	ctrl.SetLogger(logger)
 
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Currently we are using textlogger, using which we are not able to see any V level logs, For example. log.V(3).Info("hello").
This PR contains the change which uses klog.Background() instead of text logger.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Switch to kloger instead of textloger
```
