### PR TITLE
Use multiple zones in case of multiple subnets

### DIFF
--- a/cloud/scope/powervs_cluster_test.go
+++ b/cloud/scope/powervs_cluster_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/IBM/ibm-cos-sdk-go/aws/awserr"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	regionUtil "github.com/ppc64le-cloud/powervs-utils"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3364,6 +3365,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					VPC:        &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
 					VPCSubnets: []infrav1beta2.Subnet{{ID: ptr.To("subnet1ID"), Name: ptr.To("subnet1Name")}, {ID: ptr.To("subnet2ID"), Name: ptr.To("subnet2Name")}}},
 			},
 		}
@@ -3379,8 +3381,122 @@ func TestReconcileVPCSubnets(t *testing.T) {
 		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ID).To(Equal(subnet1Details.ID))
 		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet2Details.Name].ID).To(Equal(subnet2Details.ID))
 		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ControllerCreated).To(BeNil())
+		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet2Details.Name].ControllerCreated).To(BeNil())
 	})
 
+	t.Run("When more VPCSubnets are set in the spec than the available VPC zones with zone explicitly mentioned for few subnets", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		var subnetZone *string
+
+		clusterScope := PowerVSClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
+				Status: infrav1beta2.IBMPowerVSClusterStatus{
+					VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")},
+				},
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
+					VPC:           &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+					VPCSubnets: []infrav1beta2.Subnet{
+						{Name: ptr.To("subnet1Name"), Zone: ptr.To("eu-de-2")},
+						{Name: ptr.To("subnet2Name")},
+						{Name: ptr.To("subnet3Name")},
+						{Name: ptr.To("subnet4Name")},
+						{Name: ptr.To("subnet5Name")},
+					}},
+			},
+		}
+
+		vpcZones, err := regionUtil.VPCZonesForVPCRegion(*clusterScope.IBMPowerVSCluster.Spec.VPC.Region)
+		g.Expect(err).To(BeNil())
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets))
+		for i := 0; i < len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets); i++ {
+			subnet1Options := &vpcv1.CreateSubnetOptions{}
+			if clusterScope.IBMPowerVSCluster.Spec.VPCSubnets[i].Zone != nil {
+				subnetZone = clusterScope.IBMPowerVSCluster.Spec.VPCSubnets[i].Zone
+			} else {
+				subnetZone = &vpcZones[i%len(vpcZones)]
+			}
+			subnet1Options.SetSubnetPrototype(&vpcv1.SubnetPrototype{
+				IPVersion:             ptr.To("ipv4"),
+				TotalIpv4AddressCount: ptr.To(vpcSubnetIPAddressCount),
+				Name:                  clusterScope.IBMPowerVSCluster.Spec.VPCSubnets[i].Name,
+				VPC: &vpcv1.VPCIdentity{
+					ID: clusterScope.IBMPowerVSCluster.Status.VPC.ID,
+				},
+				Zone: &vpcv1.ZoneIdentity{
+					Name: subnetZone,
+				},
+				ResourceGroup: &vpcv1.ResourceGroupIdentity{
+					ID: clusterScope.IBMPowerVSCluster.Spec.ResourceGroup.ID,
+				},
+			})
+			subnetDetails := &vpcv1.Subnet{ID: ptr.To(fmt.Sprintf("subnet%dID", i+1)), Name: ptr.To(fmt.Sprintf("subnet%dName", i+1))}
+			mockVPC.EXPECT().CreateSubnet(subnet1Options).Return(subnetDetails, nil, nil)
+		}
+		requeue, err := clusterScope.ReconcileVPCSubnets()
+		g.Expect(requeue).To(BeTrue())
+		g.Expect(err).To(BeNil())
+		for i := 1; i <= len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets); i++ {
+			g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[fmt.Sprintf("subnet%dName", i)].ID).To(Equal(fmt.Sprintf("subnet%dID", i)))
+			g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[fmt.Sprintf("subnet%dName", i)].ControllerCreated).To(BeTrue())
+		}
+	})
+
+	t.Run("When VPCSubnets are set in the spec along with the zones", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		clusterScope := PowerVSClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
+				Status: infrav1beta2.IBMPowerVSClusterStatus{
+					VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")},
+				},
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
+					VPC:           &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+					VPCSubnets: []infrav1beta2.Subnet{
+						{Name: ptr.To("subnet1Name"), Zone: ptr.To("eu-de-1")},
+						{Name: ptr.To("subnet2Name"), Zone: ptr.To("eu-de-2")},
+						{Name: ptr.To("subnet3Name"), Zone: ptr.To("eu-de-3")},
+					}},
+			},
+		}
+
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets))
+		for i := 0; i < len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets); i++ {
+			subnet1Options := &vpcv1.CreateSubnetOptions{}
+			subnet1Options.SetSubnetPrototype(&vpcv1.SubnetPrototype{
+				IPVersion:             ptr.To("ipv4"),
+				TotalIpv4AddressCount: ptr.To(vpcSubnetIPAddressCount),
+				Name:                  clusterScope.IBMPowerVSCluster.Spec.VPCSubnets[i].Name,
+				VPC: &vpcv1.VPCIdentity{
+					ID: clusterScope.IBMPowerVSCluster.Status.VPC.ID,
+				},
+				Zone: &vpcv1.ZoneIdentity{
+					Name: clusterScope.IBMPowerVSCluster.Spec.VPCSubnets[i].Zone,
+				},
+				ResourceGroup: &vpcv1.ResourceGroupIdentity{
+					ID: clusterScope.IBMPowerVSCluster.Spec.ResourceGroup.ID,
+				},
+			})
+			subnetDetails := &vpcv1.Subnet{ID: ptr.To(fmt.Sprintf("subnet%dID", i+1)), Name: ptr.To(fmt.Sprintf("subnet%dName", i+1))}
+			mockVPC.EXPECT().CreateSubnet(subnet1Options).Return(subnetDetails, nil, nil)
+		}
+		requeue, err := clusterScope.ReconcileVPCSubnets()
+		g.Expect(requeue).To(BeTrue())
+		g.Expect(err).To(BeNil())
+		for i := 1; i <= len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets); i++ {
+			g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[fmt.Sprintf("subnet%dName", i)].ID).To(Equal(fmt.Sprintf("subnet%dID", i)))
+			g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[fmt.Sprintf("subnet%dName", i)].ControllerCreated).To(BeTrue())
+		}
+	})
 	t.Run("When VPCSubnets are not set in spec and subnet doesnot exist in cloud", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
@@ -3399,13 +3515,41 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			},
 		}
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
-		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
-		mockVPC.EXPECT().GetSubnetAddrPrefix(gomock.Any(), "eu-de-1").Return("10.240.20.0/18", nil)
-		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(subnet1Details, nil, nil)
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(3)
+		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(subnet1Details, nil, nil).Times(3)
 		requeue, err := clusterScope.ReconcileVPCSubnets()
 		g.Expect(requeue).To(BeTrue())
 		g.Expect(err).To(BeNil())
