### PR TITLE
Bump PowerVS CI to k8s v1.31

### DIFF
--- a/docs/book/src/machine-images/powervs.md
+++ b/docs/book/src/machine-images/powervs.md
@@ -3,6 +3,7 @@
 
 | Region   | Bucket           | Object                                                          | Kubernetes Version |
 |----------|------------------|-----------------------------------------------------------------|--------------------|
+| us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-31-0-1737533452.ova.gz][capibm-powervs-centos-streams9-1-31-0] | 1.31.0             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams8-1-29-3.ova.gz][streams8-1-29-3] | 1.29.3             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams8-1-28-4.ova.gz][streams8-1-28-4] | 1.28.4             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams8-1-27-2.ova.gz][streams8-1-27-2] | 1.27.2             |
@@ -22,6 +23,7 @@
 
 > **Note:** These images are built using the [image-builder][image-builder] tool and more information can be found [here](../developer/build-images.md#powervs)
 
+[centos-streams9-1-31-0]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-31-0-1737533452.ova.gz
 [centos-streams9-1-29-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-29-3-1719470782.ova.gz
 [centos-streams8-1-28-4]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams8-1-28-4-1707287079.ova.gz
 [streams8-1-29-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams8-1-29-3.ova.gz

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -124,7 +124,7 @@ init_network_powervs(){
 prerequisites_powervs(){
     # Assigning PowerVS variables
     export IBMPOWERVS_SSHKEY_NAME=${IBMPOWERVS_SSHKEY_NAME:-"powercloud-bot-key"}
-    export IBMPOWERVS_IMAGE_NAME=${IBMPOWERVS_IMAGE_NAME:-"capibm-powervs-centos-streams8-1-29-3"}
+    export IBMPOWERVS_IMAGE_NAME=${IBMPOWERVS_IMAGE_NAME:-"capibm-powervs-centos-streams9-1-31-0"}
     export IBMPOWERVS_SERVICE_INSTANCE_ID=${BOSKOS_RESOURCE_ID:-"d53da3bf-1f4a-42fa-9735-acf16b1a05cd"}
     export IBMPOWERVS_NETWORK_NAME="capi-net-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head --bytes 5)"
     export ZONE=${BOSKOS_ZONE:-"osa21"}

--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -42,7 +42,7 @@ providers:
         targetName: "cluster-template-powervs-md-remediation.yaml"
 
 variables:
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.29.3}"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.31.0}"
   # Below variable should be set based on the targeted environment
   SERVICE_ENDPOINT: "${SERVICE_ENDPOINT:-}"
   # Cluster Addons


### PR DESCRIPTION
What this PR does / why we need it:
Bump PowerVS CI to k8s v1.31

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #2084 

Special notes for your reviewer:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Release note:

`Bump PowerVS CI to k8s v1.31`