### PR TITLE
Fetch service instance id from spec of IBMPowerVSCluster object while setting provider id

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -922,10 +922,16 @@ func (m *PowerVSMachineScope) GetZone() string {
 
 // GetServiceInstanceID returns the service instance id.
 func (m *PowerVSMachineScope) GetServiceInstanceID() string {
-	if m.IBMPowerVSCluster.Status.ServiceInstance == nil || m.IBMPowerVSCluster.Status.ServiceInstance.ID == nil {
-		return ""
+	if m.IBMPowerVSCluster.Status.ServiceInstance != nil && m.IBMPowerVSCluster.Status.ServiceInstance.ID != nil {
+		return *m.IBMPowerVSCluster.Status.ServiceInstance.ID
 	}
-	return *m.IBMPowerVSCluster.Status.ServiceInstance.ID
+	if m.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
+		return m.IBMPowerVSCluster.Spec.ServiceInstanceID
+	}
+	if m.IBMPowerVSCluster.Spec.ServiceInstance != nil && m.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+		return *m.IBMPowerVSCluster.Spec.ServiceInstance.ID
+	}
+	return ""
 }
 
 // SetProviderID will set the provider id for the machine.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When we are using external [cloud-provider template](https://cluster-api-ibmcloud.sigs.k8s.io/topics/powervs/external-cloud-provider) we explicitly pass the service instance id.
Internally in the code that wont be set under status field of IBMPowerVSCluster, so the in the [provider id of machine](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/e49f8ee8a7bfb2d627461f2b1e415eedbee09297/cloud/scope/powervs_machine.go#L942) the service instance will be set as empty string which is incorrect.

In this PR we try to fetch the service instance id from spec of object if its not present under the status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fetch Service instance id from spec field of IBMPowerVSCluster object if its not present under status.
```
