### PR TITLE
remove cloud-provider flag for kube-apiserver due to removal in v1.33

### DIFF
--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -87,8 +87,6 @@ spec:
             certSANs:
             - ${IBMPOWERVS_VIP}
             - ${IBMPOWERVS_VIP_EXTERNAL}
-            extraArgs:
-              cloud-provider: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -87,8 +87,6 @@ spec:
             certSANs:
               - "${IBMPOWERVS_VIP}"
               - "${IBMPOWERVS_VIP_EXTERNAL}"
-            extraArgs:
-              cloud-provider: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -57,9 +57,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -48,8 +48,6 @@ spec:
         certSANs:
         - ${IBMPOWERVS_VIP}
         - ${IBMPOWERVS_VIP_EXTERNAL}
-        extraArgs:
-          cloud-provider: external
       controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-powervs/kcp.yaml
+++ b/templates/cluster-template-powervs/kcp.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-vpc-clusterclass.yaml
+++ b/templates/cluster-template-vpc-clusterclass.yaml
@@ -92,8 +92,6 @@ spec:
             certSANs:
             - localhost
             - 127.0.0.1
-            extraArgs:
-              cloud-provider: external
           controllerManager:
             extraArgs:
               cloud-provider: external

--- a/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
@@ -91,8 +91,6 @@ spec:
           kubernetesVersion: ${KUBERNETES_VERSION}
           apiServer:
             certSANs: [localhost, 127.0.0.1]
-            extraArgs:
-              cloud-provider: external
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: 'true'

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -52,8 +52,6 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template/kcp.yaml
+++ b/templates/cluster-template/kcp.yaml
@@ -9,6 +9,3 @@ spec:
       controllerManager:
         extraArgs:
           cloud-provider: external
-      apiServer:
-        extraArgs:
-          cloud-provider: external


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
ref: https://github.com/kubernetes/kubernetes/pull/130162
Without this, the templates used set the flag --cloud-provider=external, lead APIServer not starting due to unknown flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2224

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove cloud-provider flag for kube-apiserver due to removal in v1.33
```
