### PR TITLE
Derive VPC zones from VPC region instead of PowerVS region.

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -1050,17 +1050,12 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 	// check whether user has set the vpc subnets
 	if len(s.IBMPowerVSCluster.Spec.VPCSubnets) == 0 {
 		// if the user did not set any subnet, we try to create subnet in all the zones.
-		powerVSZone := s.Zone()
-		if powerVSZone == nil {
-			return false, fmt.Errorf("PowerVS zone is not set")
-		}
-		region := endpoints.ConstructRegionFromZone(*powerVSZone)
-		vpcZones, err := genUtil.VPCZonesForPowerVSRegion(region)
+		vpcZones, err := genUtil.VPCZonesForVPCRegion(*s.VPC().Region)
 		if err != nil {
 			return false, err
 		}
 		if len(vpcZones) == 0 {
-			return false, fmt.Errorf("failed to fetch VPC zones, no zone found for region %s", region)
+			return false, fmt.Errorf("failed to fetch VPC zones, no zone found for region %s", *s.VPC().Region)
 		}
 		for _, zone := range vpcZones {
 			subnet := infrav1beta2.Subnet{
@@ -1150,12 +1145,7 @@ func (s *PowerVSClusterScope) createVPCSubnet(subnet infrav1beta2.Subnet) (*stri
 	if subnet.Zone != nil {
 		zone = *subnet.Zone
 	} else {
-		powerVSZone := s.Zone()
-		if powerVSZone == nil {
-			return nil, fmt.Errorf("PowerVS zone is not set")
-		}
-		region := endpoints.ConstructRegionFromZone(*powerVSZone)
-		vpcZones, err := genUtil.VPCZonesForPowerVSRegion(region)
+		vpcZones, err := genUtil.VPCZonesForVPCRegion(*s.VPC().Region)
 		if err != nil {
 			return nil, err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -230,3 +230,13 @@ func GetTransitGatewayLocationAndRouting(powerVSZone *string, vpcRegion *string)
 	// since VPC region is not set and used PowerVS region to calculate the transit gateway location, hence returning local routing as default.
 	return &location, ptr.To(false), nil
 }
+
+// VPCZonesForVPCRegion returns the VPC zones associated with the VPC region.
+func VPCZonesForVPCRegion(region string) ([]string, error) {
+	for _, regionDetails := range Regions {
+		if regionDetails.VPCRegion == region {
+			return regionDetails.VPCZones, nil
+		}
+	}
+	return nil, fmt.Errorf("VPC zones corresponding to the VPC region %s is not found", region)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR contains changes to derive the VPC zone from the VPC region, compared to the zone derived from PowerVS region. This mitigates errors/conflicts arising where the VPC zone is different from the PowerVS zone, causing a mismatch in the CIDR.


Tests: 
The change has been tested where the compute infrastructure is provisioned in `jp-osa`, while the VPC subnet infrastructure was provisioned in `jp-tok`. The was available for use post completion of deployment.
<img width="1354" alt="Pasted Graphic 2" src="https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/assets/110517346/61908b0b-9ed8-4d51-a36b-8fa599ccaf90">

A similar exercise was done to provision both Compute and VPC subnet in `jp-osa`. 

**Which issue(s) this PR fixes** :
Fixes #1817 

**Special notes for your reviewer**:
Please let me know if there are other scenarios to be covered before the changes can be merged to main.

/area provider/ibmcloud


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Derive VPC zones from VPC region instead of PowerVS region.
```
