### PR TITLE
Bumped go.mod version in tools

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/cluster-api-provider-ibmcloud/hack/tools
 
 go 1.22.9
 
-toolchain go1.22.9
-
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0
 
 require (

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-ibmcloud/hack/tools
 
-go 1.22.0
+go 1.22.9
 
 toolchain go1.22.9
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Fixes the lint failure here: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2071
This is happening because dependabot does not update the go.mod version automatically and our CI checks that running `go mod tidy` does not make any further changes to the go.mod file. The version change is happening because go-lint depends on version 1.22.1 which is due to this dependency in go-lint: honnef.co/go/tools

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