-		g.Expect(len(clusterScope.IBMPowerVSCluster.Status.VPCSubnet)).To(Equal(1))
+		g.Expect(len(clusterScope.IBMPowerVSCluster.Status.VPCSubnet)).To(Equal(3))
+		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ID).To(Equal(subnet1Details.ID))
+		g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ControllerCreated).To(BeTrue())
+	})
+
+	t.Run("When VPCSubnets are set in spec but zone is not specified", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		clusterScope := PowerVSClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
+				Status: infrav1beta2.IBMPowerVSClusterStatus{
+					VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")},
+				},
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
+					VPC:           &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+					VPCSubnets:    []infrav1beta2.Subnet{{Name: ptr.To("subnet1Name")}}},
+			},
+		}
+		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("subnet1Name")}
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
+		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(subnet1Details, nil, nil)
+
+		requeue, err := clusterScope.ReconcileVPCSubnets()
+		g.Expect(requeue).To(BeTrue())
+		g.Expect(err).To(BeNil())
 		g.Expect(clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ID).To(Equal(subnet1Details.ID))
 		g.Expect(*clusterScope.IBMPowerVSCluster.Status.VPCSubnet[*subnet1Details.Name].ControllerCreated).To(BeTrue())
 	})
@@ -3441,7 +3585,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 		g.Expect(requeue).To(BeFalse())
 		g.Expect(err).ToNot(BeNil())
 	})
