### PR TITLE
Fix cluster name references

### DIFF
--- a/cloud/scope/vpc_cluster.go
+++ b/cloud/scope/vpc_cluster.go
@@ -275,7 +275,7 @@ func (s *VPCClusterScope) GetResourceGroupID() (string, error) {
 	// If the Resource Group is not defined in Spec, we generate the name based on the cluster name.
 	resourceGroupName := s.IBMVPCCluster.Spec.ResourceGroup
 	if resourceGroupName == "" {
-		resourceGroupName = s.IBMVPCCluster.Name
+		resourceGroupName = s.Name()
 	}
 
 	// Retrieve the Resource Group based on the name.
@@ -486,7 +486,9 @@ func (s *VPCClusterScope) createVPC() (*vpcv1.VPC, error) {
 	} else if vpcDetails == nil {
 		return nil, fmt.Errorf("no vpc details after creation")
 	}
-	if err = s.TagResource(s.IBMVPCCluster.Name, *vpcDetails.CRN); err != nil {
+
+	// NOTE: This tagging is only attempted once. We may wish to refactor in case this single attempt fails.
+	if err = s.TagResource(s.Name(), *vpcDetails.CRN); err != nil {
 		return nil, fmt.Errorf("error tagging vpc: %w", err)
 	}
 


### PR DESCRIPTION
Fix the references to use the cluster's name for VPC clusters.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster name references for vpc
```
