### PR TITLE
Explicitly return error incase of not able to set provider id in correct format

### DIFF
--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -248,7 +248,9 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(machineScope *scope.PowerV
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		machineScope.SetProviderID(instance.PvmInstanceID)
+		if err := machineScope.SetProviderID(*ins.PvmInstanceID); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to set provider id")
+		}
 		machineScope.SetInstanceID(instance.PvmInstanceID)
 		machineScope.SetAddresses(instance)
 		machineScope.SetHealth(instance.Health)

--- a/controllers/ibmpowervsmachine_controller_test.go
+++ b/controllers/ibmpowervsmachine_controller_test.go
@@ -512,6 +512,9 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1beta2.IBMPowerVSClusterSpec{
+						ServiceInstance: &infrav1beta2.IBMPowerVSResourceReference{
+							ID: ptr.To("serviceInstanceID"),
+						},
 						VPC: &infrav1beta2.VPCResourceReference{
 							Region: ptr.To("us-south"),
 						},
@@ -606,6 +609,9 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1beta2.IBMPowerVSClusterSpec{
+						ServiceInstance: &infrav1beta2.IBMPowerVSResourceReference{
+							ID: ptr.To("serviceInstanceID"),
+						},
 						VPC: &infrav1beta2.VPCResourceReference{
 							Region: ptr.To("us-south"),
 						},
@@ -708,9 +714,15 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						Ready: true,
 					},
 				},
-				IBMPowerVSClient:  mockpowervs,
-				DHCPIPCacheStore:  cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
-				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{},
+				IBMPowerVSClient: mockpowervs,
+				DHCPIPCacheStore: cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
+				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{
+					Spec: infrav1beta2.IBMPowerVSClusterSpec{
+						ServiceInstance: &infrav1beta2.IBMPowerVSResourceReference{
+							ID: ptr.To("serviceInstanceID"),
+						},
+					},
+				},
 			}
 
 			instanceReferences := &models.PVMInstances{
@@ -822,6 +834,9 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 					},
 				},
 				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ServiceInstance: &infrav1beta2.IBMPowerVSResourceReference{
+						ID: ptr.To("serviceInstanceID"),
+					},
 					LoadBalancers: []infrav1beta2.VPCLoadBalancerSpec{
 						{
 							Name: "capi-test-lb",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR modifies the logic around setting provider id.
There were many instances where provider id was not set properly and the cluster creation was not successfull. Main reason for that is service instance id being set empty.

Made changes to fetch service instance id from name if id not found in spec or status. This case will occur mainly when cluster is reconciled by external controller.
Made changes to return error instead of empty string in case of not able to find service instance id.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
