### PR TITLE
Infra: Fix Machine GT endpoint management

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/globaltagging"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
@@ -104,8 +105,17 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		core.SetLoggingLevel(core.LevelDebug)
 	}
 
+	auth, err := authenticator.GetAuthenticator()
+	if err != nil {
+		return nil, fmt.Errorf("error failed to create authenticator: %w", err)
+	}
+
 	// Create Global Tagging client.
-	gtOptions := globaltagging.ServiceOptions{}
+	gtOptions := globaltagging.ServiceOptions{
+		GlobalTaggingV1Options: &globaltaggingv1.GlobalTaggingV1Options{
+			Authenticator: auth,
+		},
+	}
 	// Override the Global Tagging endpoint if provided.
 	if gtEndpoint := endpoints.FetchEndpoints(string(endpoints.GlobalTagging), params.ServiceEndpoint); gtEndpoint != "" {
 		gtOptions.URL = gtEndpoint


### PR DESCRIPTION
Fix the Infrastructure Machine management for Global Tagging service and endpoints.

Related: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2231

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fixes Infrastructure Machine endpoint override for GlobalTagging

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2231 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix globaltagging endpoint override for infrastructure machines
```
