### PR TITLE
Move away from use of controller-runtime scheme while registering api types

### DIFF
--- a/api/v1beta2/groupversion_info.go
+++ b/api/v1beta2/groupversion_info.go
@@ -20,18 +20,26 @@ limitations under the License.
 package v1beta2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1beta2/ibmpowervscluster_types.go
+++ b/api/v1beta2/ibmpowervscluster_types.go
@@ -338,5 +338,5 @@ func (rf *ResourceReference) Set(resource ResourceReference) {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMPowerVSCluster{}, &IBMPowerVSClusterList{})
+	objectTypes = append(objectTypes, &IBMPowerVSCluster{}, &IBMPowerVSClusterList{})
 }

--- a/api/v1beta2/ibmpowervsclustertemplate_types.go
+++ b/api/v1beta2/ibmpowervsclustertemplate_types.go
@@ -59,5 +59,5 @@ type IBMPowerVSClusterTemplateResource struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMPowerVSClusterTemplate{}, &IBMPowerVSClusterTemplateList{})
+	objectTypes = append(objectTypes, &IBMPowerVSClusterTemplate{}, &IBMPowerVSClusterTemplateList{})
 }

--- a/api/v1beta2/ibmpowervsimage_types.go
+++ b/api/v1beta2/ibmpowervsimage_types.go
@@ -131,5 +131,5 @@ type IBMPowerVSImageList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMPowerVSImage{}, &IBMPowerVSImageList{})
+	objectTypes = append(objectTypes, &IBMPowerVSImage{}, &IBMPowerVSImageList{})
 }

--- a/api/v1beta2/ibmpowervsmachine_types.go
+++ b/api/v1beta2/ibmpowervsmachine_types.go
@@ -271,5 +271,5 @@ type IBMPowerVSMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMPowerVSMachine{}, &IBMPowerVSMachineList{})
+	objectTypes = append(objectTypes, &IBMPowerVSMachine{}, &IBMPowerVSMachineList{})
 }

--- a/api/v1beta2/ibmpowervsmachinetemplate_types.go
+++ b/api/v1beta2/ibmpowervsmachinetemplate_types.go
@@ -65,5 +65,5 @@ type IBMPowerVSMachineTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMPowerVSMachineTemplate{}, &IBMPowerVSMachineTemplateList{})
+	objectTypes = append(objectTypes, &IBMPowerVSMachineTemplate{}, &IBMPowerVSMachineTemplateList{})
 }

--- a/api/v1beta2/ibmvpccluster_types.go
+++ b/api/v1beta2/ibmvpccluster_types.go
@@ -385,10 +385,6 @@ type IBMVPCClusterList struct {
 	Items           []IBMVPCCluster `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&IBMVPCCluster{}, &IBMVPCClusterList{})
-}
-
 // GetConditions returns the observations of the operational state of the IBMVPCCluster resource.
 func (r *IBMVPCCluster) GetConditions() capiv1beta1.Conditions {
 	return r.Status.Conditions
@@ -397,4 +393,8 @@ func (r *IBMVPCCluster) GetConditions() capiv1beta1.Conditions {
 // SetConditions sets the underlying service state of the IBMVPCCluster to the predescribed clusterv1.Conditions.
 func (r *IBMVPCCluster) SetConditions(conditions capiv1beta1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+func init() {
+	objectTypes = append(objectTypes, &IBMVPCCluster{}, &IBMVPCClusterList{})
 }

--- a/api/v1beta2/ibmvpcclustertemplate_types.go
+++ b/api/v1beta2/ibmvpcclustertemplate_types.go
@@ -58,5 +58,5 @@ type IBMVPCClusterTemplateResource struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMVPCClusterTemplate{}, &IBMVPCClusterTemplateList{})
+	objectTypes = append(objectTypes, &IBMVPCClusterTemplate{}, &IBMVPCClusterTemplateList{})
 }

--- a/api/v1beta2/ibmvpcmachine_types.go
+++ b/api/v1beta2/ibmvpcmachine_types.go
@@ -212,5 +212,5 @@ type IBMVPCMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMVPCMachine{}, &IBMVPCMachineList{})
+	objectTypes = append(objectTypes, &IBMVPCMachine{}, &IBMVPCMachineList{})
 }

--- a/api/v1beta2/ibmvpcmachinetemplate_types.go
+++ b/api/v1beta2/ibmvpcmachinetemplate_types.go
@@ -65,5 +65,5 @@ type IBMVPCMachineTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IBMVPCMachineTemplate{}, &IBMVPCMachineTemplateList{})
+	objectTypes = append(objectTypes, &IBMVPCMachineTemplate{}, &IBMVPCMachineTemplateList{})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Its a work towards #2286 , This PR changes the scheme registration for API types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
