### PR TITLE
Refactor reconcilation of resources

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -384,14 +384,8 @@ func (s *PowerVSClusterScope) ServiceInstance() *infrav1beta2.IBMPowerVSResource
 	return s.IBMPowerVSCluster.Spec.ServiceInstance
 }
 
-// GetServiceInstanceID get the service instance id.
+// GetServiceInstanceID returns service instance id set in status field of IBMPowerVSCluster object. If it doesn't exist, returns empty string.
 func (s *PowerVSClusterScope) GetServiceInstanceID() string {
-	if s.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-		return s.IBMPowerVSCluster.Spec.ServiceInstanceID
-	}
-	if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
-		return *s.IBMPowerVSCluster.Spec.ServiceInstance.ID
-	}
 	if s.IBMPowerVSCluster.Status.ServiceInstance != nil && s.IBMPowerVSCluster.Status.ServiceInstance.ID != nil {
 		return *s.IBMPowerVSCluster.Status.ServiceInstance.ID
 	}
@@ -470,11 +464,8 @@ func (s *PowerVSClusterScope) Network() *infrav1beta2.IBMPowerVSResourceReferenc
 	return &s.IBMPowerVSCluster.Spec.Network
 }
 
-// GetDHCPServerID returns the DHCP id from spec or status of IBMPowerVSCluster object.
+// GetDHCPServerID returns the DHCP id from status of IBMPowerVSCluster object. If it doesn't exist, returns nil.
 func (s *PowerVSClusterScope) GetDHCPServerID() *string {
-	if s.IBMPowerVSCluster.Spec.DHCPServer != nil && s.IBMPowerVSCluster.Spec.DHCPServer.ID != nil {
-		return s.IBMPowerVSCluster.Spec.DHCPServer.ID
-	}
 	if s.IBMPowerVSCluster.Status.DHCPServer != nil {
 		return s.IBMPowerVSCluster.Status.DHCPServer.ID
 	}
@@ -491,11 +482,8 @@ func (s *PowerVSClusterScope) VPC() *infrav1beta2.VPCResourceReference {
 	return s.IBMPowerVSCluster.Spec.VPC
 }
 
-// GetVPCID returns the VPC id.
+// GetVPCID returns the VPC id set in status field of IBMPowerVSCluster object. If it doesn't exist, returns nil.
 func (s *PowerVSClusterScope) GetVPCID() *string {
-	if s.IBMPowerVSCluster.Spec.VPC != nil && s.IBMPowerVSCluster.Spec.VPC.ID != nil {
-		return s.IBMPowerVSCluster.Spec.VPC.ID
-	}
 	if s.IBMPowerVSCluster.Status.VPC != nil {
 		return s.IBMPowerVSCluster.Status.VPC.ID
 	}
@@ -516,15 +504,6 @@ func (s *PowerVSClusterScope) GetVPCSubnetID(subnetName string) *string {
 // GetVPCSubnetIDs returns all the VPC subnet ids.
 func (s *PowerVSClusterScope) GetVPCSubnetIDs() []*string {
 	subnets := []*string{}
-	// use the vpc subnet id set by user.
-	for _, subnet := range s.IBMPowerVSCluster.Spec.VPCSubnets {
-		if subnet.ID != nil {
-			subnets = append(subnets, subnet.ID)
-		}
-	}
-	if len(subnets) != 0 {
-		return subnets
-	}
 	if s.IBMPowerVSCluster.Status.VPCSubnet == nil {
 		return nil
 	}
@@ -534,8 +513,8 @@ func (s *PowerVSClusterScope) GetVPCSubnetIDs() []*string {
 	return subnets
 }
 
-// SetVPCSubnetID set the VPC subnet id.
-func (s *PowerVSClusterScope) SetVPCSubnetID(name string, resource infrav1beta2.ResourceReference) {
+// SetVPCSubnetStatus set the VPC subnet id.
+func (s *PowerVSClusterScope) SetVPCSubnetStatus(name string, resource infrav1beta2.ResourceReference) {
 	s.V(3).Info("Setting status", "name", name, "resource", resource)
 	if s.IBMPowerVSCluster.Status.VPCSubnet == nil {
 		s.IBMPowerVSCluster.Status.VPCSubnet = make(map[string]infrav1beta2.ResourceReference)
@@ -572,8 +551,8 @@ func (s *PowerVSClusterScope) GetVPCSecurityGroupByID(securityGroupID string) (*
 	return nil, nil, nil
 }
 
-// SetVPCSecurityGroup set the VPC security group id.
-func (s *PowerVSClusterScope) SetVPCSecurityGroup(name string, resource infrav1beta2.VPCSecurityGroupStatus) {
+// SetVPCSecurityGroupStatus set the VPC security group id.
+func (s *PowerVSClusterScope) SetVPCSecurityGroupStatus(name string, resource infrav1beta2.VPCSecurityGroupStatus) {
 	s.V(3).Info("Setting VPC security group status", "name", name, "resource", resource)
 	if s.IBMPowerVSCluster.Status.VPCSecurityGroups == nil {
 		s.IBMPowerVSCluster.Status.VPCSecurityGroups = make(map[string]infrav1beta2.VPCSecurityGroupStatus)
@@ -595,23 +574,6 @@ func (s *PowerVSClusterScope) TransitGateway() *infrav1beta2.TransitGateway {
 func (s *PowerVSClusterScope) GetTransitGatewayID() *string {
 	if s.IBMPowerVSCluster.Status.TransitGateway != nil {
 		return s.IBMPowerVSCluster.Status.TransitGateway.ID
-	}
-	return nil
-}
-
-// PublicLoadBalancer returns the cluster public loadBalancer information.
-func (s *PowerVSClusterScope) PublicLoadBalancer() *infrav1beta2.VPCLoadBalancerSpec {
-	// if the user did not specify any loadbalancer then return the public loadbalancer created by the controller.
-	if len(s.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
-		return &infrav1beta2.VPCLoadBalancerSpec{
-			Name:   *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer),
-			Public: ptr.To(true),
-		}
-	}
-	for _, lb := range s.IBMPowerVSCluster.Spec.LoadBalancers {
-		if lb.Public != nil && *lb.Public {
-			return &lb
-		}
 	}
 	return nil
 }
@@ -652,18 +614,45 @@ func (s *PowerVSClusterScope) GetLoadBalancerState(name string) *infrav1beta2.VP
 	return nil
 }
 
-// GetLoadBalancerHostName will return the hostname of load balancer.
-func (s *PowerVSClusterScope) GetLoadBalancerHostName(name string) *string {
+// GetPublicLoadBalancerHostName will return the hostname of the public load balancer.
+func (s *PowerVSClusterScope) GetPublicLoadBalancerHostName() (*string, error) {
 	if s.IBMPowerVSCluster.Status.LoadBalancers == nil {
-		return nil
+		return nil, nil
 	}
+
+	var name string
+	if len(s.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
+		name = *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer)
+	}
+
+	for _, lb := range s.IBMPowerVSCluster.Spec.LoadBalancers {
+		if !*lb.Public {
+			continue
+		}
+
+		if lb.Name != "" {
+			name = lb.Name
+			break
+		}
+		if lb.ID != nil {
+			loadBalancer, _, err := s.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{
+				ID: lb.ID,
+			})
+			if err != nil {
+				return nil, err
+			}
+			name = *loadBalancer.Name
+			break
+		}
+	}
+
 	if val, ok := s.IBMPowerVSCluster.Status.LoadBalancers[name]; ok {
-		return val.Hostname
+		return val.Hostname, nil
 	}
-	return nil
+	return nil, nil
 }
 
-// GetResourceGroupID returns the resource group id if it present under spec or statue filed of IBMPowerVSCluster object
+// GetResourceGroupID returns the resource group id if it present under spec or status filed of IBMPowerVSCluster object
 // or returns empty string.
 func (s *PowerVSClusterScope) GetResourceGroupID() string {
 	if s.IBMPowerVSCluster.Spec.ResourceGroup != nil && s.IBMPowerVSCluster.Spec.ResourceGroup.ID != nil {
@@ -716,10 +705,10 @@ func (s *PowerVSClusterScope) ReconcileResourceGroup() error {
 
 // ReconcilePowerVSServiceInstance reconciles Power VS service instance.
 func (s *PowerVSClusterScope) ReconcilePowerVSServiceInstance() (bool, error) {
-	// Verify if service instance id is set in spec or status field of IBMPowerVSCluster object.
+	// Verify if service instance id is set in status field of IBMPowerVSCluster object.
 	serviceInstanceID := s.GetServiceInstanceID()
 	if serviceInstanceID != "" {
-		s.V(3).Info("PowerVS service instance ID is set, fetching details", "id", serviceInstanceID)
+		s.V(3).Info("PowerVS service instance ID is set, fetching details", "serviceInstanceID", serviceInstanceID)
 		// if serviceInstanceID is set, verify that it exist and in active state.
 		serviceInstance, _, err := s.ResourceClient.GetResourceInstance(&resourcecontrollerv2.GetResourceInstanceOptions{
 			ID: &serviceInstanceID,
@@ -745,6 +734,7 @@ func (s *PowerVSClusterScope) ReconcilePowerVSServiceInstance() (bool, error) {
 	}
 	// Set the status of IBMPowerVSCluster object with serviceInstanceID and ControllerCreated to false as PowerVS service instance is already exist in cloud.
 	if serviceInstanceID != "" {
+		s.V(3).Info("Found PowerVS service instance in IBM Cloud", "serviceInstanceID", serviceInstanceID)
 		s.SetStatus(infrav1beta2.ResourceTypeServiceInstance, infrav1beta2.ResourceReference{ID: &serviceInstanceID, ControllerCreated: ptr.To(false)})
 		return requeue, nil
 	}
@@ -758,7 +748,7 @@ func (s *PowerVSClusterScope) ReconcilePowerVSServiceInstance() (bool, error) {
 		return false, fmt.Errorf("created PowerVS service instance is nil")
 	}
 
-	s.Info("Created PowerVS service instance", "id", serviceInstance.GUID)
+	s.Info("Created PowerVS service instance", "serviceInstanceID", serviceInstance.GUID)
 	// Set the status of IBMPowerVSCluster object with serviceInstanceID and ControllerCreated to true as new PowerVS service instance is created.
 	s.SetStatus(infrav1beta2.ResourceTypeServiceInstance, infrav1beta2.ResourceReference{ID: serviceInstance.GUID, ControllerCreated: ptr.To(true)})
 	return true, nil
@@ -782,17 +772,38 @@ func (s *PowerVSClusterScope) checkServiceInstanceState(instance resourcecontrol
 	return false, fmt.Errorf("PowerVS service instance is in %s state", *instance.State)
 }
 
-// checkServiceInstance checks PowerVS service instance exist in cloud.
+// checkServiceInstance checks PowerVS service instance exist in cloud by ID or name.
 func (s *PowerVSClusterScope) isServiceInstanceExists() (string, bool, error) {
 	s.V(3).Info("Checking for PowerVS service instance in IBM Cloud")
-	// Fetches service instance by name.
-	serviceInstance, err := s.getServiceInstance()
+	var (
+		id              string
+		err             error
+		serviceInstance *resourcecontrollerv2.ResourceInstance
+	)
+
+	if s.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
+		id = s.IBMPowerVSCluster.Spec.ServiceInstanceID
+	} else if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+		id = *s.IBMPowerVSCluster.Spec.ServiceInstance.ID
+	}
+
+	if id != "" {
+		// Fetches service instance by ID.
+		serviceInstance, _, err = s.ResourceClient.GetResourceInstance(&resourcecontrollerv2.GetResourceInstanceOptions{
+			ID: &id,
+		})
+	} else {
+		// Fetches service instance by name.
+		serviceInstance, err = s.getServiceInstance()
+	}
+
 	if err != nil {
 		s.Error(err, "failed to get PowerVS service instance")
 		return "", false, err
 	}
+
 	if serviceInstance == nil {
-		s.V(3).Info("PowerVS service instance with given name does not exist in IBM Cloud", "name", *s.GetServiceName(infrav1beta2.ResourceTypeServiceInstance))
+		s.V(3).Info("PowerVS service instance with given ID or name does not exist in IBM Cloud")
 		return "", false, nil
 	}
 
@@ -839,7 +850,7 @@ func (s *PowerVSClusterScope) createServiceInstance() (*resourcecontrollerv2.Res
 // ReconcileNetwork reconciles network.
 func (s *PowerVSClusterScope) ReconcileNetwork() (bool, error) {
 	if s.GetDHCPServerID() != nil {
-		s.V(3).Info("DHCP server ID is set, fetching details", "id", s.GetDHCPServerID())
+		s.V(3).Info("DHCP server ID is set, fetching details", "dhcpServerID", s.GetDHCPServerID())
 		active, err := s.isDHCPServerActive()
 		if err != nil {
 			return false, err
@@ -855,46 +866,30 @@ func (s *PowerVSClusterScope) ReconcileNetwork() (bool, error) {
 		return false, err
 	}
 	if networkID != nil {
-		s.V(3).Info("Found PowerVS network in IBM Cloud", "id", networkID)
+		s.V(3).Info("Found PowerVS network in IBM Cloud", "networkID", networkID)
 		s.SetStatus(infrav1beta2.ResourceTypeNetwork, infrav1beta2.ResourceReference{ID: networkID, ControllerCreated: ptr.To(false)})
 		return true, nil
 	}
 
-	dhcpServer, err := s.createDHCPServer()
+	dhcpServerID, err := s.createDHCPServer()
 	if err != nil {
 		s.Error(err, "Error creating DHCP server")
 		return false, err
 	}
 
-	s.Info("Created DHCP Server", "id", *dhcpServer)
-	s.SetStatus(infrav1beta2.ResourceTypeDHCPServer, infrav1beta2.ResourceReference{ID: dhcpServer, ControllerCreated: ptr.To(true)})
+	s.Info("Created DHCP Server", "dhcpServerID", *dhcpServerID)
+	s.SetStatus(infrav1beta2.ResourceTypeDHCPServer, infrav1beta2.ResourceReference{ID: dhcpServerID, ControllerCreated: ptr.To(true)})
 	return false, nil
 }
 
-// checkNetwork checks the network exist in cloud.
+// checkNetwork checks if network exists in cloud with given name or ID mentioned in spec.
 func (s *PowerVSClusterScope) checkNetwork() (*string, error) {
-	// get network from cloud.
-	s.V(3).Info("Checking if PowerVS network exists in IBM Cloud")
-	networkID, err := s.getNetwork()
-	if err != nil {
-		s.Error(err, "failed to get PowerVS network")
-		return nil, err
-	}
-	if networkID == nil {
-		s.V(3).Info("Unable to find PowerVS network in IBM Cloud", "network", s.IBMPowerVSCluster.Spec.Network)
-		return nil, nil
-	}
-	return networkID, nil
-}
-
-func (s *PowerVSClusterScope) getNetwork() (*string, error) {
-	// fetch the network associated with network id
 	if s.IBMPowerVSCluster.Spec.Network.ID != nil {
+		s.V(3).Info("Checking if PowerVS network exists in IBM Cloud with ID", "networkID", *s.IBMPowerVSCluster.Spec.Network.ID)
 		network, err := s.IBMPowerVSClient.GetNetworkByID(*s.IBMPowerVSCluster.Spec.Network.ID)
 		if err != nil {
 			return nil, err
 		}
-		s.V(3).Info("Found the PowerVS network", "id", network.NetworkID)
 		return network.NetworkID, nil
 	}
 
@@ -907,25 +902,22 @@ func (s *PowerVSClusterScope) getNetwork() (*string, error) {
 		networkName = *s.GetServiceName(infrav1beta2.ResourceTypeNetwork)
 	}
 
+	s.V(3).Info("Checking if PowerVS network exists in IBM Cloud with name", "name", networkName)
 	// fetch the network associated with name
 	network, err := s.IBMPowerVSClient.GetNetworkByName(networkName)
 	if err != nil {
 		return nil, err
 	}
-	if network == nil {
+	if network == nil || network.NetworkID == nil {
+		s.V(3).Info("Unable to find PowerVS network in IBM Cloud", "network", s.IBMPowerVSCluster.Spec.Network)
 		return nil, nil
 	}
 	return network.NetworkID, nil
-	//TODO: Support regular expression
 }
 
 // isDHCPServerActive checks if the DHCP server status is active.
 func (s *PowerVSClusterScope) isDHCPServerActive() (bool, error) {
-	dhcpID := *s.GetDHCPServerID()
-	if dhcpID == "" {
-		return false, fmt.Errorf("DHCP ID is empty")
-	}
-	dhcpServer, err := s.IBMPowerVSClient.GetDHCPServer(dhcpID)
+	dhcpServer, err := s.IBMPowerVSClient.GetDHCPServer(*s.GetDHCPServerID())
 	if err != nil {
 		return false, err
 	}
@@ -941,7 +933,7 @@ func (s *PowerVSClusterScope) isDHCPServerActive() (bool, error) {
 // If state is active, true is returned.
 // In all other cases, it returns false.
 func (s *PowerVSClusterScope) checkDHCPServerStatus(dhcpServer models.DHCPServerDetail) (bool, error) {
-	s.V(3).Info("Checking the status of DHCP server", "id", *dhcpServer.ID)
+	s.V(3).Info("Checking the status of DHCP server", "dhcpServerID", *dhcpServer.ID)
 	switch *dhcpServer.Status {
 	case string(infrav1beta2.DHCPServerStateActive):
 		s.V(3).Info("DHCP server is in active state")
@@ -996,7 +988,7 @@ func (s *PowerVSClusterScope) ReconcileVPC() (bool, error) {
 	// if VPC server id is set means the VPC is already created
 	vpcID := s.GetVPCID()
 	if vpcID != nil {
-		s.V(3).Info("VPC ID is set, fetching details", "id", *vpcID)
+		s.V(3).Info("VPC ID is set, fetching details", "vpcID", *vpcID)
 		vpcDetails, _, err := s.IBMVPCClient.GetVPC(&vpcv1.GetVPCOptions{
 			ID: vpcID,
 		})
@@ -1021,6 +1013,7 @@ func (s *PowerVSClusterScope) ReconcileVPC() (bool, error) {
 		return false, err
 	}
 	if id != "" {
+		s.V(3).Info("VPC found in IBM Cloud", "vpcID", id)
 		s.SetStatus(infrav1beta2.ResourceTypeVPC, infrav1beta2.ResourceReference{ID: &id, ControllerCreated: ptr.To(false)})
 		return false, nil
 	}
@@ -1033,14 +1026,25 @@ func (s *PowerVSClusterScope) ReconcileVPC() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to create VPC: %w", err)
 	}
-	s.Info("Created VPC", "id", *vpcID)
+	s.Info("Created VPC", "vpcID", *vpcID)
 	s.SetStatus(infrav1beta2.ResourceTypeVPC, infrav1beta2.ResourceReference{ID: vpcID, ControllerCreated: ptr.To(true)})
 	return true, nil
 }
 
 // checkVPC checks VPC exist in cloud.
 func (s *PowerVSClusterScope) checkVPC() (string, error) {
-	vpcDetails, err := s.getVPCByName()
+	var (
+		err        error
+		vpcDetails *vpcv1.VPC
+	)
+	if s.IBMPowerVSCluster.Spec.VPC != nil && s.IBMPowerVSCluster.Spec.VPC.ID != nil {
+		vpcDetails, _, err = s.IBMVPCClient.GetVPC(&vpcv1.GetVPCOptions{
+			ID: s.IBMPowerVSCluster.Spec.VPC.ID,
+		})
+	} else {
+		vpcDetails, err = s.getVPCByName()
+	}
+
 	if err != nil {
 		s.Error(err, "failed to get VPC")
 		return "", err
@@ -1049,7 +1053,7 @@ func (s *PowerVSClusterScope) checkVPC() (string, error) {
 		s.V(3).Info("VPC not found in IBM Cloud", "vpc", s.IBMPowerVSCluster.Spec.VPC)
 		return "", nil
 	}
-	s.V(3).Info("VPC found in IBM Cloud", "id", *vpcDetails.ID)
+	s.V(3).Info("VPC found in IBM Cloud", "vpcID", *vpcDetails.ID)
 	return *vpcDetails.ID, nil
 }
 
@@ -1115,23 +1119,24 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 			}
 			subnets = append(subnets, subnet)
 		}
+	} else {
+		subnets = append(subnets, s.IBMPowerVSCluster.Spec.VPCSubnets...)
 	}
-	for index, subnet := range s.IBMPowerVSCluster.Spec.VPCSubnets {
-		if subnet.Name == nil {
-			subnet.Name = ptr.To(fmt.Sprintf("%s-%d", *s.GetServiceName(infrav1beta2.ResourceTypeSubnet), index))
-		}
-		subnets = append(subnets, subnet)
-	}
-	for _, subnet := range subnets {
+
+	for index, subnet := range subnets {
 		s.Info("Reconciling VPC subnet", "subnet", subnet)
 		var subnetID *string
 		if subnet.ID != nil {
 			subnetID = subnet.ID
 		} else {
+			if subnet.Name == nil {
+				subnet.Name = ptr.To(fmt.Sprintf("%s-%d", *s.GetServiceName(infrav1beta2.ResourceTypeSubnet), index))
+			}
 			subnetID = s.GetVPCSubnetID(*subnet.Name)
 		}
+
 		if subnetID != nil {
-			s.V(3).Info("VPC subnet ID is set, fetching details", "id", *subnetID)
+			s.V(3).Info("VPC subnet ID is set, fetching details", "subnetID", *subnetID)
 			subnetDetails, _, err := s.IBMVPCClient.GetSubnet(&vpcv1.GetSubnetOptions{
 				ID: subnetID,
 			})
@@ -1142,6 +1147,7 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 				return false, fmt.Errorf("failed to get VPC subnet with ID %s", *subnetID)
 			}
 			// check for next subnet
+			s.SetVPCSubnetStatus(*subnetDetails.Name, infrav1beta2.ResourceReference{ID: subnetDetails.ID})
 			continue
 		}
 
@@ -1152,8 +1158,8 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 			return false, err
 		}
 		if vpcSubnetID != "" {
-			s.V(3).Info("Found VPC subnet in IBM Cloud", "id", vpcSubnetID)
-			s.SetVPCSubnetID(*subnet.Name, infrav1beta2.ResourceReference{ID: &vpcSubnetID, ControllerCreated: ptr.To(false)})
+			s.V(3).Info("Found VPC subnet in IBM Cloud", "subnetID", vpcSubnetID)
+			s.SetVPCSubnetStatus(*subnet.Name, infrav1beta2.ResourceReference{ID: &vpcSubnetID, ControllerCreated: ptr.To(false)})
 			// check for next subnet
 			continue
 		}
@@ -1164,14 +1170,14 @@ func (s *PowerVSClusterScope) ReconcileVPCSubnets() (bool, error) {
 			s.Error(err, "failed to create VPC subnet")
 			return false, err
 		}
-		s.Info("Created VPC subnet", "id", subnetID)
-		s.SetVPCSubnetID(*subnet.Name, infrav1beta2.ResourceReference{ID: subnetID, ControllerCreated: ptr.To(true)})
+		s.Info("Created VPC subnet", "subnetID", subnetID)
+		s.SetVPCSubnetStatus(*subnet.Name, infrav1beta2.ResourceReference{ID: subnetID, ControllerCreated: ptr.To(true)})
 		return true, nil
 	}
 	return false, nil
 }
 
-// checkVPCSubnet checks VPC subnet exist in cloud.
+// checkVPCSubnet checks if VPC subnet by the given name exists in cloud.
 func (s *PowerVSClusterScope) checkVPCSubnet(subnetName string) (string, error) {
 	vpcSubnet, err := s.IBMVPCClient.GetVPCSubnetByName(subnetName)
 	if err != nil {
@@ -1279,7 +1285,7 @@ func (s *PowerVSClusterScope) ReconcileVPCSecurityGroups() error {
 		}
 		if sg != nil {
 			s.V(3).Info("VPC security group already exists", "name", *sg.Name)
-			s.SetVPCSecurityGroup(*sg.Name, infrav1beta2.VPCSecurityGroupStatus{
+			s.SetVPCSecurityGroupStatus(*sg.Name, infrav1beta2.VPCSecurityGroupStatus{
 				ID:                sg.ID,
 				RuleIDs:           ruleIDs,
 				ControllerCreated: ptr.To(false),
@@ -1292,7 +1298,7 @@ func (s *PowerVSClusterScope) ReconcileVPCSecurityGroups() error {
 			return fmt.Errorf("failed to create VPC security group: %w", err)
 		}
 		s.Info("VPC security group created", "name", *securityGroup.Name)
-		s.SetVPCSecurityGroup(*securityGroup.Name, infrav1beta2.VPCSecurityGroupStatus{
+		s.SetVPCSecurityGroupStatus(*securityGroup.Name, infrav1beta2.VPCSecurityGroupStatus{
 			ID:                securityGroupID,
 			ControllerCreated: ptr.To(true),
 		})
@@ -1374,7 +1380,7 @@ func (s *PowerVSClusterScope) createVPCSecurityGroupRule(securityGroupID, direct
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)
 		ruleID = rule.ID
 	}
-	s.Info("Created VPC security group rule", "id", *ruleID)
+	s.Info("Created VPC security group rule", "ruleID", *ruleID)
 	return ruleID, nil
 }
 
@@ -1431,7 +1437,7 @@ func (s *PowerVSClusterScope) createVPCSecurityGroupRulesAndSetStatus(ogSecurity
 	}
 	s.Info("VPC security group rules created", "security group name", *securityGroupName)
 
-	s.SetVPCSecurityGroup(*securityGroupName, infrav1beta2.VPCSecurityGroupStatus{
+	s.SetVPCSecurityGroupStatus(*securityGroupName, infrav1beta2.VPCSecurityGroupStatus{
 		ID:                securityGroupID,
 		RuleIDs:           ruleIDs,
 		ControllerCreated: ptr.To(true),
@@ -1637,7 +1643,7 @@ func (s *PowerVSClusterScope) validateVPCSecurityGroup(securityGroup infrav1beta
 // ReconcileTransitGateway reconcile transit gateway.
 func (s *PowerVSClusterScope) ReconcileTransitGateway() (bool, error) {
 	if s.GetTransitGatewayID() != nil {
-		s.V(3).Info("Transit gateway ID is set, fetching details", "id", s.GetTransitGatewayID())
+		s.V(3).Info("Transit gateway ID is set, fetching details", "tgID", s.GetTransitGatewayID())
 		tg, _, err := s.TransitGatewayClient.GetTransitGateway(&tgapiv1.GetTransitGatewayOptions{
 			ID: s.GetTransitGatewayID(),
 		})
@@ -1835,7 +1841,6 @@ func (s *PowerVSClusterScope) checkTransitGatewayConnectionStatus(con tgapiv1.Tr
 	s.V(3).Info("Checking the status of transit gateway connection", "name", *con.Name)
 	switch *con.Status {
 	case string(infrav1beta2.TransitGatewayConnectionStateAttached):
-		s.V(3).Info("Transit gateway connection is in attached state")
 		return false, nil
 	case string(infrav1beta2.TransitGatewayConnectionStateFailed):
 		return false, fmt.Errorf("failed to attach connection to transit gateway, current status: %s", *con.Status)
@@ -1887,6 +1892,10 @@ func (s *PowerVSClusterScope) createTransitGateway() error {
 		return fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
 	}
 
+	if s.IBMPowerVSCluster.Status.ServiceInstance == nil || s.IBMPowerVSCluster.Status.VPC == nil {
+		return fmt.Errorf("failed to proeceed with transit gateway creation as either one of VPC or PowerVS service instance reconciliation is not successful")
+	}
+
 	location, globalRouting, err := genUtil.GetTransitGatewayLocationAndRouting(s.Zone(), s.VPC().Region)
 	if err != nil {
 		return fmt.Errorf("failed to get transit gateway location and routing: %w", err)
@@ -1894,11 +1903,11 @@ func (s *PowerVSClusterScope) createTransitGateway() error {
 
 	// throw error when user tries to use local routing where global routing is required.
 	// TODO: Add a webhook validation for below condition.
-	if s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting != nil && !*s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting && *globalRouting {
+	if s.IBMPowerVSCluster.Spec.TransitGateway != nil && s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting != nil && !*s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting && *globalRouting {
 		return fmt.Errorf("failed to use local routing for transit gateway since powervs and vpc are in different region and requires global routing")
 	}
 	// setting global routing to true when it is set by user.
-	if s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting != nil && *s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting {
+	if s.IBMPowerVSCluster.Spec.TransitGateway != nil && s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting != nil && *s.IBMPowerVSCluster.Spec.TransitGateway.GlobalRouting {
 		globalRouting = ptr.To(true)
 	}
 
@@ -1940,19 +1949,18 @@ func (s *PowerVSClusterScope) ReconcileLoadBalancers() (bool, error) {
 			Public: ptr.To(true),
 		}
 		loadBalancers = append(loadBalancers, loadBalancer)
-	}
-	for index, loadBalancer := range s.IBMPowerVSCluster.Spec.LoadBalancers {
-		if loadBalancer.Name == "" {
-			loadBalancer.Name = fmt.Sprintf("%s-%d", *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer), index)
-		}
-		loadBalancers = append(loadBalancers, loadBalancer)
+	} else {
+		loadBalancers = append(loadBalancers, s.IBMPowerVSCluster.Spec.LoadBalancers...)
 	}
 
-	for _, loadBalancer := range loadBalancers {
+	for index, loadBalancer := range loadBalancers {
 		var loadBalancerID *string
 		if loadBalancer.ID != nil {
 			loadBalancerID = loadBalancer.ID
 		} else {
+			if loadBalancer.Name == "" {
+				loadBalancer.Name = fmt.Sprintf("%s-%d", *s.GetServiceName(infrav1beta2.ResourceTypeLoadBalancer), index)
+			}
 			loadBalancerID = s.GetLoadBalancerID(loadBalancer.Name)
 		}
 		if loadBalancerID != nil {
@@ -1983,6 +1991,7 @@ func (s *PowerVSClusterScope) ReconcileLoadBalancers() (bool, error) {
 			return false, err
 		}
 		if loadBalancerStatus != nil {
+			s.V(3).Info("Found VPC load balancer in IBM Cloud", "loadBalancerID", *loadBalancerStatus.ID)
 			s.SetLoadBalancerStatus(loadBalancer.Name, *loadBalancerStatus)
 			continue
 		}
@@ -1999,7 +2008,7 @@ func (s *PowerVSClusterScope) ReconcileLoadBalancers() (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("failed to create VPC load balancer: %w", err)
 		}
-		s.Info("Created VPC load balancer", "id", loadBalancerStatus.ID)
+		s.Info("Created VPC load balancer", "loadBalancerID", loadBalancerStatus.ID)
 		s.SetLoadBalancerStatus(loadBalancer.Name, *loadBalancerStatus)
 		return false, nil
 	}
@@ -2033,7 +2042,7 @@ func (s *PowerVSClusterScope) checkLoadBalancerPort(lb infrav1beta2.VPCLoadBalan
 	return nil
 }
 
-// checkLoadBalancer checks loadBalancer in cloud.
+// checkLoadBalancer checks if VPC load balancer by the given name exists in cloud.
 func (s *PowerVSClusterScope) checkLoadBalancer(lb infrav1beta2.VPCLoadBalancerSpec) (*infrav1beta2.VPCLoadBalancerStatus, error) {
 	loadBalancer, err := s.IBMVPCClient.GetLoadBalancerByName(lb.Name)
 	if err != nil {
@@ -2156,7 +2165,7 @@ func (s *PowerVSClusterScope) ReconcileCOSInstance() error {
 			s.Error(err, "failed to create COS service instance")
 			return err
 		}
-		s.Info("Created COS service instance", "id", cosServiceInstanceStatus.GUID)
+		s.Info("Created COS service instance", "cosID", cosServiceInstanceStatus.GUID)
 		s.SetStatus(infrav1beta2.ResourceTypeCOSInstance, infrav1beta2.ResourceReference{ID: cosServiceInstanceStatus.GUID, ControllerCreated: ptr.To(true)})
 	}
 
@@ -2331,7 +2340,9 @@ func (s *PowerVSClusterScope) fetchResourceGroupID() (string, error) {
 func (s *PowerVSClusterScope) fetchVPCCRN() (*string, error) {
 	vpcID := s.GetVPCID()
 	if vpcID == nil {
-		return nil, fmt.Errorf("VPC ID is empty")
+		if s.IBMPowerVSCluster.Spec.VPC != nil && s.IBMPowerVSCluster.Spec.VPC.ID != nil {
+			vpcID = s.IBMPowerVSCluster.Spec.VPC.ID
+		}
 	}
 	vpcDetails, _, err := s.IBMVPCClient.GetVPC(&vpcv1.GetVPCOptions{
 		ID: vpcID,
@@ -2345,6 +2356,13 @@ func (s *PowerVSClusterScope) fetchVPCCRN() (*string, error) {
 // fetchPowerVSServiceInstanceCRN returns Power VS service instance CRN.
 func (s *PowerVSClusterScope) fetchPowerVSServiceInstanceCRN() (*string, error) {
 	serviceInstanceID := s.GetServiceInstanceID()
+	if serviceInstanceID == "" {
+		if s.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
+			serviceInstanceID = s.IBMPowerVSCluster.Spec.ServiceInstanceID
+		} else if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+			serviceInstanceID = *s.IBMPowerVSCluster.Spec.ServiceInstance.ID
+		}
+	}
 	pvsDetails, _, err := s.ResourceClient.GetResourceInstance(&resourcecontrollerv2.GetResourceInstanceOptions{
 		ID: &serviceInstanceID,
 	})
@@ -2455,20 +2473,20 @@ func (s *PowerVSClusterScope) DeleteVPCSecurityGroups() error {
 			ID: securityGroup.ID,
 		}); err != nil {
 			if resp != nil && resp.StatusCode == ResourceNotFoundCode {
-				s.Info("VPC security group has been already deleted", "ID", *securityGroup.ID)
+				s.Info("VPC security group has been already deleted", "securityGroupID", *securityGroup.ID)
 				continue
 			}
 			return fmt.Errorf("failed to fetch VPC security group '%s': %w", *securityGroup.ID, err)
 		}
 
-		s.V(3).Info("Deleting VPC security group", "ID", *securityGroup.ID)
+		s.V(3).Info("Deleting VPC security group", "securityGroupID", *securityGroup.ID)
 		options := &vpcv1.DeleteSecurityGroupOptions{
 			ID: securityGroup.ID,
 		}
 		if _, err := s.IBMVPCClient.DeleteSecurityGroup(options); err != nil {
 			return fmt.Errorf("failed to delete VPC security group '%s': %w", *securityGroup.ID, err)
 		}
-		s.Info("VPC security group successfully deleted", "ID", *securityGroup.ID)
+		s.Info("VPC security group successfully deleted", "securityGroupID", *securityGroup.ID)
 	}
 	return nil
 }
@@ -2604,7 +2622,7 @@ func (s *PowerVSClusterScope) deleteTransitGatewayConnections(tg *tgapiv1.Transi
 			ID:               connID,
 		})
 		if resp.StatusCode == ResourceNotFoundCode {
-			s.V(3).Info("Connection deleted in transit gateway", "id", *connID)
+			s.V(3).Info("Connection deleted in transit gateway", "connectionID", *connID)
 			return false, nil
 		}
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**This PR refactors the reconciliation of resources to follow a unit format as below**
1. Fetch ID from IBMPowerVSCluster status object. If ID exists, check the status of the resource in cloud and return
2. If ID is not present in the status, try to fetch it from the IBMPowerVSCluster spec and check if the resource exists in cloud. Here we can check either via name or ID passed in the spec. If resource with given ID doesn't exist, return err, or else check the status of the resource in cloud and set IBMPowerVSCluster.status accordingly
3. If resource with given name doesn't exist, proceed with creating the resource. If it exists, check the status of the resource in cloud. Set IBMPowerVSCluster.status accordingly in both cases


**The changes in this PR has been tested with the following scenarios**
1. Resource names are set in spec and they do not exist
2. Resource names are set in spec and they exist
3. Resource IDs are set in spec and they do not exist
4. Resource IDs are set in spec and they exist
5. Spec with only required fields

**Note:**
1. Adjustments were made to support if ID or Name are set in spec
2. The changes in this PR were also tested with TG changes from existing PR https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/1901
3. Caveats noticed where in terms of handling existing DHCP server ID set in spec and it has been documented in https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1933




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1907 #1726

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Refactor reconcilation of resources
```
