### PR TITLE
Redirect stderr to /dev/null to suppress make command warnings.

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -71,7 +71,7 @@ version::get_version_vars() {
         fi
     fi
 
-    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
     GIT_RELEASE_COMMIT=$(git rev-list -n 1  "${GIT_RELEASE_TAG}")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR contains a minor change to suppress a fatal warning from `git` , which is expected to be raised when make commands are used from the Development fork. The stderr is redirected to /dev/null to avoid confusion, as the error is on the expected lines that forks do not carry tags. 

Existing change: 

```
 cluster-api-provider-ibmcloud : main ✔ : ᐅ  make release
fatal: No names found, cannot describe anything.                    <--------------
RELEASE_TAG is not set
make: *** [check-release-tag] Error 1

cluster-api-provider-ibmcloud : main ✔ : ᐅ  make build
fatal: No names found, cannot describe anything.                    <--------------
make: *** No rule to make target `build'.  Stop.
```

Current change, when make release is run from fork.(intended as a release is not expected to be cut from development branch) 

```
 cluster-api-provider-ibmcloud : avoid-git-warnings ✔ : ᐅ  make release
RELEASE_TAG is not set
make: *** [check-release-tag] Error 1
```

Make release, when run from upstream branch. 
```
cluster-api-provider-ibmcloud : main ✔ : ᐅ  make release
Note: switching to 'v0.8.0'.
You are in 'detached HEAD' state. You can look around, make experimental
* main
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1609 

**Special notes for your reviewer**:
Please ensure that the changes do suffice from a release-tooling aspect. 

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Redirect stderr to /dev/null to suppress make command warnings.
```