-	t.Run("When subnetID and subnetName is nil", func(t *testing.T) {
+	t.Run("When subnetID and subnetName is nil and vpc subnet exists in cloud", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -3451,7 +3595,9 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
-					VPCSubnets: []infrav1beta2.Subnet{{}}},
+					VPC:        &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+					VPCSubnets: []infrav1beta2.Subnet{{Zone: ptr.To("eu-de-1")}},
+				},
 				Status: infrav1beta2.IBMPowerVSClusterStatus{
 					VPCSubnet: map[string]infrav1beta2.ResourceReference{
 						"subnet1Name": {ID: ptr.To("subnet1ID"), ControllerCreated: ptr.To(true)},
@@ -3460,7 +3606,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 		}
 		vpcSubnet1Name := fmt.Sprintf("%s-vpcsubnet-0", clusterScope.IBMPowerVSCluster.ObjectMeta.Name)
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: &vpcSubnet1Name}
-		mockVPC.EXPECT().GetVPCSubnetByName(vpcSubnet1Name).Return(subnet1Details, nil)
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(subnet1Details, nil)
 
 		requeue, err := clusterScope.ReconcileVPCSubnets()
 		g.Expect(requeue).To(BeFalse())
@@ -3479,6 +3625,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
 					VPCSubnets: []infrav1beta2.Subnet{
 						{
 							ID:   ptr.To("subnet1ID"),
@@ -3504,6 +3651,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
 					VPCSubnets: []infrav1beta2.Subnet{
 						{
 							ID:   ptr.To("subnet1ID"),
@@ -3529,7 +3677,8 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
-					VPCSubnets: []infrav1beta2.Subnet{{}}},
+					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+				},
 			},
 		}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, fmt.Errorf("GetVPCSubnetByName returns error"))
@@ -3548,7 +3697,8 @@ func TestReconcileVPCSubnets(t *testing.T) {
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
-					VPCSubnets: []infrav1beta2.Subnet{{}}},
+					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("eu-de")},
+				},
 			},
 		}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
