### PR TITLE
Update kube-vip spec in cluster templates to adopt k8s 1.29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ generate-go-conversions: $(CONVERSION_GEN) ## Generate conversions go code
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-templates
-generate-templates: $(KUSTOMIZE)
+generate-templates: $(KUSTOMIZE) ## Generate cluster templates
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/cluster-template --load-restrictor LoadRestrictionsNone > $(TEMPLATES_DIR)/cluster-template.yaml
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/cluster-template-powervs --load-restrictor LoadRestrictionsNone > $(TEMPLATES_DIR)/cluster-template-powervs.yaml
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/cluster-template-powervs-cloud-provider --load-restrictor LoadRestrictionsNone > $(TEMPLATES_DIR)/cluster-template-powervs-cloud-provider.yaml
@@ -195,7 +195,7 @@ generate-templates: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/cluster-template-vpc-clusterclass --load-restrictor LoadRestrictionsNone > $(TEMPLATES_DIR)/cluster-template-vpc-clusterclass.yaml
 	
 .PHONY: generate-e2e-templates
-generate-e2e-templates: $(KUSTOMIZE)
+generate-e2e-templates: $(KUSTOMIZE) ## Generate E2E cluster templates
 ifeq ($(E2E_FLAVOR), powervs-md-remediation)
 	$(KUSTOMIZE) build $(E2E_TEMPLATES)/cluster-template-powervs-md-remediation --load-restrictor LoadRestrictionsNone > $(E2E_TEMPLATES)/cluster-template-powervs-md-remediation.yaml
 else

--- a/templates/bases/powervs/kcp.yaml
+++ b/templates/bases/powervs/kcp.yaml
@@ -47,6 +47,9 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
       - echo "{{ v1.local_hostname }}" >/etc/hostname
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
     files:
       - path: /etc/kubernetes/manifests/kube-vip.yaml
         content: |
@@ -87,7 +90,7 @@ spec:
                 value: "1"
               - name: address
                 value: "${IBMPOWERVS_VIP}"
-              image: ghcr.io/kube-vip/kube-vip:v0.4.4
+              image: ghcr.io/kube-vip/kube-vip:v0.8.0
               imagePullPolicy: Always
               name: kube-vip
               resources: {}
@@ -99,18 +102,71 @@ spec:
               volumeMounts:
               - mountPath: /etc/kubernetes/admin.conf
                 name: kubeconfig
-            hostAliases:
-            - hostnames:
-              - kubernetes
-              ip: 127.0.0.1
+              - mountPath: /etc/hosts
+                name: etchosts
             hostNetwork: true
             volumes:
             - hostPath:
                 path: /etc/kubernetes/admin.conf
               name: kubeconfig
+            - hostPath:
+                path: /etc/kube-vip.hosts
+                type: File
+              name: etchosts
           status: {}
         owner: "root:root"
         permissions: "0744"
+      - content: 127.0.0.1 localhost kubernetes
+        owner: root:root
+        path: /etc/kube-vip.hosts
+        permissions: "0644"
+      - content: |
+          #!/bin/bash
+    
+          # Copyright 2020 The Kubernetes Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+    
+          set -e
+    
+          # Configure the workaround required for kubeadm init with kube-vip:
+          # xref: https://github.com/kube-vip/kube-vip/issues/684
+    
+          # Nothing to do for kubernetes < v1.29
+          KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+          if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+            exit 0
+          fi
+    
+          IS_KUBEADM_INIT="false"
+    
+          # cloud-init kubeadm init
+          if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+            IS_KUBEADM_INIT="true"
+          fi
+    
+          # ignition kubeadm init
+          if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+            IS_KUBEADM_INIT="true"
+          fi
+    
+          if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+            sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+              /etc/kubernetes/manifests/kube-vip.yaml
+          fi
+        owner: root:root
+        path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+        permissions: "0700"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: IBMPowerVSMachineTemplate

--- a/templates/cluster-template-powervs-cloud-provider.yaml
+++ b/templates/cluster-template-powervs-cloud-provider.yaml
@@ -94,7 +94,7 @@ spec:
               value: "1"
             - name: address
               value: "${IBMPOWERVS_VIP}"
-            image: ghcr.io/kube-vip/kube-vip:v0.4.4
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: Always
             name: kube-vip
             resources: {}
@@ -106,19 +106,72 @@ spec:
             volumeMounts:
             - mountPath: /etc/kubernetes/admin.conf
               name: kubeconfig
-          hostAliases:
-          - hostnames:
-            - kubernetes
-            ip: 127.0.0.1
+            - mountPath: /etc/hosts
+              name: etchosts
           hostNetwork: true
           volumes:
           - hostPath:
               path: /etc/kubernetes/admin.conf
             name: kubeconfig
+          - hostPath:
+              path: /etc/kube-vip.hosts
+              type: File
+            name: etchosts
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
       permissions: "0744"
