### PR TITLE
Use ignition only when Ignition is set in IBMPowerVSCluster

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -131,6 +131,7 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	scope.IBMPowerVSMachine = params.IBMPowerVSMachine
 	scope.IBMPowerVSCluster = params.IBMPowerVSCluster
 	scope.IBMPowerVSImage = params.IBMPowerVSImage
+	scope.ServiceEndpoint = params.ServiceEndpoint
 
 	if params.Logger == (logr.Logger{}) {
 		params.Logger = klog.Background()
@@ -168,6 +169,7 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 		}
 		scope.Logger.V(3).Info("Overriding the default resource controller endpoint")
 	}
+	scope.ResourceClient = rc
 
 	var serviceInstanceID, serviceInstanceName string
 	if params.IBMPowerVSMachine.Spec.ServiceInstanceID != "" {
@@ -221,10 +223,6 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	scope.IBMPowerVSClient = c
 	scope.DHCPIPCacheStore = params.DHCPIPCacheStore
 
-	if !CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
-		return scope, nil
-	}
-
 	var vpcRegion string
 	if params.IBMPowerVSCluster.Spec.VPC == nil || params.IBMPowerVSCluster.Spec.VPC.Region == nil {
 		vpcRegion, err = regionUtil.VPCRegionForPowerVSRegion(scope.GetRegion())
@@ -239,10 +237,7 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	if err != nil {
 		return nil, fmt.Errorf("failed to create IBM VPC client: %w", err)
 	}
-
 	scope.IBMVPCClient = vpcClient
-	scope.ResourceClient = rc
-	scope.ServiceEndpoint = params.ServiceEndpoint
 	return scope, nil
 }
 
