### PR TITLE
Add webhook validation for transit gateway's global routing field

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	regionUtil "github.com/ppc64le-cloud/powervs-utils"
 
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -206,7 +207,7 @@ func NewPowerVSClusterScope(params PowerVSClusterScopeParams) (*PowerVSClusterSc
 	}
 
 	// if powervs.cluster.x-k8s.io/create-infra=true annotation is not set, create only powerVSClient.
-	if !genUtil.CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
+	if !CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
 		return &PowerVSClusterScope{
 			session:           session,
 			Logger:            params.Logger,
@@ -1050,7 +1051,7 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 	// check whether user has set the vpc subnets
 	if len(s.IBMPowerVSCluster.Spec.VPCSubnets) == 0 {
 		// if the user did not set any subnet, we try to create subnet in all the zones.
-		vpcZones, err := genUtil.VPCZonesForVPCRegion(*s.VPC().Region)
+		vpcZones, err := regionUtil.VPCZonesForVPCRegion(*s.VPC().Region)
 		if err != nil {
 			return false, err
 		}
@@ -1145,7 +1146,7 @@ func (s *PowerVSClusterScope) createVPCSubnet(subnet infrav1beta2.Subnet) (*stri
 	if subnet.Zone != nil {
 		zone = *subnet.Zone
 	} else {
-		vpcZones, err := genUtil.VPCZonesForVPCRegion(*s.VPC().Region)
+		vpcZones, err := regionUtil.VPCZonesForVPCRegion(*s.VPC().Region)
 		if err != nil {
 			return nil, err
 		}

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -32,6 +32,7 @@ import (
 	"github.com/blang/semver/v4"
 	ignV3Types "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/go-logr/logr"
+	regionUtil "github.com/ppc64le-cloud/powervs-utils"
 
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
@@ -66,7 +67,6 @@ import (
 	ignV2Types "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/ignition"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
-	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
 const cosURLDomain = "cloud-object-storage.appdomain.cloud"
@@ -221,13 +221,13 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	scope.IBMPowerVSClient = c
 	scope.DHCPIPCacheStore = params.DHCPIPCacheStore
 
-	if !genUtil.CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
+	if !CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
 		return scope, nil
 	}
 
 	var vpcRegion string
 	if params.IBMPowerVSCluster.Spec.VPC == nil || params.IBMPowerVSCluster.Spec.VPC.Region == nil {
-		vpcRegion, err = genUtil.VPCRegionForPowerVSRegion(scope.GetRegion())
+		vpcRegion, err = regionUtil.VPCRegionForPowerVSRegion(scope.GetRegion())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create VPC client, error getting VPC region %v", err)
 		}

--- a/cloud/scope/util.go
+++ b/cloud/scope/util.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+)
+
+// GetClusterByName finds and return a Cluster object using the specified params.
+func GetClusterByName(ctx context.Context, c client.Client, namespace, name string) (*infrav1beta2.IBMPowerVSCluster, error) {
+	cluster := &infrav1beta2.IBMPowerVSCluster{}
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if err := c.Get(ctx, key, cluster); err != nil {
+		return nil, fmt.Errorf("failed to get Cluster/%s: %w", name, err)
+	}
+
+	return cluster, nil
+}
+
+// CheckCreateInfraAnnotation checks for annotations set on IBMPowerVSCluster object to determine cluster creation workflow.
+func CheckCreateInfraAnnotation(cluster infrav1beta2.IBMPowerVSCluster) bool {
+	annotations := cluster.GetAnnotations()
+	if len(annotations) == 0 {
+		return false
+	}
+	value, found := annotations[infrav1beta2.CreateInfrastructureAnnotation]
+	if !found {
+		return false
+	}
+	createInfra, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+	return createInfra
+}

--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
-	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
 // IBMPowerVSClusterReconciler reconciles a IBMPowerVSCluster object.
@@ -119,7 +118,7 @@ func (r *IBMPowerVSClusterReconciler) reconcile(clusterScope *scope.PowerVSClust
 
 	// check for annotation set for cluster resource and decide on proceeding with infra creation.
 	// do not proceed further if "powervs.cluster.x-k8s.io/create-infra=true" annotation is not set.
-	if !genUtil.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
+	if !scope.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
 		clusterScope.IBMPowerVSCluster.Status.Ready = true
 		return ctrl.Result{}, nil
 	}
@@ -263,7 +262,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clust
 	}
 
 	// check for annotation set for cluster resource and decide on proceeding with infra deletion.
-	if !genUtil.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
+	if !scope.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
 		controllerutil.RemoveFinalizer(cluster, infrav1beta2.IBMPowerVSClusterFinalizer)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/ibmpowervsimage_controller.go
+++ b/controllers/ibmpowervsimage_controller.go
@@ -40,7 +40,6 @@ import (
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
 // IBMPowerVSImageReconciler reconciles a IBMPowerVSImage object.
@@ -92,7 +91,7 @@ func (r *IBMPowerVSImageReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.reconcileDelete(imageScope)
 	}
 
-	cluster, err := util.GetClusterByName(ctx, r.Client, ibmImage.Namespace, ibmImage.Spec.ClusterName)
+	cluster, err := scope.GetClusterByName(ctx, r.Client, ibmImage.Namespace, ibmImage.Spec.ClusterName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
 	capibmrecord "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
-	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
 // IBMPowerVSMachineReconciler reconciles a IBMPowerVSMachine object.
@@ -280,7 +279,7 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(machineScope *scope.PowerV
 		return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
 	}
 
-	if !genUtil.CheckCreateInfraAnnotation(*machineScope.IBMPowerVSCluster) {
+	if !scope.CheckCreateInfraAnnotation(*machineScope.IBMPowerVSCluster) {
 		return ctrl.Result{}, nil
 	}
 	// Register instance with load balancer

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/pkg/errors v0.9.1
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247 h1:XY7lIZaLKFDyETNfTTiYmaXO+mk9apox4otFel88nUk=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=

--- a/util/util.go
+++ b/util/util.go
@@ -17,197 +17,14 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"fmt"
-	"strconv"
+
+	regionUtil "github.com/ppc64le-cloud/powervs-utils"
 
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
 )
-
-// GetClusterByName finds and return a Cluster object using the specified params.
-func GetClusterByName(ctx context.Context, c client.Client, namespace, name string) (*infrav1beta2.IBMPowerVSCluster, error) {
-	cluster := &infrav1beta2.IBMPowerVSCluster{}
-	key := client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-
-	if err := c.Get(ctx, key, cluster); err != nil {
-		return nil, fmt.Errorf("failed to get Cluster/%s: %w", name, err)
-	}
-
-	return cluster, nil
-}
-
-// CheckCreateInfraAnnotation checks for annotations set on IBMPowerVSCluster object to determine cluster creation workflow.
-func CheckCreateInfraAnnotation(cluster infrav1beta2.IBMPowerVSCluster) bool {
-	annotations := cluster.GetAnnotations()
-	if len(annotations) == 0 {
-		return false
-	}
-	value, found := annotations[infrav1beta2.CreateInfrastructureAnnotation]
-	if !found {
-		return false
-	}
-	createInfra, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-	return createInfra
-}
-
-//TODO: Move this to powervs-utils.
-
-// Region describes respective IBM Cloud COS region, VPC region and Zones associated with a region in Power VS.
-type Region struct {
-	Description string
-	VPCRegion   string
-	COSRegion   string
-	Zones       []string
-	VPCZones    []string
-	SysTypes    []string
-}
-
-// Regions provides a mapping between Power VS and IBM Cloud VPC and IBM COS regions.
-var Regions = map[string]Region{
-	"dal": {
-		Description: "Dallas, USA",
-		VPCRegion:   "us-south",
-		COSRegion:   "us-south",
-		Zones: []string{
-			"dal10",
-			"dal12",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
-	},
-	"eu-de": {
-		Description: "Frankfurt, Germany",
-		VPCRegion:   "eu-de",
-		COSRegion:   "eu-de",
-		Zones: []string{
-			"eu-de-1",
-			"eu-de-2",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"eu-de-2", "eu-de-3"},
-	},
-	"lon": {
-		Description: "London, UK.",
-		VPCRegion:   "eu-gb",
-		COSRegion:   "eu-gb",
-		Zones: []string{
-			"lon04",
-			"lon06",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"eu-gb-1", "eu-gb-3"},
-	},
-	"mad": {
-		Description: "Madrid, Spain",
-		VPCRegion:   "eu-es",
-		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
-		Zones: []string{
-			"mad02",
-			"mad04",
-		},
-		SysTypes: []string{"s1022"},
-		VPCZones: []string{"eu-es-1", "eu-es-2"},
-	},
-	"mon": {
-		Description: "Montreal, Canada",
-		VPCRegion:   "ca-tor",
-		COSRegion:   "ca-tor",
-		Zones:       []string{"mon01"},
-		SysTypes:    []string{"s922", "e980"},
-	},
-	"osa": {
-		Description: "Osaka, Japan",
-		VPCRegion:   "jp-osa",
-		COSRegion:   "jp-osa",
-		Zones:       []string{"osa21"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"jp-osa-1"},
-	},
-	"syd": {
-		Description: "Sydney, Australia",
-		VPCRegion:   "au-syd",
-		COSRegion:   "au-syd",
-		Zones: []string{
-			"syd04",
-			"syd05",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"au-syd-2", "au-syd-3"},
-	},
-	"sao": {
-		Description: "São Paulo, Brazil",
-		VPCRegion:   "br-sao",
-		COSRegion:   "br-sao",
-		Zones: []string{
-			"sao01",
-			"sao04",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"br-sao-1", "br-sao-2"},
-	},
-	"tok": {
-		Description: "Tokyo, Japan",
-		VPCRegion:   "jp-tok",
-		COSRegion:   "jp-tok",
-		Zones:       []string{"tok04"},
-		SysTypes:    []string{"s922", "e980"},
-		VPCZones:    []string{"jp-tok-2"},
-	},
-	"us-east": {
-		Description: "Washington DC, USA",
-		VPCRegion:   "us-east",
-		COSRegion:   "us-east",
-		Zones:       []string{"us-east"},
-		SysTypes:    []string{}, // Missing
-		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
-	},
-	"wdc": {
-		Description: "Washington DC, USA",
-		VPCRegion:   "us-east",
-		COSRegion:   "us-east",
-		Zones: []string{
-			"wdc06",
-			"wdc07",
-		},
-		SysTypes: []string{"s922", "e980"},
-		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
-	},
-}
-
-// VPCRegionForPowerVSRegion returns the VPC region for the specified PowerVS region.
-func VPCRegionForPowerVSRegion(region string) (string, error) {
-	if r, ok := Regions[region]; ok {
-		return r.VPCRegion, nil
-	}
-	return "", fmt.Errorf("VPC region corresponding to a PowerVS region %s not found ", region)
-}
-
-// VPCZonesForPowerVSRegion returns the VPC zones associated with Power VS region.
-func VPCZonesForPowerVSRegion(region string) ([]string, error) {
-	if r, ok := Regions[region]; ok {
-		return r.VPCZones, nil
-	}
-	return nil, fmt.Errorf("VPC zones corresponding to a PowerVS region %s not found ", region)
-}
-
-// IsGlobalRoutingRequiredForTG returns true when powervs and vpc regions are different.
-func IsGlobalRoutingRequiredForTG(powerVSRegion string, vpcRegion string) bool {
-	if r, ok := Regions[powerVSRegion]; ok && r.VPCRegion == vpcRegion {
-		return false
-	}
-	return true
-}
 
 // GetTransitGatewayLocationAndRouting returns appropriate location and routing suitable for transit gateway.
 // routing indicates whether to enable global routing on transit gateway or not.
@@ -219,24 +36,14 @@ func GetTransitGatewayLocationAndRouting(powerVSZone *string, vpcRegion *string)
 	powerVSRegion := endpoints.ConstructRegionFromZone(*powerVSZone)
 
 	if vpcRegion != nil {
-		routing := IsGlobalRoutingRequiredForTG(powerVSRegion, *vpcRegion)
+		routing := regionUtil.IsGlobalRoutingRequiredForTG(powerVSRegion, *vpcRegion)
 		return vpcRegion, &routing, nil
 	}
-	location, err := VPCRegionForPowerVSRegion(powerVSRegion)
+	location, err := regionUtil.VPCRegionForPowerVSRegion(powerVSRegion)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch vpc region associated with powervs region '%s': %w", powerVSRegion, err)
 	}
 
 	// since VPC region is not set and used PowerVS region to calculate the transit gateway location, hence returning local routing as default.
 	return &location, ptr.To(false), nil
-}
-
-// VPCZonesForVPCRegion returns the VPC zones associated with the VPC region.
-func VPCZonesForVPCRegion(region string) ([]string, error) {
-	for _, regionDetails := range Regions {
-		if regionDetails.VPCRegion == region {
-			return regionDetails.VPCZones, nil
-		}
-	}
-	return nil, fmt.Errorf("VPC zones corresponding to the VPC region %s is not found", region)
 }


### PR DESCRIPTION
Extend existing conditions to check valid PowerVS zone and VPC region is used

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1826 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add webhook validation for transit gateway's global routing field
```
