### PR TITLE
Enhanced updateCondition function

### DIFF
--- a/controllers/ibmpowervscluster_controller.go
+++ b/controllers/ibmpowervscluster_controller.go
@@ -128,15 +128,10 @@ type reconcileResult struct {
 	error
 }
 
-func (update *powerVSCluster) updateCondition(condition bool, conditionArgs ...interface{}) {
+func (update *powerVSCluster) updateCondition(condition capiv1beta1.Condition) {
 	update.mu.Lock()
 	defer update.mu.Unlock()
-	if condition {
-		conditions.MarkTrue(update.cluster, conditionArgs[0].(capiv1beta1.ConditionType))
-		return
-	}
-
-	conditions.MarkFalse(update.cluster, conditionArgs[0].(capiv1beta1.ConditionType), conditionArgs[1].(string), conditionArgs[2].(capiv1beta1.ConditionSeverity), conditionArgs[3].(string), conditionArgs[4:]...)
+	conditions.Set(update.cluster, &condition)
 }
 
 func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(clusterScope *scope.PowerVSClusterScope, powerVSCluster *powerVSCluster, ch chan reconcileResult, wg *sync.WaitGroup) {
@@ -146,7 +141,13 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(clusterScope *sc
 	powerVSLog.Info("Reconciling PowerVS service instance")
 	if requeue, err := clusterScope.ReconcilePowerVSServiceInstance(); err != nil {
 		powerVSLog.Error(err, "failed to reconcile PowerVS service instance")
-		powerVSCluster.updateCondition(false, infrav1beta2.ServiceInstanceReadyCondition, infrav1beta2.ServiceInstanceReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.ServiceInstanceReadyCondition,
+			Reason:   infrav1beta2.ServiceInstanceReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	} else if requeue {
@@ -154,7 +155,10 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(clusterScope *sc
 		ch <- reconcileResult{reconcile.Result{Requeue: true}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(true, infrav1beta2.ServiceInstanceReadyCondition)
+	powerVSCluster.updateCondition(capiv1beta1.Condition{
+		Status: corev1.ConditionTrue,
+		Type:   infrav1beta2.ServiceInstanceReadyCondition,
+	})
 
 	clusterScope.IBMPowerVSClient.WithClients(powervs.ServiceOptions{CloudInstanceID: clusterScope.GetServiceInstanceID()})
 
@@ -162,11 +166,20 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(clusterScope *sc
 	powerVSLog.Info("Reconciling network")
 	if networkActive, err := clusterScope.ReconcileNetwork(); err != nil {
 		powerVSLog.Error(err, "failed to reconcile PowerVS network")
-		powerVSCluster.updateCondition(false, infrav1beta2.NetworkReadyCondition, infrav1beta2.NetworkReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.NetworkReadyCondition,
+			Reason:   infrav1beta2.NetworkReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	} else if networkActive {
-		powerVSCluster.updateCondition(true, infrav1beta2.NetworkReadyCondition)
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status: corev1.ConditionTrue,
+			Type:   infrav1beta2.NetworkReadyCondition,
+		})
 		return
 	}
 	// Do not want to block the reconciliation of other resources like setting up TG and COS, so skipping the requeue and only logging the info.
@@ -179,7 +192,13 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(clusterScope *scope.
 	vpcLog.Info("Reconciling VPC")
 	if requeue, err := clusterScope.ReconcileVPC(); err != nil {
 		clusterScope.Error(err, "failed to reconcile VPC")
-		powerVSCluster.updateCondition(false, infrav1beta2.VPCReadyCondition, infrav1beta2.VPCReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.VPCReadyCondition,
+			Reason:   infrav1beta2.VPCReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	} else if requeue {
@@ -187,13 +206,22 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(clusterScope *scope.
 		ch <- reconcileResult{reconcile.Result{Requeue: true}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(true, infrav1beta2.VPCReadyCondition)
+	powerVSCluster.updateCondition(capiv1beta1.Condition{
+		Status: corev1.ConditionTrue,
+		Type:   infrav1beta2.VPCReadyCondition,
+	})
 
 	// reconcile VPC Subnet
 	vpcLog.Info("Reconciling VPC subnets")
 	if requeue, err := clusterScope.ReconcileVPCSubnets(); err != nil {
 		vpcLog.Error(err, "failed to reconcile VPC subnets")
-		powerVSCluster.updateCondition(false, infrav1beta2.VPCSubnetReadyCondition, infrav1beta2.VPCSubnetReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.VPCSubnetReadyCondition,
+			Reason:   infrav1beta2.VPCSubnetReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	} else if requeue {
@@ -201,27 +229,48 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(clusterScope *scope.
 		ch <- reconcileResult{reconcile.Result{Requeue: true}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(true, infrav1beta2.VPCSubnetReadyCondition)
+	powerVSCluster.updateCondition(capiv1beta1.Condition{
+		Status: corev1.ConditionTrue,
+		Type:   infrav1beta2.VPCSubnetReadyCondition,
+	})
 
 	// reconcile VPC security group
 	vpcLog.Info("Reconciling VPC security group")
 	if err := clusterScope.ReconcileVPCSecurityGroups(); err != nil {
 		vpcLog.Error(err, "failed to reconcile VPC security groups")
-		powerVSCluster.updateCondition(false, infrav1beta2.VPCSecurityGroupReadyCondition, infrav1beta2.VPCSecurityGroupReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.VPCSecurityGroupReadyCondition,
+			Reason:   infrav1beta2.VPCSecurityGroupReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	}
-	powerVSCluster.updateCondition(true, infrav1beta2.VPCSecurityGroupReadyCondition)
+	powerVSCluster.updateCondition(capiv1beta1.Condition{
+		Status: corev1.ConditionTrue,
+		Type:   infrav1beta2.VPCSecurityGroupReadyCondition,
+	})
 
 	// reconcile LoadBalancer
 	vpcLog.Info("Reconciling VPC load balancers")
 	if loadBalancerReady, err := clusterScope.ReconcileLoadBalancers(); err != nil {
 		vpcLog.Error(err, "failed to reconcile VPC load balancers")
-		powerVSCluster.updateCondition(false, infrav1beta2.LoadBalancerReadyCondition, infrav1beta2.LoadBalancerReconciliationFailedReason, capiv1beta1.ConditionSeverityError, err.Error())
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1beta2.LoadBalancerReadyCondition,
+			Reason:   infrav1beta2.LoadBalancerReconciliationFailedReason,
+			Severity: capiv1beta1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		ch <- reconcileResult{reconcile.Result{}, err}
 		return
 	} else if loadBalancerReady {
-		powerVSCluster.updateCondition(true, infrav1beta2.LoadBalancerReadyCondition)
+		powerVSCluster.updateCondition(capiv1beta1.Condition{
+			Status: corev1.ConditionTrue,
+			Type:   infrav1beta2.LoadBalancerReadyCondition,
+		})
 		return
 	}
 	// Do not want to block the reconciliation of other resources like setting up TG and COS, so skipping the requeue and only logging the info.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The existing implementation of `updateCondition` in IBM PowerVS Cluster Controller was a bit problematic as it expected interface type, Without the length and type check we could run into null pointer dereferencing and index out of bound conditions. This PR helps resolve the same. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2115 

**Special notes for your reviewer**:
For testing my changes, I made a local setup using tilt and created the cluster using following command:
```
IBMCLOUD_API_KEY=<api-key-here> \
  IBMPOWERVS_SSHKEY_NAME="sharath-sshkey" \
  COS_BUCKET_REGION="us-south" \
  COS_BUCKET_NAME="power-oss-bucket" \
  COS_OBJECT_NAME=capibm-powervs-centos-streams8-1-28-4-1707287079.ova.gz \
  IBMACCOUNT_ID="c265c8cefda241ca9c107adcbbacaa84" \
  IBMPOWERVS_REGION="wdc" \
  IBMPOWERVS_ZONE="wdc06" \
  IBMVPC_REGION="us-east" \
  IBM_RESOURCE_GROUP="ibm-hypershift-dev" \
  BASE64_API_KEY=$(echo -n $IBMCLOUD_API_KEY | base64) \
  clusterctl generate cluster capi-powervs --kubernetes-version v1.28.4 \
  --target-namespace default \
  --control-plane-machine-count=3 \
  --worker-machine-count=1 \
  --from=./templates/cluster-template-powervs-create-infra.yaml | kubectl apply -f -
```

I observed that the conditions were true for all resources as shown below:
```
Status:
  Conditions:
    Last Transition Time:  2025-01-15T10:51:24Z
    Status:                True
    Type:                  LoadBalancerReady
    Last Transition Time:  2025-01-15T10:53:54Z
    Status:                True
    Type:                  NetworkReady
    Last Transition Time:  2025-01-15T10:44:20Z
    Status:                True
    Type:                  ServiceInstanceReady
    Last Transition Time:  2025-01-15T10:48:26Z
    Status:                True
    Type:                  TransitGatewayReady
    Last Transition Time:  2025-01-15T10:43:58Z
    Status:                True
    Type:                  VPCReady
    Last Transition Time:  2025-01-15T10:44:03Z
    Status:                True
    Type:                  VPCSecurityGroupReady
    Last Transition Time:  2025-01-15T10:44:03Z
    Status:                True
    Type:                  VPCSubnetReady
``` 

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