@@ -354,11 +349,11 @@ func (m *PowerVSMachineScope) CreateMachine() (*models.PVMInstanceReference, err
 }
 
 func (m *PowerVSMachineScope) resolveUserData() (string, error) {
-	userData, userDataFormat, err := m.GetRawBootstrapDataWithFormat()
+	userData, err := m.GetRawBootstrapData()
 	if err != nil {
 		return "", err
 	}
-	if m.UseIgnition(userDataFormat) {
+	if m.UseIgnition() {
 		data, err := m.ignitionUserData(userData)
 		if err != nil {
 			return "", err
@@ -512,9 +507,9 @@ func (m *PowerVSMachineScope) ignitionUserData(userData []byte) ([]byte, error) 
 	}
 }
 
-// UseIgnition returns true if user data format is of type 'ignition', else returns false.
-func (m *PowerVSMachineScope) UseIgnition(userDataFormat string) bool {
-	return userDataFormat == "ignition" || (m.IBMPowerVSCluster.Spec.Ignition != nil)
+// UseIgnition returns true if Ignition is set in IBMPowerVSCluster.
+func (m *PowerVSMachineScope) UseIgnition() bool {
+	return m.IBMPowerVSCluster.Spec.Ignition != nil
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
@@ -539,11 +534,11 @@ func (m *PowerVSMachineScope) DeleteMachine() error {
 
 // DeleteMachineIgnition deletes the ignition associated with machine.
 func (m *PowerVSMachineScope) DeleteMachineIgnition() error {
-	_, userDataFormat, err := m.GetRawBootstrapDataWithFormat()
+	_, err := m.GetRawBootstrapData()
 	if err != nil {
 		return err
 	}
-	if !m.UseIgnition(userDataFormat) {
+	if !m.UseIgnition() {
 		m.V(3).Info("Machine is not using user data of type ignition")
 		return nil
 	}
@@ -632,24 +627,24 @@ func (m *PowerVSMachineScope) createCOSClient() (*cos.Service, error) {
 	return cosClient, nil
 }
 
-// GetRawBootstrapDataWithFormat returns the bootstrap data if present.
-func (m *PowerVSMachineScope) GetRawBootstrapDataWithFormat() ([]byte, string, error) {
+// GetRawBootstrapData returns the bootstrap data if present.
+func (m *PowerVSMachineScope) GetRawBootstrapData() ([]byte, error) {
 	if m.Machine == nil || m.Machine.Spec.Bootstrap.DataSecretName == nil {
-		return nil, "", errors.New("failed to retrieve bootstrap data: linked Machine's bootstrap.dataSecretName is nil")
+		return nil, errors.New("failed to retrieve bootstrap data: linked Machine's bootstrap.dataSecretName is nil")
 	}
 
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: m.Machine.Namespace, Name: *m.Machine.Spec.Bootstrap.DataSecretName}
 	if err := m.Client.Get(context.TODO(), key, secret); err != nil {
-		return nil, "", fmt.Errorf("failed to retrieve bootstrap data secret for IBMPowerVSMachine %s/%s: %w", m.Machine.Namespace, m.Machine.Name, err)
+		return nil, fmt.Errorf("failed to retrieve bootstrap data secret for IBMPowerVSMachine %s/%s: %w", m.Machine.Namespace, m.Machine.Name, err)
 	}
 
 	value, ok := secret.Data["value"]
 	if !ok {
-		return nil, "", errors.New("failed to retrieve bootstrap data: secret value key is missing")
+		return nil, errors.New("failed to retrieve bootstrap data: secret value key is missing")
 	}
 
-	return value, string(secret.Data["format"]), nil
+	return value, nil
 }
 
 func getImageID(image *infrav1beta2.IBMPowerVSResourceReference, m *PowerVSMachineScope) (*string, error) {

--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -289,9 +289,11 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(machineScope *scope.PowerV
 		return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
 	}
 
-	if !scope.CheckCreateInfraAnnotation(*machineScope.IBMPowerVSCluster) {
+	if machineScope.IBMPowerVSCluster.Spec.VPC == nil || machineScope.IBMPowerVSCluster.Spec.VPC.Region == nil {
+		machineScope.Info("Skipping configuring machine to loadbalancer as VPC is not set")
 		return ctrl.Result{}, nil
 	}
+
 	// Register instance with load balancer
 	machineScope.Info("updating loadbalancer for machine", "name", machineScope.IBMPowerVSMachine.Name)
 	internalIP := machineScope.GetMachineInternalIP()

--- a/controllers/ibmpowervsmachine_controller_test.go
+++ b/controllers/ibmpowervsmachine_controller_test.go
@@ -512,6 +512,9 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1beta2.IBMPowerVSClusterSpec{
+						VPC: &infrav1beta2.VPCResourceReference{
+							Region: ptr.To("us-south"),
+						},
 						LoadBalancers: []infrav1beta2.VPCLoadBalancerSpec{
 							{
 								Name: "capi-test-lb",
@@ -603,6 +606,9 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1beta2.IBMPowerVSClusterSpec{
+						VPC: &infrav1beta2.VPCResourceReference{
+							Region: ptr.To("us-south"),
+						},
 						LoadBalancers: []infrav1beta2.VPCLoadBalancerSpec{
 							{
 								Name: "capi-test-lb",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR allows to create cos bucket and push ignition data to it only when IBMPowerVSCluster.Spec.Ignition is set because COS Instance is created only when this is [set](https://github.com/Karthik-K-N/cluster-api-provider-ibmcloud/blob/2a3745effaed2d825024566f8f876a3f25d8127f/controllers/ibmpowervscluster_controller.go#L311-L318).

Even if user data format is ignition and IBMPowerVSCluster.Spec.Ignition is nil, the code will eventually fail to [fetch cos ](https://github.com/Karthik-K-N/cluster-api-provider-ibmcloud/blob/5e43c6e5df57581d724dc70f49db76506f91a2c5/cloud/scope/powervs_machine.go#L584-L588)instance as it might not be created.

Removed create infra anotation checks in machine controller as it might not needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
