### PR TITLE
Support bootstrap only additional listener

### DIFF
--- a/api/v1beta2/ibmvpccluster_types.go
+++ b/api/v1beta2/ibmvpccluster_types.go
@@ -127,6 +127,11 @@ type AdditionalListenerSpec struct {
 	// Will default to TCP protocol if not specified.
 	// +optional
 	Protocol *VPCLoadBalancerListenerProtocol `json:"protocol,omitempty"`
+
+	// Add defines which VMs are added to this pool.  If empty, it will default to all VMs.
+	// +kubebuilder:validation:Enum=all;bootstrap_only;masters_only
+	// +optional
+	Add VPCLoadBalancerPoolAdd `json:"add,omitempty"`
 }
 
 // VPCLoadBalancerBackendPoolSpec defines the desired configuration of a VPC Load Balancer Backend Pool.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -117,6 +117,21 @@ var (
 	TransitGatewayConnectionStateDeleting = TransitGatewayConnectionState("deleting")
 )
 
+// VPCLoadBalancerPoolAdd describes which VMs are added to the pool.
+// +kubebuilder:validation:Enum=all;bootstrap_only;masters_only
+type VPCLoadBalancerPoolAdd string
+
+var (
+	// VPCLoadBalancerPoolAddAll is the string representing that every VM should be added to the pool.
+	VPCLoadBalancerPoolAddAll = VPCLoadBalancerPoolAdd("all")
+
+	// VPCLoadBalancerPoolAddBootstrapOnly is the string representing that only the bootstrap VM should be added to the pool.
+	VPCLoadBalancerPoolAddBootstrapOnly = VPCLoadBalancerPoolAdd("bootstrap_only")
+
+	// VPCLoadBalancerPoolAddMastersOnly is the string representing that only master VMs should be added to the pool.
+	VPCLoadBalancerPoolAddMastersOnly = VPCLoadBalancerPoolAdd("masters_only")
+)
+
 // VPCLoadBalancerBackendPoolAlgorithm describes the backend pool's load balancing algorithm.
 // +kubebuilder:validation:Enum=least_connections;round_robin;weighted_round_robin
 type VPCLoadBalancerBackendPoolAlgorithm string

--- a/cloud/scope/vpc_cluster.go
+++ b/cloud/scope/vpc_cluster.go
@@ -1967,7 +1967,7 @@ func (s *VPCClusterScope) createLoadBalancer(loadBalancer infrav1beta2.VPCLoadBa
 		for _, additionalListener := range loadBalancer.AdditionalListeners {
 			listener := s.buildLoadBalancerListener(additionalListener)
 
-			s.V(3).Info("addd listener to load balancer", "loadBalancerName", loadBalancer.Name, "listenerPort", listener.Port)
+			s.V(3).Info("added listener to load balancer", "loadBalancerName", loadBalancer.Name, "listenerPort", listener.Port)
 			listeners = append(listeners, listener)
 		}
 	} else {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -275,6 +275,19 @@ spec:
                           AdditionalListenerSpec defines the desired state of an
                           additional listener on an VPC load balancer.
                         properties:
+                          add:
+                            allOf:
+                            - enum:
+                              - all
+                              - bootstrap_only
+                              - masters_only
+                            - enum:
+                              - all
+                              - bootstrap_only
+                              - masters_only
+                            description: Add defines which VMs are added to this pool.  If
+                              empty, it will default to all VMs.
+                            type: string
                           defaultPoolName:
                             description: defaultPoolName defines the name of a VPC
                               Load Balancer Backend Pool to use for the VPC Load Balancer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -305,6 +305,20 @@ spec:
                                   AdditionalListenerSpec defines the desired state of an
                                   additional listener on an VPC load balancer.
                                 properties:
+                                  add:
+                                    allOf:
+                                    - enum:
+                                      - all
+                                      - bootstrap_only
+                                      - masters_only
+                                    - enum:
+                                      - all
+                                      - bootstrap_only
+                                      - masters_only
+                                    description: Add defines which VMs are added to
+                                      this pool.  If empty, it will default to all
+                                      VMs.
+                                    type: string
                                   defaultPoolName:
                                     description: defaultPoolName defines the name
                                       of a VPC Load Balancer Backend Pool to use for

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
@@ -260,6 +260,19 @@ spec:
                         AdditionalListenerSpec defines the desired state of an
                         additional listener on an VPC load balancer.
                       properties:
+                        add:
+                          allOf:
+                          - enum:
+                            - all
+                            - bootstrap_only
+                            - masters_only
+                          - enum:
+                            - all
+                            - bootstrap_only
+                            - masters_only
+                          description: Add defines which VMs are added to this pool.  If
+                            empty, it will default to all VMs.
+                          type: string
                         defaultPoolName:
                           description: defaultPoolName defines the name of a VPC Load
                             Balancer Backend Pool to use for the VPC Load Balancer
@@ -532,6 +545,19 @@ spec:
                               AdditionalListenerSpec defines the desired state of an
                               additional listener on an VPC load balancer.
                             properties:
+                              add:
+                                allOf:
+                                - enum:
+                                  - all
+                                  - bootstrap_only
+                                  - masters_only
+                                - enum:
+                                  - all
+                                  - bootstrap_only
+                                  - masters_only
+                                description: Add defines which VMs are added to this
+                                  pool.  If empty, it will default to all VMs.
+                                type: string
                               defaultPoolName:
                                 description: defaultPoolName defines the name of a
                                   VPC Load Balancer Backend Pool to use for the VPC

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
@@ -108,6 +108,19 @@ spec:
                                 AdditionalListenerSpec defines the desired state of an
                                 additional listener on an VPC load balancer.
                               properties:
+                                add:
+                                  allOf:
+                                  - enum:
+                                    - all
+                                    - bootstrap_only
+                                    - masters_only
+                                  - enum:
+                                    - all
+                                    - bootstrap_only
+                                    - masters_only
+                                  description: Add defines which VMs are added to
+                                    this pool.  If empty, it will default to all VMs.
+                                  type: string
                                 defaultPoolName:
                                   description: defaultPoolName defines the name of
                                     a VPC Load Balancer Backend Pool to use for the
@@ -389,6 +402,20 @@ spec:
                                       AdditionalListenerSpec defines the desired state of an
                                       additional listener on an VPC load balancer.
                                     properties:
+                                      add:
+                                        allOf:
+                                        - enum:
+                                          - all
+                                          - bootstrap_only
+                                          - masters_only
+                                        - enum:
+                                          - all
+                                          - bootstrap_only
+                                          - masters_only
+                                        description: Add defines which VMs are added
+                                          to this pool.  If empty, it will default
+                                          to all VMs.
+                                        type: string
                                       defaultPoolName:
                                         description: defaultPoolName defines the name
                                           of a VPC Load Balancer Backend Pool to use


### PR DESCRIPTION
Add an option to the AdditionalListenerSpec to signify that this pool should only contain the boostrap node.  An example of this would be for port 22 since every master node also has ssh but we need the public load balancer to only connect to the bootstrap ssh server and not randomly to any one of the four nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