+    - content: 127.0.0.1 localhost kubernetes
+      owner: root:root
+      path: /etc/kube-vip.hosts
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        # Copyright 2020 The Kubernetes Authors.
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+
+        set -e
+
+        # Configure the workaround required for kubeadm init with kube-vip:
+        # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+        # Nothing to do for kubernetes < v1.29
+        KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+        if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+          exit 0
+        fi
+
+        IS_KUBEADM_INIT="false"
+
+        # cloud-init kubeadm init
+        if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        # ignition kubeadm init
+        if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+            /etc/kubernetes/manifests/kube-vip.yaml
+        fi
+      owner: root:root
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+      permissions: "0700"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -145,6 +198,9 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
     - echo "{{ v1.local_hostname }}" >/etc/hostname
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     useExperimentalRetryJoin: true
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -133,7 +133,7 @@ spec:
                   value: "1"
                 - name: address
                   value: "${IBMPOWERVS_VIP}"
-                image: ghcr.io/kube-vip/kube-vip:v0.4.4
+                image: ghcr.io/kube-vip/kube-vip:v0.8.0
                 imagePullPolicy: Always
                 name: kube-vip
                 resources: {}
@@ -145,19 +145,72 @@ spec:
                 volumeMounts:
                 - mountPath: /etc/kubernetes/admin.conf
                   name: kubeconfig
-              hostAliases:
-              - hostnames:
-                - kubernetes
-                ip: 127.0.0.1
+                - mountPath: /etc/hosts
+                  name: etchosts
               hostNetwork: true
               volumes:
               - hostPath:
                   path: /etc/kubernetes/admin.conf
                 name: kubeconfig
+              - hostPath:
+                  path: /etc/kube-vip.hosts
+                  type: File
+                name: etchosts
             status: {}
           owner: root:root
           path: /etc/kubernetes/manifests/kube-vip.yaml
           permissions: "0744"
+        - content: 127.0.0.1 localhost kubernetes
+          owner: root:root
+          path: /etc/kube-vip.hosts
+          permissions: "0644"
+        - content: |
+            #!/bin/bash
+
+            # Copyright 2020 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            set -e
+
+            # Configure the workaround required for kubeadm init with kube-vip:
+            # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+            # Nothing to do for kubernetes < v1.29
+            KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+            if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+              exit 0
+            fi
+
+            IS_KUBEADM_INIT="false"
+
+            # cloud-init kubeadm init
+            if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+              IS_KUBEADM_INIT="true"
+            fi
+
+            # ignition kubeadm init
+            if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+              IS_KUBEADM_INIT="true"
+            fi
+
+            if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+              sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+                /etc/kubernetes/manifests/kube-vip.yaml
+            fi
+          owner: root:root
+          path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+          permissions: "0700"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
@@ -184,6 +237,8 @@ spec:
         - echo "127.0.0.1   localhost" >>/etc/hosts
         - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
         - echo "{{ v1.local_hostname }}" >/etc/hostname
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
         useExperimentalRetryJoin: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -133,7 +133,7 @@ spec:
                     value: "1"
                   - name: address
                     value: "${IBMPOWERVS_VIP}"
-                  image: ghcr.io/kube-vip/kube-vip:v0.4.4
+                  image: ghcr.io/kube-vip/kube-vip:v0.8.0
                   imagePullPolicy: Always
                   name: kube-vip
                   resources: {}
@@ -145,19 +145,72 @@ spec:
                   volumeMounts:
                   - mountPath: /etc/kubernetes/admin.conf
                     name: kubeconfig
-                hostAliases:
-                - hostnames:
-                  - kubernetes
-                  ip: 127.0.0.1
+                  - mountPath: /etc/hosts
+                    name: etchosts
                 hostNetwork: true
                 volumes:
                 - hostPath:
                     path: /etc/kubernetes/admin.conf
                   name: kubeconfig
+                - hostPath:
+                    path: /etc/kube-vip.hosts
+                    type: File
+                  name: etchosts
               status: {}
             owner: root:root
             path: /etc/kubernetes/manifests/kube-vip.yaml
             permissions: "0744"
+          - content: 127.0.0.1 localhost kubernetes
+            owner: root:root
+            path: /etc/kube-vip.hosts
+            permissions: "0644"
+          - content: |
+              #!/bin/bash
+      
+              # Copyright 2020 The Kubernetes Authors.
+              #
+              # Licensed under the Apache License, Version 2.0 (the "License");
+              # you may not use this file except in compliance with the License.
+              # You may obtain a copy of the License at
+              #
+              #     http://www.apache.org/licenses/LICENSE-2.0
+              #
+              # Unless required by applicable law or agreed to in writing, software
+              # distributed under the License is distributed on an "AS IS" BASIS,
+              # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              # See the License for the specific language governing permissions and
+              # limitations under the License.
+      
+              set -e
+      
+              # Configure the workaround required for kubeadm init with kube-vip:
+              # xref: https://github.com/kube-vip/kube-vip/issues/684
+      
+              # Nothing to do for kubernetes < v1.29
+              KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+              if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+                exit 0
+              fi
+      
+              IS_KUBEADM_INIT="false"
+      
+              # cloud-init kubeadm init
+              if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+                IS_KUBEADM_INIT="true"
+              fi
+      
+              # ignition kubeadm init
+              if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+                IS_KUBEADM_INIT="true"
+              fi
+      
+              if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+                sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+                  /etc/kubernetes/manifests/kube-vip.yaml
+              fi
+            owner: root:root
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+            permissions: "0700"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
@@ -184,4 +237,6 @@ spec:
           - echo "127.0.0.1   localhost" >>/etc/hosts
           - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
           - echo "{{ v1.local_hostname }}" >/etc/hostname
