### PR TITLE
The typo of Tokyo TG location in region mapping list

### DIFF
--- a/docs/book/src/reference/regions-zones-mapping.md
+++ b/docs/book/src/reference/regions-zones-mapping.md
@@ -13,7 +13,7 @@
 | Europe       | London, UK         |       lon       |   lon04<br>lon06   |     lon.power-iaas.cloud.ibm.com      |        eu-gb         |     eu-gb-1<br>eu-gb-2<br>eu-gb-3      |     eu-gb.iaas.cloud.ibm.com      | eu-gb                     |
 | Europe       | Madrid             |       mad       |     mad02          |     mad.power-iaas.cloud.ibm.com      |        eu-es         |     eu-es-1<br>eu-es-2<br>eu-es-3      |     eu-es.iaas.cloud.ibm.com      | eu-es                     |
 | Asia Pacific | Sydney, Australia  |       syd       |   syd04<br>syd05   |     syd.power-iaas.cloud.ibm.com      |        au-syd        |    au-syd-1<br>au-syd-2<br>au-syd-3    |     au-syd.iaas.cloud.ibm.com     | au-syd                    |
-| Asia Pacific | Tokyo, Japan       |       tok       |       tok04        |     tok.power-iaas.cloud.ibm.com      |        jp-tok        |    jp-tok-1<br>jp-tok-2<br>jp-tok-3    |     jp-tok.iaas.cloud.ibm.com     | jp-rok                    |
+| Asia Pacific | Tokyo, Japan       |       tok       |       tok04        |     tok.power-iaas.cloud.ibm.com      |        jp-tok        |    jp-tok-1<br>jp-tok-2<br>jp-tok-3    |     jp-tok.iaas.cloud.ibm.com     | jp-tok                    |
 | Asia Pacific | Osaka, Japan       |       osa       |       osa21        |     osa.power-iaas.cloud.ibm.com      |        jp-osa        |    jp-osa-1<br>jp-osa-2<br>jp-osa-3    |     jp-osa.iaas.cloud.ibm.com     | jp-osa                    | 
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: This PR addresses a typo in the region mapping list for the Tokyo TG location. The Tokyo location was previously listed as jp-rok instead of the correct jp-tok. This fix ensures that the Tokyo TG location is correctly identified as jp-tok.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2005 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
