### PR TITLE
Add support for JSON output format for logs

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -155,6 +155,42 @@ kustomize_substitutions:
   IBMCLOUD_AUTH_URL: "https://iam.test.cloud.ibm.com"
 ```
 
+### 4.  Configuration to use observability tools
+
+- cluster-api provides support for deploying observability tools, More information about it is available in cluster-api [book](https://cluster-api.sigs.k8s.io/developer/logging#developing-and-testing-logs).
+
+```yaml
+default_registry: "gcr.io/you-project-name-here"
+deploy_observability:
+   - promtail
+   - loki
+   - grafana
+   - prometheus
+provider_repos:
+  - ../cluster-api-provider-ibmcloud
+enable_providers:
+  - ibmcloud
+  - kubeadm-bootstrap
+  - kubeadm-control-plane
+kustomize_substitutions:
+  IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
+  PROVIDER_ID_FORMAT: "v2"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+extra_args:
+   core:
+      - "--logging-format=json"
+      - "--v=5"
+   kubeadm-bootstrap:
+      - "--v=5"
+      - "--logging-format=json"
+   kubeadm-control-plane:
+      - "--v=5"
+      - "--logging-format=json"
+   ibmcloud:
+      - "--v=5"
+      - "--logging-format=json"
+```
+
 **NOTE**: For information about all the fields that can be used in the `tilt-settings.yaml` file, check them [here](https://cluster-api.sigs.k8s.io/developer/tilt.html#tilt-settings-fields).
 
 ## Run Tilt

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	k8s.io/apimachinery v0.30.3
 	k8s.io/cli-runtime v0.30.3
 	k8s.io/client-go v0.30.3
+	k8s.io/component-base v0.30.3
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	sigs.k8s.io/cluster-api v1.8.3
@@ -80,6 +81,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.21.5 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.1 // indirect
@@ -162,6 +164,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
@@ -180,7 +183,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.30.3 // indirect
 	k8s.io/cluster-bootstrap v0.30.3 // indirect
-	k8s.io/component-base v0.30.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Most of the core components of cluster-api supports JSON output format for logs and capi is planning to make json output format for logs as default in future releases rather than having text output format like now. 
This PR adds support for the same in cluster-api-provider-ibmcloud repository, This will help in easy parsing of logs in obervability tools.

User needs to pass additional flag `--logging-format=json ` to set the output log format to JSON

Default text format log output
```
I0923 08:58:50.656130       1 reflector.go:302] Stopping reflector *v1beta2.IBMVPCMachineTemplate (10m27.692803049s) from pkg/mod/k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232
I0923 08:58:50.660508       1 reflector.go:302] Stopping reflector *v1beta2.IBMPowerVSMachineTemplate (9m52.646239995s) from pkg/mod/k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232
I0923 08:58:50.666075       1 internal.go:541] "Stopping and waiting for webhooks"
I0923 08:58:50.669962       1 server.go:249] "Shutting down webhook server with timeout of 1 minute" logger="controller-runtime.webhook"
I0923 08:58:50.672521       1 internal.go:544] "Stopping and waiting for HTTP servers"
I0923 08:58:50.673560       1 server.go:254] "Shutting down metrics server with timeout of 1 minute" logger="controller-runtime.metrics"
I0923 08:58:50.673729       1 server.go:68] "shutting down server" name="health probe" addr="[::]:9440"
I0923 08:58:50.673822       1 internal.go:548] "Wait completed, proceeding to shutdown the manager"
```

Log format when JSON output format is set
```
{"ts":1727081930843.5164,"logger":"controller-runtime.metrics","caller":"server/server.go:247","msg":"Serving metrics server","v":0,"bindAddress":":8443","secure":true}
{"ts":1727081934322.6074,"caller":"leaderelection/leaderelection.go:367","msg":"lock is held by capi-ibmcloud-controller-manager-7d574bbf58-ptbqk_4eaa0a09-0efc-4bd1-95f2-ae84e4ac9f47 and has not yet expired","v":4}
{"ts":1727081934322.689,"caller":"leaderelection/leaderelection.go:255","msg":"failed to acquire lease capi-ibmcloud-system/effcf9b8.cluster.x-k8s.io","v":4}
{"ts":1727081936795.2607,"caller":"leaderelection/leaderelection.go:367","msg":"lock is held by capi-ibmcloud-controller-manager-7d574bbf58-ptbqk_4eaa0a09-0efc-4bd1-95f2-ae84e4ac9f47 and has not yet expired","v":4}
{"ts":1727081936795.3213,"caller":"leaderelection/leaderelection.go:255","msg":"failed to acquire lease capi-ibmcloud-system/effcf9b8.cluster.x-k8s.io","v":4}
{"ts":1727081941185.4644,"caller":"leaderelection/leaderelection.go:367","msg":"lock is held by capi-ibmcloud-controller-manager-7d574bbf58-ptbqk_4eaa0a09-0efc-4bd1-95f2-ae84e4ac9f47 and has not yet expired","v":4}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for JSON output format for logs
```
