### PR TITLE
BUG: IBM Cloud Infra: Return existing VPC ID

### DIFF
--- a/cloud/scope/vpc_cluster.go
+++ b/cloud/scope/vpc_cluster.go
@@ -496,12 +496,13 @@ func (s *VPCClusterScope) GetVPCID() (*string, error) {
 
 			// Check if the VPC was found and has an ID
 			if vpcDetails != nil && vpcDetails.ID != nil {
-				// Set VPC ID in Status to shortcut future lookups
+				// Set VPC ID in Status to shortcut future lookups, prior to returning the ID.
 				s.SetResourceStatus(infrav1beta2.ResourceTypeVPC, &infrav1beta2.ResourceStatus{
 					ID:    *vpcDetails.ID,
 					Name:  s.NetworkSpec().VPC.Name,
 					Ready: true,
 				})
+				return vpcDetails.ID, nil
 			}
 		}
 	}


### PR DESCRIPTION
Fix bug where an existing VPC ID that was found, was not being returned, resulting in attempts to recreate the VPC.

Related: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2140

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Resolves 2140

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug when an existing vpc is provided for IBM Cloud Infrastructure but attempts are still made to create it 
```
