### PR TITLE
Build and publish vpc image for k8s version 1.31.4

### DIFF
--- a/docs/book/src/machine-images/vpc.md
+++ b/docs/book/src/machine-images/vpc.md
@@ -3,6 +3,7 @@
 
 | Region   | Bucket           | Object                                                   | Kubernetes Version |
 |----------|------------------|----------------------------------------------------------|--------------------|
+| us-south | power-oss-bucket | [capibm-vpc-ubuntu-2204-kube-v1-31-4.qcow2][kube-1-31-4] | 1.31.4   
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2204-kube-v1-29-3.qcow2][kube-1-29-3] | 1.29.3             |
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2004-kube-v1-28-4.qcow2][kube-1-28-4] | 1.28.4             |
 | us-south | power-oss-bucket | [capibm-vpc-ubuntu-2004-kube-v1-27-2.qcow2][kube-1-27-2] | 1.27.2             |
@@ -12,6 +13,7 @@
 
 Note: These images are built using the [image-builder][image-builder] tool and more information can be found [here](../developer/build-images.md#vpc)
 
+[kube-1-31-4]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2204-kube-v1-31-4.qcow2
 [kube-1-29-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2204-kube-v1-29-3.qcow2
 [kube-1-28-4]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2004-kube-v1-28-4.qcow2
 [kube-1-27-2]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-vpc-ubuntu-2004-kube-v1-27-2.qcow2

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -139,7 +139,7 @@ prerequisites_vpc(){
     export IBMVPC_ZONE="${IBMVPC_REGION}-1"
     export IBMVPC_RESOURCEGROUP=${BOSKOS_RESOURCE_GROUP:-"fa5405a58226402f9a5818cb9b8a5a8a"}
     export IBMVPC_NAME=${BOSKOS_RESOURCE_NAME:-"capi-vpc-e2e"}
-    export IBMVPC_IMAGE_NAME=${IBMVPC_IMAGE_NAME:-"capibm-vpc-ubuntu-2204-kube-v1-29-3"}
+    export IBMVPC_IMAGE_NAME=${IBMVPC_IMAGE_NAME:-"capibm-vpc-ubuntu-2204-kube-v1-31-4"}
     export IBMVPC_PROFILE=${IBMVPC_PROFILE:-"bx2-4x16"}
     export IBMVPC_SSHKEY_NAME=${IBMVPC_SSHKEY_NAME:-"vpc-cloud-bot-key"}
 }

--- a/test/e2e/config/ibmcloud-e2e-vpc.yaml
+++ b/test/e2e/config/ibmcloud-e2e-vpc.yaml
@@ -42,7 +42,7 @@ providers:
         targetName: "cluster-template-vpc.yaml"
 
 variables:
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.29.3}"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.31.4}"
   # Below variable should be set based on the targeted environment
   SERVICE_ENDPOINT: "${SERVICE_ENDPOINT:-}"
   # Cluster Addons


### PR DESCRIPTION

**What this PR does / why we need it**: Bump VPC CI to k8s v1.31


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


/area provider/ibmcloud