@@ -3581,7 +3731,7 @@ func TestSetVPCSubnetStatus(t *testing.T) {
 					Status: infrav1beta2.IBMPowerVSClusterStatus{
 						VPCSubnet: map[string]infrav1beta2.ResourceReference{
 							"subnet1Name": {
-								ControllerCreated: ptr.To(false),
+								ControllerCreated: ptr.To(true),
 							},
 						},
 					},
@@ -3686,7 +3836,6 @@ func TestCreateVPCSubnet(t *testing.T) {
 		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1"), Zone: ptr.To("eu-de-1")}
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
 
-		mockVPC.EXPECT().GetSubnetAddrPrefix(*clusterScope.IBMPowerVSCluster.Status.VPC.ID, *subnet.Zone).Return("10.240.20.0/18", nil)
 		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(subnet1Details, nil, nil)
 		subnetID, err := clusterScope.createVPCSubnet(subnet)
 		g.Expect(subnetID).To(Equal(subnet1Details.ID))
@@ -3710,7 +3859,6 @@ func TestCreateVPCSubnet(t *testing.T) {
 		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
 
-		mockVPC.EXPECT().GetSubnetAddrPrefix(*clusterScope.IBMPowerVSCluster.Status.VPC.ID, "eu-de-1").Return("10.240.20.0/18", nil)
 		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(subnet1Details, nil, nil)
 		subnetID, err := clusterScope.createVPCSubnet(subnet)
 		g.Expect(subnetID).To(Equal(subnet1Details.ID))
@@ -3740,26 +3888,9 @@ func TestCreateVPCSubnet(t *testing.T) {
 		clusterScope := PowerVSClusterScope{
 			IBMVPCClient: mockVPC,
 			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
-				Spec: infrav1beta2.IBMPowerVSClusterSpec{ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")}}, Status: infrav1beta2.IBMPowerVSClusterStatus{}},
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")}}},
 		}
 		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1"), Zone: ptr.To("eu-de-1")}
-		subnetID, err := clusterScope.createVPCSubnet(subnet)
-		g.Expect(subnetID).To(BeNil())
-		g.Expect(err).ToNot(BeNil())
-	})
-	t.Run("When GetSubnetAddrPrefix returns error", func(t *testing.T) {
-		g := NewWithT(t)
-		setup(t)
-		t.Cleanup(teardown)
-
-		clusterScope := PowerVSClusterScope{
-			IBMVPCClient: mockVPC,
-			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
-				Spec:   infrav1beta2.IBMPowerVSClusterSpec{ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")}},
-				Status: infrav1beta2.IBMPowerVSClusterStatus{VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")}}},
-		}
-		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1"), Zone: ptr.To("eu-de-1")}
-		mockVPC.EXPECT().GetSubnetAddrPrefix(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("GetSubnetAddrPrefix returns error"))
 		subnetID, err := clusterScope.createVPCSubnet(subnet)
 		g.Expect(subnetID).To(BeNil())
 		g.Expect(err).ToNot(BeNil())
@@ -3777,8 +3908,7 @@ func TestCreateVPCSubnet(t *testing.T) {
 				Status: infrav1beta2.IBMPowerVSClusterStatus{VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")}}},
 		}
 		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1"), Zone: ptr.To("eu-de-1")}
-		mockVPC.EXPECT().GetSubnetAddrPrefix(gomock.Any(), gomock.Any()).Return("10.10.1.10/24", nil)
-		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(nil, nil, fmt.Errorf("GetSubnetAddrPrefix returns error"))
+		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(nil, nil, fmt.Errorf("error creating subnet"))
 		subnetID, err := clusterScope.createVPCSubnet(subnet)
 		g.Expect(subnetID).To(BeNil())
 		g.Expect(err).ToNot(BeNil())
@@ -3795,42 +3925,7 @@ func TestCreateVPCSubnet(t *testing.T) {
 				Status: infrav1beta2.IBMPowerVSClusterStatus{VPC: &infrav1beta2.ResourceReference{ID: ptr.To("vpcID")}}},
 		}
 		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1"), Zone: ptr.To("eu-de-1")}
-		mockVPC.EXPECT().GetSubnetAddrPrefix(gomock.Any(), gomock.Any()).Return("10.10.1.10/24", nil)
 		mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(nil, nil, nil)
-		subnetID, err := clusterScope.createVPCSubnet(subnet)
-		g.Expect(subnetID).To(BeNil())
-		g.Expect(err).ToNot(BeNil())
-	})
-	t.Run("When VPCZonesForVPCRegion returns error", func(t *testing.T) {
-		g := NewWithT(t)
-		setup(t)
-		t.Cleanup(teardown)
-
-		clusterScope := PowerVSClusterScope{
-			IBMVPCClient: mockVPC,
-			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
-				Spec: infrav1beta2.IBMPowerVSClusterSpec{ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
-					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("aadd")}},
-			},
-		}
-		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
-		subnetID, err := clusterScope.createVPCSubnet(subnet)
-		g.Expect(subnetID).To(BeNil())
-		g.Expect(err).ToNot(BeNil())
-	})
-	t.Run("When VPCZonesForVPCRegion returns zero zones for the region set in spec", func(t *testing.T) {
-		g := NewWithT(t)
-		setup(t)
-		t.Cleanup(teardown)
-
-		clusterScope := PowerVSClusterScope{
-			IBMVPCClient: mockVPC,
-			IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
-				Spec: infrav1beta2.IBMPowerVSClusterSpec{ResourceGroup: &infrav1beta2.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
-					VPC: &infrav1beta2.VPCResourceReference{Region: ptr.To("")}},
-			},
-		}
-		subnet := infrav1beta2.Subnet{Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
 		subnetID, err := clusterScope.createVPCSubnet(subnet)
 		g.Expect(subnetID).To(BeNil())
 		g.Expect(err).ToNot(BeNil())

--- a/controllers/ibmpowervscluster_controller_test.go
+++ b/controllers/ibmpowervscluster_controller_test.go
@@ -31,6 +31,7 @@ import (
 	tgapiv1 "github.com/IBM/networking-go-sdk/transitgatewayapisv1"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	regionUtil "github.com/ppc64le-cloud/powervs-utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1381,11 +1382,11 @@ func TestReconcileVPCResources(t *testing.T) {
 						},
 					},
 				}
+				vpcZones, _ := regionUtil.VPCZonesForVPCRegion("us-south")
 				mockVPC := vpcmock.NewMockVpc(gomock.NewController(t))
 				mockVPC.EXPECT().GetVPC(gomock.Any()).Return(&vpcv1.VPC{Status: ptr.To("active")}, nil, nil)
-				mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
-				mockVPC.EXPECT().GetSubnetAddrPrefix(gomock.Any(), gomock.Any()).Return("cidr", nil)
-				mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(&vpcv1.Subnet{Status: ptr.To("active")}, nil, nil)
+				mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(len(vpcZones))
+				mockVPC.EXPECT().CreateSubnet(gomock.Any()).Return(&vpcv1.Subnet{Status: ptr.To("active")}, nil, nil).Times(len(vpcZones))
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},

--- a/pkg/cloud/services/vpc/mock/vpc_generated.go
+++ b/pkg/cloud/services/vpc/mock/vpc_generated.go
@@ -491,21 +491,6 @@ func (mr *MockVpcMockRecorder) GetSubnet(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockVpc)(nil).GetSubnet), arg0)
 }
 
