### PR TITLE
CI: check if PowerVS instances are cleaned up in workspace before creating a cluster

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -43,12 +43,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	KubernetesVersion = "KUBERNETES_VERSION"
-	CNIPath           = "CNI"
-	CNIResources      = "CNI_RESOURCES"
-)
-
 // Test suite flags.
 var (
 	// configPath is the path to the e2e config file.

--- a/test/helpers/powervs.go
+++ b/test/helpers/powervs.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+)
+
+var (
+	pollingInterval                = time.Second * 30
+	powerVSInstanceDeletionTimeout = time.Minute * 10
+)
+
+const (
+	powervsInstanceDoesNotExist  = "pvm-instance does not exist"
+	powervsInstanceNotFound      = "could not be found"
+	powervsInstanceStateDeleting = "deleting"
+)
+
+// VerifyServerInstancesDeletion checks if the virtual server instances
+// are deleted in a given PowerVS workspace.
+func VerifyServerInstancesDeletion(serviceInstanceID string) error {
+	pclient, err := getPowerVSInstanceClient(serviceInstanceID)
+	if err != nil {
+		return err
+	}
+
+	instances, err := pclient.GetAll()
+	if err != nil {
+		return err
+	}
+
+	for _, ins := range instances.PvmInstances {
+		err = wait.PollUntilContextTimeout(context.Background(), pollingInterval, powerVSInstanceDeletionTimeout, false, func(_ context.Context) (done bool, err error) {
+			instance, err := pclient.Get(*ins.PvmInstanceID)
+			if err != nil {
+				if strings.Contains(err.Error(), powervsInstanceNotFound) || strings.Contains(err.Error(), powervsInstanceDoesNotExist) {
+					return true, nil
+				}
+				return false, err
+			}
+
+			if instance.TaskState == powervsInstanceStateDeleting {
+				return false, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getPowerVSInstanceClient(serviceInstanceID string) (*instance.IBMPIInstanceClient, error) {
+	auth, err := authenticator.GetAuthenticator()
+	if err != nil {
+		return nil, err
+	}
+
+	zone := os.Getenv("IBMPOWERVS_ZONE")
+	if zone == "" {
+		return nil, fmt.Errorf("IBMPOWERVS_ZONE is not set")
+	}
+
+	account, err := utils.GetAccount(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	piOptions := ibmpisession.IBMPIOptions{
+		Authenticator: auth,
+		UserAccount:   account,
+		Zone:          zone,
+		Debug:         true,
+	}
+
+	session, err := ibmpisession.NewIBMPISession(&piOptions)
+	if err != nil {
+		return nil, err
+	}
+	return instance.NewIBMPIInstanceClient(context.Background(), session, serviceInstanceID), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
 In PowerVS CI, we have seen a case where after the first test case, the VMs deletion is in progress and we proceed to create the second cluster. It leads to the error
```
Failed to allocate the network(s) with error No fixed IP addresses available for network
```
Adding this change to check if the instances are deleted before each cluster creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1877 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
check if PowerVS instances are cleaned up in workspace before creating a cluster
```
