### PR TITLE
Refactor PowerVSClusterscope function to faciliate UT integration

### DIFF
--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -53,6 +53,8 @@ type IBMPowerVSClusterReconciler struct {
 	Recorder        record.EventRecorder
 	ServiceEndpoint []endpoints.ServiceEndpoint
 	Scheme          *runtime.Scheme
+
+	ClientFactory scope.ClientFactory
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=get;list;watch;create;update;patch;delete
@@ -90,6 +92,7 @@ func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		Cluster:           cluster,
 		IBMPowerVSCluster: ibmCluster,
 		ServiceEndpoint:   r.ServiceEndpoint,
+		ClientFactory:     r.ClientFactory,
 	})
 
 	if err != nil {

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -45,22 +45,27 @@ type Service struct {
 // ServiceOptions holds the PowerVS Service Options specific information.
 type ServiceOptions struct {
 	*ibmpisession.IBMPIOptions
-
 	CloudInstanceID string
 }
 
-// NewService returns a new service for the Power VS api client.
+// NewService returns a new service for the PowerVS api client.
+// This will create only PowerVS session and actual clients can be created later by calling WithClients method.
 func NewService(options ServiceOptions) (PowerVS, error) {
-	auth, err := authenticator.GetAuthenticator()
-	if err != nil {
-		return nil, err
+	if options.Authenticator == nil {
+		auth, err := authenticator.GetAuthenticator()
+		if err != nil {
+			return nil, err
+		}
+		options.Authenticator = auth
 	}
-	options.Authenticator = auth
-	account, err := utils.GetAccount(auth)
-	if err != nil {
-		return nil, err
+	if options.UserAccount == "" {
+		account, err := utils.GetAccount(options.Authenticator)
+		if err != nil {
+			return nil, err
+		}
+		options.IBMPIOptions.UserAccount = account
 	}
-	options.IBMPIOptions.UserAccount = account
+
 	session, err := ibmpisession.NewIBMPISession(options.IBMPIOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/services/resourcecontroller/service.go
+++ b/pkg/cloud/services/resourcecontroller/service.go
@@ -197,7 +197,7 @@ func (s *Service) CreateResourceKey(options *resourcecontrollerv2.CreateResource
 }
 
 // NewService returns a new service for the IBM Cloud Resource Controller api client.
-func NewService(options ServiceOptions) (*Service, error) {
+func NewService(options ServiceOptions) (ResourceController, error) {
 	if options.ResourceControllerV2Options == nil {
 		options.ResourceControllerV2Options = &resourcecontrollerv2.ResourceControllerV2Options{}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

1. This PR refactors the code to make use of factory functions which can be used during unit test cases for easy overriding of the function.
2. Changes are made to PowerVSClient to reuse the session or authenticator if already present in the options passed
3. Added some sample UT to demonstrate the usage of factory functions 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refactor PowerVSClusterscope function to faciliate UT integration
```
