### PR TITLE
Bump k8s version to 1.29 in e2e for VPC

### DIFF
--- a/docs/book/src/machine-images/vpc.md
+++ b/docs/book/src/machine-images/vpc.md
@@ -3,6 +3,7 @@
 
 | Region   | Bucket           | Object                                                   | Kubernetes Version |
 |----------|------------------|----------------------------------------------------------|--------------------|
+| us-south | power-oss-bucket | [capibm-vpc-ubuntu-2204-kube-v1-29-3.qcow2][kube-1-29-3] | 1.29.3             |
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2004-kube-v1-28-4.qcow2][kube-1-28-4] | 1.28.4             |
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2004-kube-v1-27-2.qcow2][kube-1-27-2] | 1.27.2             |
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2004-kube-v1-26-2.qcow2][kube-1-26-2] | 1.26.2             |
@@ -11,6 +12,7 @@
 
 Note: These images are built using the [image-builder][image-builder] tool and more information can be found [here](../developer/build-images.md#vpc)
 
+[kube-1-29-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2204-kube-v1-29-3.qcow2
 [kube-1-28-4]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2004-kube-v1-28-4.qcow2
 [kube-1-27-2]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2004-kube-v1-27-2.qcow2
 [kube-1-26-2]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2004-kube-v1-26-2.qcow2

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -136,7 +136,7 @@ prerequisites_vpc(){
     export IBMVPC_ZONE="${IBMVPC_REGION}-1"
     export IBMVPC_RESOURCEGROUP=${BOSKOS_RESOURCE_GROUP:-"fa5405a58226402f9a5818cb9b8a5a8a"}
     export IBMVPC_NAME=${BOSKOS_RESOURCE_NAME:-"capi-vpc-e2e"}
-    export IBMVPC_IMAGE_NAME=${IBMVPC_IMAGE_NAME:-"capibm-vpc-ubuntu-2004-kube-v1-28-4"}
+    export IBMVPC_IMAGE_NAME=${IBMVPC_IMAGE_NAME:-"capibm-vpc-ubuntu-2204-kube-v1-29-3"}
     export IBMVPC_PROFILE=${IBMVPC_PROFILE:-"bx2-4x16"}
     export IBMVPC_SSHKEY_NAME=${IBMVPC_SSHKEY_NAME:-"vpc-cloud-bot-key"}
     export PROVIDER_ID_FORMAT=v2

--- a/test/e2e/config/ibmcloud-e2e-vpc.yaml
+++ b/test/e2e/config/ibmcloud-e2e-vpc.yaml
@@ -42,7 +42,7 @@ providers:
         targetName: "cluster-template-vpc.yaml"
 
 variables:
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.28.4}"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.29.3}"
   # Below variable should be set based on the targeted environment
   SERVICE_ENDPOINT: "${SERVICE_ENDPOINT:-}"
   # Cluster Addons


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Bump k8s version to 1.29 in e2e for VPC

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # part of #1782

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump k8s version to 1.29 in e2e for VPC
```
