### PR TITLE
Fix priority between network and DHCP server

### DIFF
--- a/api/v1beta2/ibmpowervscluster_types.go
+++ b/api/v1beta2/ibmpowervscluster_types.go
@@ -42,7 +42,7 @@ type IBMPowerVSClusterSpec struct {
 	// 1. in the case of DHCPServer.Name is not set the name will be DHCPSERVER<CLUSTER_NAME>_Private.
 	// 2. if DHCPServer.Name is set the name will be DHCPSERVER<DHCPServer.Name>_Private.
 	// when Network.ID is set, its expected that there exist a network in PowerVS workspace with id or else system will give error.
-	// when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist network will be created by DHCP service.
+	// when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist system will check DHCP network with given Network.name, if that also not exist, it will create a new DHCP service and name will be DHCPSERVER<Network.Name>_Private.
 	// Network.RegEx is not yet supported and system will ignore the value.
 	Network IBMPowerVSResourceReference `json:"network"`
 

--- a/cloud/scope/powervs_cluster_test.go
+++ b/cloud/scope/powervs_cluster_test.go
@@ -2767,22 +2767,6 @@ func TestGetServiceName(t *testing.T) {
 			expectedName: ptr.To("ServiceInstanceName"),
 		},
 		{
-			name:         "Resource type is network and Network is nil",
-			resourceType: infrav1beta2.ResourceTypeNetwork,
-			clusterScope: PowerVSClusterScope{
-				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{ObjectMeta: metav1.ObjectMeta{Name: "ClusterName"}},
-			},
-			expectedName: ptr.To("DHCPSERVERClusterName_Private"),
-		},
-		{
-			name:         "Resource type is network and Network is not nil",
-			resourceType: infrav1beta2.ResourceTypeNetwork,
-			clusterScope: PowerVSClusterScope{
-				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{Spec: infrav1beta2.IBMPowerVSClusterSpec{Network: infrav1beta2.IBMPowerVSResourceReference{Name: ptr.To("NetworkName")}}},
-			},
-			expectedName: ptr.To("NetworkName"),
-		},
-		{
 			name:         "Resource type is vpc and VPC is nil",
 			resourceType: infrav1beta2.ResourceTypeVPC,
 			clusterScope: PowerVSClusterScope{
@@ -2829,6 +2813,14 @@ func TestGetServiceName(t *testing.T) {
 				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{Spec: infrav1beta2.IBMPowerVSClusterSpec{DHCPServer: &infrav1beta2.DHCPServer{Name: ptr.To("DHCPServerName")}}},
 			},
 			expectedName: ptr.To("DHCPServerName"),
+		},
+		{
+			name:         "Resource type is dhcp server and dhcpserver is not nil and network is not nil",
+			resourceType: infrav1beta2.ResourceTypeDHCPServer,
+			clusterScope: PowerVSClusterScope{
+				IBMPowerVSCluster: &infrav1beta2.IBMPowerVSCluster{Spec: infrav1beta2.IBMPowerVSClusterSpec{Network: infrav1beta2.IBMPowerVSResourceReference{Name: ptr.To("NetworkName")}}},
+			},
+			expectedName: ptr.To("NetworkName"),
 		},
 		{
 			name:         "Resource type is cos instance and cos instance is nil",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -462,7 +462,7 @@ spec:
                   1. in the case of DHCPServer.Name is not set the name will be DHCPSERVER<CLUSTER_NAME>_Private.
                   2. if DHCPServer.Name is set the name will be DHCPSERVER<DHCPServer.Name>_Private.
                   when Network.ID is set, its expected that there exist a network in PowerVS workspace with id or else system will give error.
-                  when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist network will be created by DHCP service.
+                  when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist system will check DHCP network with given Network.name, if that also not exist, it will create a new DHCP service and name will be DHCPSERVER<Network.Name>_Private.
                   Network.RegEx is not yet supported and system will ignore the value.
                 properties:
                   id:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -499,7 +499,7 @@ spec:
                           1. in the case of DHCPServer.Name is not set the name will be DHCPSERVER<CLUSTER_NAME>_Private.
                           2. if DHCPServer.Name is set the name will be DHCPSERVER<DHCPServer.Name>_Private.
                           when Network.ID is set, its expected that there exist a network in PowerVS workspace with id or else system will give error.
-                          when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist network will be created by DHCP service.
+                          when Network.Name is set, system will first check for network with Name in PowerVS workspace, if not exist system will check DHCP network with given Network.name, if that also not exist, it will create a new DHCP service and name will be DHCPSERVER<Network.Name>_Private.
                           Network.RegEx is not yet supported and system will ignore the value.
                         properties:
                           id:

--- a/internal/webhooks/ibmpowervscluster.go
+++ b/internal/webhooks/ibmpowervscluster.go
@@ -104,6 +104,12 @@ func validateIBMPowerVSClusterNetwork(cluster *infrav1beta2.IBMPowerVSCluster) *
 	if res, err := validateIBMPowerVSNetworkReference(cluster.Spec.Network); !res {
 		return err
 	}
+	if (cluster.Spec.Network.Name != nil || cluster.Spec.Network.ID != nil) && (cluster.Spec.DHCPServer != nil && cluster.Spec.DHCPServer.Name != nil) {
+		return field.Invalid(field.NewPath("spec.dhcpServer.name"), cluster.Spec.DHCPServer.Name, "either one of network or dhcpServer details can be provided")
+	}
+	if (cluster.Spec.Network.Name != nil || cluster.Spec.Network.ID != nil) && (cluster.Spec.DHCPServer != nil && cluster.Spec.DHCPServer.ID != nil) {
+		return field.Invalid(field.NewPath("spec.dhcpServer.id"), cluster.Spec.DHCPServer.ID, "either one of network or dhcpServer details can be provided")
+	}
 	return nil
 }
 

--- a/internal/webhooks/ibmpowervscluster_test.go
+++ b/internal/webhooks/ibmpowervscluster_test.go
@@ -70,6 +70,66 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Should error if both Network name and DHCP name are set",
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1beta2.IBMPowerVSResourceReference{
+						Name: ptr.To("capi-net"),
+					},
+					DHCPServer: &infrav1beta2.DHCPServer{
+						Name: ptr.To("capi-dhcp"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should error if both Network id and DHCP name are set",
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1beta2.IBMPowerVSResourceReference{
+						ID: ptr.To("capi-net-id"),
+					},
+					DHCPServer: &infrav1beta2.DHCPServer{
+						Name: ptr.To("capi-dhcp"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should error if both Network name and DHCP id are set",
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1beta2.IBMPowerVSResourceReference{
+						Name: ptr.To("capi-net"),
+					},
+					DHCPServer: &infrav1beta2.DHCPServer{
+						ID: ptr.To("capi-dhcp-id"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should error if both Network id and DHCP id are set",
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1beta2.IBMPowerVSResourceReference{
+						ID: ptr.To("capi-net-id"),
+					},
+					DHCPServer: &infrav1beta2.DHCPServer{
+						ID: ptr.To("capi-dhcp-id"),
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fix priority between network and DHCP server
Do not allow to set both network and DHCP server details which will create conflict while creating new DHCP server on whether to use network name or DHCP server name

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2159 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix priority between network and DHCP server
```
