### PR TITLE
Deprecate provider-id format v1

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         - /manager
         args:
         - "--leader-elect"
-        - "--provider-id-fmt=${PROVIDER_ID_FORMAT:=v1}"
+        - "--provider-id-fmt=${PROVIDER_ID_FORMAT:=v2}"
         - "--metrics-bind-addr=127.0.0.1:8080"
         - "--service-endpoint=${SERVICE_ENDPOINT:=none}"
         - "--v=${LOGLEVEL:=0}"

--- a/docs/book/src/topics/powervs/clusterclass-cluster.md
+++ b/docs/book/src/topics/powervs/clusterclass-cluster.md
@@ -2,7 +2,7 @@
 ## Steps
 
 - To deploy PowerVS workload cluster using [ClusterClass](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/index.html), create a cluster configuration from the [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml)
-- The PowerVS cluster will use [external cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/). As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/5e7f80878f2252c6ab13c16102de90c784a2624d/main.go#L168-L173) with value v2
+- The PowerVS cluster will use [external cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/).
 - The [clusterclass-template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-simple-powervs-clusterclass.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
 
 ### Deploy PowerVS cluster with IBM PowerVS cloud provider

--- a/docs/book/src/topics/powervs/create-resources.md
+++ b/docs/book/src/topics/powervs/create-resources.md
@@ -5,7 +5,6 @@
 - To deploy cluster which creates required resources, set ```powervs.cluster.x-k8s.io/create-infra:true``` annotation to IBMPowerVSCluster resource.
 - The cluster will be configured with IBM PowerVS external [cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/)
 - The [create_infra template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-powervs-create-infra.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
-- As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/5e7f80878f2252c6ab13c16102de90c784a2624d/main.go#L168-L173) with value v2
 
 ### Deploy PowerVS cluster with IBM PowerVS cloud provider
 

--- a/docs/book/src/topics/powervs/external-cloud-provider.md
+++ b/docs/book/src/topics/powervs/external-cloud-provider.md
@@ -5,7 +5,6 @@
 
 - To deploy a PowerVS workload cluster with IBM PowerVS external [cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/), create a cluster configuration with the [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-powervs-cloud-provider.yaml)
 - The [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-powervs-cloud-provider.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
-- As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/5e7f80878f2252c6ab13c16102de90c784a2624d/main.go#L168-L173) with value v2
 
 ### Deploy PowerVS cluster with IBM PowerVS cloud provider
 

--- a/docs/book/src/topics/vpc/load-balancer.md
+++ b/docs/book/src/topics/vpc/load-balancer.md
@@ -6,7 +6,6 @@
 
 - To deploy a VPC workload cluster with Load Balancer IBM external [cloud provider](https://kubernetes.io/docs/concepts/architecture/cloud-controller/), create a cluster configuration with the [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-load-balancer.yaml)
 - The [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/templates/cluster-template-load-balancer.yaml) will use [clusterresourceset](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) and will create the necessary config map, secret and roles to run the cloud controller manager
-- As a prerequisite set the `provider-id-fmt` [flag](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/ee70591709ac5ddaeed23222ccbfa78335d984a1/main.go#L183) with value v2
 
 ### Deploy VPC cluster with Load Balancer and IBM cloud provider
 

--- a/main.go
+++ b/main.go
@@ -103,11 +103,10 @@ func initFlags(fs *pflag.FlagSet) {
 		10*time.Minute,
 		"The minimum interval at which watched resources are reconciled.",
 	)
-
 	fs.StringVar(
 		&options.ProviderIDFormat,
 		"provider-id-fmt",
-		string(options.ProviderIDFormatV1),
+		string(options.ProviderIDFormatV2),
 		"ProviderID format is used set the Provider ID format for Machine",
 	)
 
@@ -132,8 +131,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 func validateFlags() error {
 	switch options.ProviderIDFormatType(options.ProviderIDFormat) {
+	// Deprecated: ProviderIDFormatV1 is deprecated and will be removed in a future release.
 	case options.ProviderIDFormatV1:
-		setupLog.Info("Using v1 version of ProviderID format")
+		setupLog.Info("Using v1 version of ProviderID format.V1 is deprecated and will be removed in a future release.Instead use V2.")
 	case options.ProviderIDFormatV2:
 		setupLog.Info("Using v2 version of ProviderID format")
 	default:

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -23,6 +23,8 @@ const (
 	// ProviderIDFormatV1 will set provider id to machine as follows
 	// For VPC machines: ibmvpc://<cluster_name>/<vm_hostname>
 	// For Power VS machines: ibmpowervs://<cluster_name>/<vm_hostname>
+	// Deprecated: ProviderIDFormatV1 is deprecated and will be removed in a future release. see https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1868 for more details.
+	// use ProviderIDFormatV2 instead ProviderIDFormatV1.
 	ProviderIDFormatV1 ProviderIDFormatType = "v1"
 
 	// ProviderIDFormatV2 will set provider id to machine as follows


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Deprecate provider-id format v1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1868

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate provider-id format v1
```
