### PR TITLE
Fix warnings in kustomization file

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
@@ -18,29 +16,14 @@ resources:
 - bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_ibmvpcclusters.yaml
-- patches/webhook_in_ibmvpcmachines.yaml
-- patches/webhook_in_ibmpowervsclusters.yaml
-- patches/webhook_in_ibmpowervsmachines.yaml
-- patches/webhook_in_ibmpowervsmachinetemplates.yaml
-- patches/webhook_in_ibmvpcmachinetemplates.yaml
-- patches/webhook_in_ibmpowervsimages.yaml
 #- patches/webhook_in_ibmpowervsclustertemplates.yaml
 #- patches/webhook_in_ibmvpcclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_ibmvpcclusters.yaml
-- patches/cainjection_in_ibmvpcmachines.yaml
-- patches/cainjection_in_ibmpowervsclusters.yaml
-- patches/cainjection_in_ibmpowervsmachines.yaml
-- patches/cainjection_in_ibmpowervsmachinetemplates.yaml
-- patches/cainjection_in_ibmvpcmachinetemplates.yaml
-- patches/cainjection_in_ibmpowervsimages.yaml
 #- patches/cainjection_in_ibmpowervsclustertemplates.yaml
 #- patches/cainjection_in_ibmvpcclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
@@ -48,3 +31,22 @@ patchesStrategicMerge:
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
+patches:
+- path: patches/webhook_in_ibmvpcclusters.yaml
+- path: patches/webhook_in_ibmvpcmachines.yaml
+- path: patches/webhook_in_ibmpowervsclusters.yaml
+- path: patches/webhook_in_ibmpowervsmachines.yaml
+- path: patches/webhook_in_ibmpowervsmachinetemplates.yaml
+- path: patches/webhook_in_ibmvpcmachinetemplates.yaml
+- path: patches/webhook_in_ibmpowervsimages.yaml
+- path: patches/cainjection_in_ibmvpcclusters.yaml
+- path: patches/cainjection_in_ibmvpcmachines.yaml
+- path: patches/cainjection_in_ibmpowervsclusters.yaml
+- path: patches/cainjection_in_ibmpowervsmachines.yaml
+- path: patches/cainjection_in_ibmpowervsmachinetemplates.yaml
+- path: patches/cainjection_in_ibmvpcmachinetemplates.yaml
+- path: patches/cainjection_in_ibmpowervsimages.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,64 +8,213 @@ namespace: capi-ibmcloud-system
 # field above.
 namePrefix: capi-ibmcloud-
 
-commonLabels:
-  cluster.x-k8s.io/provider: "infrastructure-ibmcloud"
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml
-- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
 #- ../prometheus
 
 resources:
 - credentials.yaml
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
 
-patchesStrategicMerge:
-- manager_credentials_patch.yaml
-- manager_image_patch.yaml
-- manager_pull_policy.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: infrastructure-ibmcloud
+patches:
+- path: manager_credentials_patch.yaml
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+- path: manager_webhook_patch.yaml
+- path: webhookcainjection_patch.yaml
+replacements:
+- source:
+    fieldPath: metadata.namespace
     kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsclusters.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsimages.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsmachines.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcclusters.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcmachines.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcmachinetemplates.infrastructure.cluster.x-k8s.io
+- source:
+    fieldPath: metadata.name
     kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsclusters.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsimages.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsmachines.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcclusters.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcmachines.infrastructure.cluster.x-k8s.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: ibmvpcmachinetemplates.infrastructure.cluster.x-k8s.io
+- source:
+    fieldPath: metadata.name
     kind: Service
-    version: v1
     name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
+  targets:
+  - fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+    select:
+      kind: Certificate
+      name: serving-cert
+- source:
+    fieldPath: metadata.namespace
     kind: Service
-    version: v1
     name: webhook-service
+  targets:
+  - fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1
+    select:
+      kind: Certificate
+      name: serving-cert

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation/kustomization.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../../../templates/cluster-template-powervs-cloud-provider.yaml
-patchesStrategicMerge:
-  - patches/mhc-label.yaml
+- ../../../../../templates/cluster-template-powervs-cloud-provider.yaml
+patches:
+- path: patches/mhc-label.yaml


### PR DESCRIPTION
**What this PR does / why we need it**: Fix Warnings in Kustomization file

`make release
`
```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```


Description:

1. Replace bases with resources
Diff:
bases (deprecated): This field was used to reference other directories or resources (e.g., CRDs, namespaces, etc.) as "bases" from which resources would be pulled.
resources (recommended): The resources field is now used to include external files or resources directly. Kustomize now uses resources instead of bases for the same purpose.
Migration Approach:
Replacing the bases field with resources, using the same paths.
Before:

```
bases:
  - ../crd
  - ../rbac
```
  
After:

```
resources:
  - ../crd
  - ../rbac
```

2. Replace commonLabels with labels
Diff:
commonLabels (deprecated): The commonLabels field was used to apply common labels to all resources within the kustomization.
labels (recommended): The labels field now serves the same purpose as commonLabels, but with more flexibility and consistent behavior.
Migration Approach:
Replacing the commonLabels field with labels, ensuring that the structure matches the new format for labels.
Before:

```
commonLabels:
  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
```

After:

```
labels:
  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
```

3. Replace patchesStrategicMerge with patches
Diff:
patchesStrategicMerge (deprecated): This field was used to apply strategic merge patches to the resources defined in the Kustomization.
patches (recommended): The patches field is now used to apply patches (both strategic and JSON patch) to resources. The main difference is that patches supports both strategicMerge and jsonPatch types.
Migration Approach:
Replacing the patchesStrategicMerge field with the patches field. The structure of the patches will stay mostly the same, but now it supports a wider variety of patch types.

Before:

[patchesStrategicMerge:
  - patches/webhook_in_ibmvpcclusters.yaml
  
After:

```
patches:
  - path: patches/webhook_in_ibmvpcclusters.yaml
```
  
4. Replace vars with replacements
Diff:
vars (deprecated): The vars field was used to define variables that could be used for substitution throughout the Kustomization file.
replacements (recommended): The replacements field provides a more explicit way to define variable substitutions. It allows you to specify where the values are coming from (source) and where they should be applied (target).
Migration Approach:
For each variable defined in vars, create a replacements entry. This involves specifying the source field and the target field for the substitution.

Before:

```
vars:
- name: SERVICE_NAMESPACE # namespace of the service
  objref:
    kind: Service
    version: v1
    name: webhook-service
  fieldref:
    fieldpath: metadata.namespace
- name: SERVICE_NAME
  objref:
    kind: Service
    version: v1
    name: webhook-service
```

After:

```
replacements:
- source:
    fieldPath: metadata.name
    kind: Service
    name: webhook-service
  targets:
  - fieldPaths:
    - spec.dnsNames.0
    - spec.dnsNames.1
    options:
      delimiter: .
    select:
      kind: Certificate
      name: serving-cert
- source:
    fieldPath: metadata.namespace
    kind: Service
    name: webhook-service
  targets:
  - fieldPaths:
    - spec.dnsNames.0
    - spec.dnsNames.1
    options:
      delimiter: .
      index: 1
    select:
      kind: Certificate
      name: serving-cert
```

Test:

`kustomize build . --stack-trace > sample.yaml`

<img width="1001" alt="Screenshot 2024-11-29 at 3 24 07 AM" src="https://github.com/user-attachments/assets/1aaef04a-9f75-4f6f-b9a8-78bfbe250fe5">


**Which issue(s) this PR fixes**:
Fixes #2061 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