+          - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+            do echo "Running script $script"; "$script"; done
         useExperimentalRetryJoin: true

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -90,7 +90,7 @@ spec:
               value: "1"
             - name: address
               value: "${IBMPOWERVS_VIP}"
-            image: ghcr.io/kube-vip/kube-vip:v0.4.4
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: Always
             name: kube-vip
             resources: {}
@@ -102,19 +102,72 @@ spec:
             volumeMounts:
             - mountPath: /etc/kubernetes/admin.conf
               name: kubeconfig
-          hostAliases:
-          - hostnames:
-            - kubernetes
-            ip: 127.0.0.1
+            - mountPath: /etc/hosts
+              name: etchosts
           hostNetwork: true
           volumes:
           - hostPath:
               path: /etc/kubernetes/admin.conf
             name: kubeconfig
+          - hostPath:
+              path: /etc/kube-vip.hosts
+              type: File
+            name: etchosts
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
       permissions: "0744"
+    - content: 127.0.0.1 localhost kubernetes
+      owner: root:root
+      path: /etc/kube-vip.hosts
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        # Copyright 2020 The Kubernetes Authors.
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+
+        set -e
+
+        # Configure the workaround required for kubeadm init with kube-vip:
+        # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+        # Nothing to do for kubernetes < v1.29
+        KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+        if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+          exit 0
+        fi
+
+        IS_KUBEADM_INIT="false"
+
+        # cloud-init kubeadm init
+        if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        # ignition kubeadm init
+        if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+            /etc/kubernetes/manifests/kube-vip.yaml
+        fi
+      owner: root:root
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+      permissions: "0700"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -143,6 +196,9 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
     - echo "{{ v1.local_hostname }}" >/etc/hostname
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     useExperimentalRetryJoin: true
   machineTemplate:
     infrastructureRef:

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -150,7 +150,7 @@ spec:
               value: "1"
             - name: address
               value: "${IBMPOWERVS_VIP}"
-            image: ghcr.io/kube-vip/kube-vip:v0.4.4
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: Always
             name: kube-vip
             resources: {}
@@ -162,19 +162,72 @@ spec:
             volumeMounts:
             - mountPath: /etc/kubernetes/admin.conf
               name: kubeconfig
-          hostAliases:
-          - hostnames:
-            - kubernetes
-            ip: 127.0.0.1
+            - mountPath: /etc/hosts
+              name: etchosts
           hostNetwork: true
           volumes:
           - hostPath:
               path: /etc/kubernetes/admin.conf
             name: kubeconfig
+          - hostPath:
+              path: /etc/kube-vip.hosts
+              type: File
+            name: etchosts
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
       permissions: "0744"
+    - content: 127.0.0.1 localhost kubernetes
+      owner: root:root
+      path: /etc/kube-vip.hosts
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        # Copyright 2020 The Kubernetes Authors.
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+
+        set -e
+
+        # Configure the workaround required for kubeadm init with kube-vip:
+        # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+        # Nothing to do for kubernetes < v1.29
+        KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+        if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+          exit 0
+        fi
+
+        IS_KUBEADM_INIT="false"
+
+        # cloud-init kubeadm init
+        if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        # ignition kubeadm init
+        if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+            /etc/kubernetes/manifests/kube-vip.yaml
+        fi
+      owner: root:root
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+      permissions: "0700"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -203,6 +256,9 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
     - echo "{{ v1.local_hostname }}" >/etc/hostname
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     useExperimentalRetryJoin: true
   machineTemplate:
     infrastructureRef:

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -168,7 +168,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibm-cloud-controller-manager
-              image: gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:07d19bf
+              image: gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:6c98ec5
               args:
                 - --v=2
                 - --cloud-provider=ibm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
kube-vip has issues when being used with k8s 1.29. This PR fixes them by

1. From 1.29, a change has been made to `kubeadm` to provision a separate Kubeconfig file called `super-admin.conf`  and reducing the `admin.conf` User's access to the permissions provided by the cluster-admin ClusterRole. It is to be noted that in a multi-cluster setup, the `super-admin.conf` is only created on the primary control plane node, which runs `kubeadm init` is failing because kube-vip deployment is hardcoded to use `admin.conf` but kube-vip requires elevated permissions to access the API server during cluster initialization, which are available only when using the `super-admin.conf`. 
2. From 1.29, `hostAliases` do not work as expected. Add a work around to mount the volumes to the `kube-vip` pod manifest.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1792 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update kube-vip spec in cluster templates to adopt k8s 1.29
```