-// GetSubnetAddrPrefix mocks base method.
-func (m *MockVpc) GetSubnetAddrPrefix(vpcID, zone string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnetAddrPrefix", vpcID, zone)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubnetAddrPrefix indicates an expected call of GetSubnetAddrPrefix.
-func (mr *MockVpcMockRecorder) GetSubnetAddrPrefix(vpcID, zone any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetAddrPrefix", reflect.TypeOf((*MockVpc)(nil).GetSubnetAddrPrefix), vpcID, zone)
-}
-
 // GetSubnetPublicGateway mocks base method.
 func (m *MockVpc) GetSubnetPublicGateway(options *vpcv1.GetSubnetPublicGatewayOptions) (*vpcv1.PublicGateway, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/services/vpc/service.go
+++ b/pkg/cloud/services/vpc/service.go
@@ -450,50 +450,6 @@ func (s *Service) GetLoadBalancerByName(loadBalancerName string) (*vpcv1.LoadBal
 	return loadBalancer, nil
 }
 
-// GetSubnetAddrPrefix returns subnets address prefix.
-func (s *Service) GetSubnetAddrPrefix(vpcID, zone string) (string, error) {
-	var addrPrefix *vpcv1.AddressPrefix
-	f := func(start string) (bool, string, error) {
-		// check for existing vpcAddressPrefixes
-		listVPCAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{
-			VPCID: &vpcID,
-		}
-		if start != "" {
-			listVPCAddressPrefixesOptions.Start = &start
-		}
-
-		vpcAddressPrefixesList, _, err := s.ListVPCAddressPrefixes(listVPCAddressPrefixesOptions)
-		if err != nil {
-			return false, "", err
-		}
-
-		if vpcAddressPrefixesList == nil {
-			return false, "", fmt.Errorf("vpcAddressPrefix list returned is nil")
-		}
-
-		for i, addressPrefix := range vpcAddressPrefixesList.AddressPrefixes {
-			if (*addressPrefix.Zone.Name) == zone {
-				addrPrefix = &vpcAddressPrefixesList.AddressPrefixes[i]
-				return true, "", nil
-			}
-		}
-
-		if vpcAddressPrefixesList.Next != nil && *vpcAddressPrefixesList.Next.Href != "" {
-			return false, *vpcAddressPrefixesList.Next.Href, nil
-		}
-		return true, "", nil
-	}
-
-	if err := utils.PagingHelper(f); err != nil {
-		return "", err
-	}
-
-	if addrPrefix != nil {
-		return *addrPrefix.CIDR, nil
-	}
-	return "", fmt.Errorf("not found a valid CIDR for VPC %s in zone %s", vpcID, zone)
-}
-
 // CreateSecurityGroup creates a new security group.
 func (s *Service) CreateSecurityGroup(options *vpcv1.CreateSecurityGroupOptions) (*vpcv1.SecurityGroup, *core.DetailedResponse, error) {
 	return s.vpcService.CreateSecurityGroup(options)

--- a/pkg/cloud/services/vpc/vpc.go
+++ b/pkg/cloud/services/vpc/vpc.go
@@ -64,7 +64,6 @@ type Vpc interface {
 	GetVPCSubnetByName(subnetName string) (*vpcv1.Subnet, error)
 	GetLoadBalancerPoolByName(loadBalancerID string, poolName string) (*vpcv1.LoadBalancerPool, error)
 	GetLoadBalancerByName(loadBalancerName string) (*vpcv1.LoadBalancer, error)
-	GetSubnetAddrPrefix(vpcID, zone string) (string, error)
 	CreateSecurityGroup(options *vpcv1.CreateSecurityGroupOptions) (*vpcv1.SecurityGroup, *core.DetailedResponse, error)
 	DeleteSecurityGroup(options *vpcv1.DeleteSecurityGroupOptions) (*core.DetailedResponse, error)
 	ListSecurityGroups(options *vpcv1.ListSecurityGroupsOptions) (*vpcv1.SecurityGroupCollection, *core.DetailedResponse, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Currently when there are multiple subnets specified, it uses the first available vpcZone for all subnets by default and as a result, there is a clash in the CIDR. Hence added logic to use the subsequent vpcZones for the subnets.

If there are multiple subnets provided than the available vpcZones, the zones are selected based on round robin method.

This PR contains change to use vpcSubnetIPAddressCount, where when two subnets are to be created in the same zone, the subnets are created with the next available address prefix based on the vpcSubnetIPAddressCount.
Taking one of the below examples for reference

```
- name: subnet-1
    zone: eu-es-2
  - name: subnet-2
  - name: subnet-3
  - name: subnet-4
  - name: subnet-5
    zone: eu-es-2
  - name: subnet-6
    zone: eu-es-1
  - name: subnet-7
```
The zone selection is done as below, considering index 0 -> Madrid 1, index 1 -> Madrid 2, index 2 -> Madrid 3

```
subnet 1 -> Madrid 2 (since zone is mentioned)
subnet 2 -> Madrid 2 (since index is 1)
subnet 3 -> Madrid 3 (since index is 2)
subnet 4 -> Madrid 1 (index % len(totalvpcZones)= 3%3= 0 so Madrid 1)
subnet 5 -> Madrid 2 (since zone is mentioned)
subnet 6 -> Madrid 1 (since zone is mentioned)
subnet 7 -> Madrid 1 (index % len(totalvpcZones)= 6%3= 0 so Madrid 1)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1779 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
