### PR TITLE
VPC: Add subnet reconciliation

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -258,10 +258,10 @@ var (
 	ResourceTypeVPC = ResourceType("vpc")
 	// ResourceTypeSubnet is VPC subnet resource.
 	ResourceTypeSubnet = ResourceType("subnet")
-	// ResourceTypeComputeSubnet is a VPC subnet resource designated for the Compute (Data) Plane.
-	ResourceTypeComputeSubnet = ResourceType("computeSubnet")
 	// ResourceTypeControlPlaneSubnet is a VPC subnet resource designated for the Control Plane.
 	ResourceTypeControlPlaneSubnet = ResourceType("controlPlaneSubnet")
+	// ResourceTypeWorkerSubnet is a VPC subnet resource designated for the Worker (Data) Plane.
+	ResourceTypeWorkerSubnet = ResourceType("workerSubnet")
 	// ResourceTypeSecurityGroup is a VPC Security Group resource.
 	ResourceTypeSecurityGroup = ResourceType("securityGroup")
 	// ResourceTypeCOSInstance is IBM COS instance resource.

--- a/pkg/cloud/services/vpc/mock/vpc_generated.go
+++ b/pkg/cloud/services/vpc/mock/vpc_generated.go
@@ -523,6 +523,21 @@ func (mr *MockVpcMockRecorder) GetVPCByName(vpcName any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCByName", reflect.TypeOf((*MockVpc)(nil).GetVPCByName), vpcName)
 }
 
+// GetVPCPublicGatewayByName mocks base method.
+func (m *MockVpc) GetVPCPublicGatewayByName(publicGatewayName, resourceGroupID string) (*vpcv1.PublicGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCPublicGatewayByName", publicGatewayName, resourceGroupID)
+	ret0, _ := ret[0].(*vpcv1.PublicGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCPublicGatewayByName indicates an expected call of GetVPCPublicGatewayByName.
+func (mr *MockVpcMockRecorder) GetVPCPublicGatewayByName(publicGatewayName, resourceGroupID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCPublicGatewayByName", reflect.TypeOf((*MockVpc)(nil).GetVPCPublicGatewayByName), publicGatewayName, resourceGroupID)
+}
+
 // GetVPCSubnetByName mocks base method.
 func (m *MockVpc) GetVPCSubnetByName(subnetName string) (*vpcv1.Subnet, error) {
 	m.ctrl.T.Helper()
@@ -536,6 +551,21 @@ func (m *MockVpc) GetVPCSubnetByName(subnetName string) (*vpcv1.Subnet, error) {
 func (mr *MockVpcMockRecorder) GetVPCSubnetByName(subnetName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCSubnetByName", reflect.TypeOf((*MockVpc)(nil).GetVPCSubnetByName), subnetName)
+}
+
+// GetVPCZonesByRegion mocks base method.
+func (m *MockVpc) GetVPCZonesByRegion(region string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCZonesByRegion", region)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCZonesByRegion indicates an expected call of GetVPCZonesByRegion.
+func (mr *MockVpcMockRecorder) GetVPCZonesByRegion(region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCZonesByRegion", reflect.TypeOf((*MockVpc)(nil).GetVPCZonesByRegion), region)
 }
 
 // ListImages mocks base method.

--- a/pkg/cloud/services/vpc/vpc.go
+++ b/pkg/cloud/services/vpc/vpc.go
@@ -58,6 +58,7 @@ type Vpc interface {
 	GetVPC(*vpcv1.GetVPCOptions) (*vpcv1.VPC, *core.DetailedResponse, error)
 	GetVPCByName(vpcName string) (*vpcv1.VPC, error)
 	GetImageByName(imageName string) (*vpcv1.Image, error)
+	GetVPCPublicGatewayByName(publicGatewayName string, resourceGroupID string) (*vpcv1.PublicGateway, error)
 	GetSubnet(*vpcv1.GetSubnetOptions) (*vpcv1.Subnet, *core.DetailedResponse, error)
 	GetVPCSubnetByName(subnetName string) (*vpcv1.Subnet, error)
 	GetLoadBalancerByName(loadBalancerName string) (*vpcv1.LoadBalancer, error)
@@ -68,4 +69,5 @@ type Vpc interface {
 	GetSecurityGroup(options *vpcv1.GetSecurityGroupOptions) (*vpcv1.SecurityGroup, *core.DetailedResponse, error)
 	GetSecurityGroupByName(name string) (*vpcv1.SecurityGroup, error)
 	GetSecurityGroupRule(options *vpcv1.GetSecurityGroupRuleOptions) (vpcv1.SecurityGroupRuleIntf, *core.DetailedResponse, error)
+	GetVPCZonesByRegion(region string) ([]string, error)
 }


### PR DESCRIPTION
Add support to reoncile VPC subnets for the new v2 VPC Infrastructure reoncile logic.

Related: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/1896

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:  
Add new support for reconciling VPC subnets for VPC Infra

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:  
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to new (v2) reconciliation of Subnets for VPC Infrastructure
```
