### PR TITLE
Remove deprecated admission interfaces

### DIFF
--- a/api/v1beta2/ibmpowervscluster_webhook.go
+++ b/api/v1beta2/ibmpowervscluster_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -28,51 +29,51 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
-// log is for logging in this package.
-var ibmpowervsclusterlog = logf.Log.WithName("ibmpowervscluster-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=create;update,versions=v1beta2,name=mibmpowervscluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,versions=v1beta2,name=vibmpowervscluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMPowerVSCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMPowerVSCluster{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=create;update,versions=v1beta2,name=mibmpowervscluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMPowerVSCluster{}
+var _ webhook.CustomValidator = &IBMPowerVSCluster{}
 
-var _ webhook.Defaulter = &IBMPowerVSCluster{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMPowerVSCluster) Default() {
-	ibmpowervsclusterlog.Info("default", "name", r.Name)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMPowerVSCluster) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,versions=v1beta2,name=vibmpowervscluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMPowerVSCluster{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSCluster) ValidateCreate() (admission.Warnings, error) {
-	ibmpowervsclusterlog.Info("validate create", "name", r.Name)
-	return r.validateIBMPowerVSCluster()
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSCluster) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	objValue, ok := obj.(*IBMPowerVSCluster)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSCluster but got a %T", obj))
+	}
+	return objValue.validateIBMPowerVSCluster()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSCluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmpowervsclusterlog.Info("validate update", "name", r.Name)
-	return r.validateIBMPowerVSCluster()
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSCluster) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	objValue, ok := newObj.(*IBMPowerVSCluster)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSCluster but got a %T", newObj))
+	}
+	return objValue.validateIBMPowerVSCluster()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSCluster) ValidateDelete() (admission.Warnings, error) {
-	ibmpowervsclusterlog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSCluster) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/api/v1beta2/ibmpowervsclustertemplate_webhook.go
+++ b/api/v1beta2/ibmpowervsclustertemplate_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -24,56 +25,51 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmpowervsclustertemplatelog = logf.Log.WithName("ibmpowervsclustertemplate-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclustertemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsclustertemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclustertemplates,versions=v1beta2,name=vibmpowervsclustertemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMPowerVSClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMPowerVSClusterTemplate{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclustertemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsclustertemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMPowerVSClusterTemplate{}
+var _ webhook.CustomValidator = &IBMPowerVSClusterTemplate{}
 
-var _ webhook.Defaulter = &IBMPowerVSClusterTemplate{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMPowerVSClusterTemplate) Default() {
-	ibmpowervsclustertemplatelog.Info("default", "name", r.Name)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMPowerVSClusterTemplate) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclustertemplates,versions=v1beta2,name=vibmpowervsclustertemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMPowerVSClusterTemplate{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSClusterTemplate) ValidateCreate() (admission.Warnings, error) {
-	ibmpowervsclustertemplatelog.Info("validate create", "name", r.Name)
-
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSClusterTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSClusterTemplate) ValidateUpdate(oldRaw runtime.Object) (admission.Warnings, error) {
-	ibmpowervsclustertemplatelog.Info("validate update", "name", r.Name)
-	old, ok := oldRaw.(*IBMPowerVSClusterTemplate)
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSClusterTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	oldObjValue, ok := oldObj.(*IBMPowerVSClusterTemplate)
 	if !ok {
-		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IBMPowerVSClusterTemplate but got a %T", oldRaw))
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IBMPowerVSClusterTemplate but got a %T", oldObj))
 	}
-	if !reflect.DeepEqual(r.Spec, old.Spec) {
+	newObjValue, ok := newObj.(*IBMPowerVSClusterTemplate)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IBMPowerVSClusterTemplate but got a %T", newObj))
+	}
+	if !reflect.DeepEqual(newObjValue.Spec, oldObjValue.Spec) {
 		return nil, apierrors.NewBadRequest("IBMPowerVSClusterTemplate.Spec is immutable")
 	}
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSClusterTemplate) ValidateDelete() (admission.Warnings, error) {
-	ibmpowervsclustertemplatelog.Info("validate delete", "name", r.Name)
-
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSClusterTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/api/v1beta2/ibmpowervsclustertemplate_webhook_test.go
+++ b/api/v1beta2/ibmpowervsclustertemplate_webhook_test.go
@@ -78,7 +78,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(_ *testing.T) {
-			_, err := test.newTemplate.ValidateUpdate(test.oldTemplate)
+			_, err := test.newTemplate.ValidateUpdate(ctx, test.oldTemplate, test.newTemplate)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta2/ibmpowervsimage_webhook.go
+++ b/api/v1beta2/ibmpowervsimage_webhook.go
@@ -17,51 +17,45 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmpowervsimagelog = logf.Log.WithName("ibmpowervsimage-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsimages,verbs=create;update,versions=v1beta2,name=mibmpowervsimage.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsimages,versions=v1beta2,name=vibmpowervsimage.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMPowerVSImage) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMPowerVSImage{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsimages,verbs=create;update,versions=v1beta2,name=mibmpowervsimage.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMPowerVSImage{}
+var _ webhook.CustomValidator = &IBMPowerVSImage{}
 
-var _ webhook.Defaulter = &IBMPowerVSImage{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMPowerVSImage) Default() {
-	ibmpowervsimagelog.Info("default", "name", r.Name)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMPowerVSImage) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsimages,versions=v1beta2,name=vibmpowervsimage.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMPowerVSImage{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSImage) ValidateCreate() (admission.Warnings, error) {
-	ibmpowervsimagelog.Info("validate create", "name", r.Name)
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSImage) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSImage) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmpowervsimagelog.Info("validate update", "name", r.Name)
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSImage) ValidateUpdate(_ context.Context, _, _ runtime.Object) (warnings admission.Warnings, err error) {
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSImage) ValidateDelete() (admission.Warnings, error) {
-	ibmpowervsimagelog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSImage) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/api/v1beta2/ibmpowervsmachine_webhook.go
+++ b/api/v1beta2/ibmpowervsmachine_webhook.go
@@ -17,55 +17,63 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmpowervsmachinelog = logf.Log.WithName("ibmpowervsmachine-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachines,verbs=create;update,versions=v1beta2,name=mibmpowervsmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachines,versions=v1beta2,name=vibmpowervsmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMPowerVSMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMPowerVSMachine{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachines,verbs=create;update,versions=v1beta2,name=mibmpowervsmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMPowerVSMachine{}
+var _ webhook.CustomValidator = &IBMPowerVSMachine{}
 
-var _ webhook.Defaulter = &IBMPowerVSMachine{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMPowerVSMachine) Default() {
-	ibmpowervsmachinelog.Info("default", "name", r.Name)
-	defaultIBMPowerVSMachineSpec(&r.Spec)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMPowerVSMachine) Default(_ context.Context, obj runtime.Object) error {
+	objValue, ok := obj.(*IBMPowerVSMachine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachine but got a %T", obj))
+	}
+	defaultIBMPowerVSMachineSpec(&objValue.Spec)
+	return nil
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachines,versions=v1beta2,name=vibmpowervsmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMPowerVSMachine{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachine) ValidateCreate() (admission.Warnings, error) {
-	ibmpowervsmachinelog.Info("validate create", "name", r.Name)
-	return r.validateIBMPowerVSMachine()
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachine) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	objValue, ok := obj.(*IBMPowerVSMachine)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachine but got a %T", obj))
+	}
+	return objValue.validateIBMPowerVSMachine()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachine) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmpowervsmachinelog.Info("validate update", "name", r.Name)
-	return r.validateIBMPowerVSMachine()
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachine) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	newObjValue, ok := newObj.(*IBMPowerVSMachine)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachine but got a %T", newObj))
+	}
+	return newObjValue.validateIBMPowerVSMachine()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachine) ValidateDelete() (admission.Warnings, error) {
-	ibmpowervsmachinelog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/api/v1beta2/ibmpowervsmachine_webhook_test.go
+++ b/api/v1beta2/ibmpowervsmachine_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestIBMPowerVSMachine_default(t *testing.T) {
@@ -42,8 +42,7 @@ func TestIBMPowerVSMachine_default(t *testing.T) {
 			},
 		},
 	}
-	t.Run("Defaults for IBMPowerVSMachine", defaulting.DefaultValidateTest(powervsMachine))
-	powervsMachine.Default()
+	g.Expect(powervsMachine.Default(context.Background(), powervsMachine)).ToNot(HaveOccurred())
 	g.Expect(powervsMachine.Spec.SystemType).To(BeEquivalentTo("s922"))
 	g.Expect(powervsMachine.Spec.ProcessorType).To(BeEquivalentTo(PowerVSProcessorTypeShared))
 }

--- a/api/v1beta2/ibmpowervsmachinetemplate_webhook.go
+++ b/api/v1beta2/ibmpowervsmachinetemplate_webhook.go
@@ -17,55 +17,63 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmpowervsmachinetemplatelog = logf.Log.WithName("ibmpowervsmachinetemplate-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachinetemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsmachinetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachinetemplates,versions=v1beta2,name=vibmpowervsmachinetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMPowerVSMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMPowerVSMachineTemplate{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachinetemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsmachinetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMPowerVSMachineTemplate{}
+var _ webhook.CustomValidator = &IBMPowerVSMachineTemplate{}
 
-var _ webhook.Defaulter = &IBMPowerVSMachineTemplate{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMPowerVSMachineTemplate) Default() {
-	ibmpowervsmachinetemplatelog.Info("default", "name", r.Name)
-	defaultIBMPowerVSMachineSpec(&r.Spec.Template.Spec)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMPowerVSMachineTemplate) Default(_ context.Context, obj runtime.Object) error {
+	objValue, ok := obj.(*IBMPowerVSMachineTemplate)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", obj))
+	}
+	defaultIBMPowerVSMachineSpec(&objValue.Spec.Template.Spec)
+	return nil
 }
 
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachinetemplates,versions=v1beta2,name=vibmpowervsmachinetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMPowerVSMachineTemplate{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachineTemplate) ValidateCreate() (admission.Warnings, error) {
-	ibmpowervsmachinetemplatelog.Info("validate create", "name", r.Name)
-	return r.validateIBMPowerVSMachineTemplate()
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachineTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	objValue, ok := obj.(*IBMPowerVSMachineTemplate)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", obj))
+	}
+	return objValue.validateIBMPowerVSMachineTemplate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachineTemplate) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmpowervsmachinetemplatelog.Info("validate update", "name", r.Name)
-	return r.validateIBMPowerVSMachineTemplate()
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachineTemplate) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	objValue, ok := newObj.(*IBMPowerVSMachineTemplate)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", newObj))
+	}
+	return objValue.validateIBMPowerVSMachineTemplate()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMPowerVSMachineTemplate) ValidateDelete() (admission.Warnings, error) {
-	ibmpowervsmachinetemplatelog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMPowerVSMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/api/v1beta2/ibmpowervsmachinetemplate_webhook_test.go
+++ b/api/v1beta2/ibmpowervsmachinetemplate_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestIBMPowerVSMachineTemplate_default(t *testing.T) {
@@ -46,8 +46,7 @@ func TestIBMPowerVSMachineTemplate_default(t *testing.T) {
 			},
 		},
 	}
-	t.Run("Defaults for IBMPowerVSMachineTemplate", defaulting.DefaultValidateTest(powervsMachineTemplate))
-	powervsMachineTemplate.Default()
+	g.Expect(powervsMachineTemplate.Default(context.Background(), powervsMachineTemplate)).ToNot(HaveOccurred())
 	g.Expect(powervsMachineTemplate.Spec.Template.Spec.SystemType).To(BeEquivalentTo("s922"))
 	g.Expect(powervsMachineTemplate.Spec.Template.Spec.ProcessorType).To(BeEquivalentTo(PowerVSProcessorTypeShared))
 }

--- a/api/v1beta2/ibmvpccluster_webhook.go
+++ b/api/v1beta2/ibmvpccluster_webhook.go
@@ -17,55 +17,58 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmvpcclusterlog = logf.Log.WithName("ibmvpccluster-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcclusters,verbs=create;update,versions=v1beta2,name=mibmvpccluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcclusters,versions=v1beta2,name=vibmvpccluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMVPCCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMVPCCluster{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcclusters,verbs=create;update,versions=v1beta2,name=mibmvpccluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMVPCCluster{}
+var _ webhook.CustomValidator = &IBMVPCCluster{}
 
-var _ webhook.Defaulter = &IBMVPCCluster{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMVPCCluster) Default() {
-	ibmvpcclusterlog.Info("default", "name", r.Name)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMVPCCluster) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcclusters,versions=v1beta2,name=vibmvpccluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMVPCCluster{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCCluster) ValidateCreate() (admission.Warnings, error) {
-	ibmvpcclusterlog.Info("validate create", "name", r.Name)
-	return r.validateIBMVPCCluster()
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCCluster) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	objValue, ok := obj.(*IBMVPCCluster)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMVPCCluster but got a %T", obj))
+	}
+	return objValue.validateIBMVPCCluster()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCCluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmvpcclusterlog.Info("validate update", "name", r.Name)
-	return r.validateIBMVPCCluster()
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCCluster) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	objValue, ok := newObj.(*IBMVPCCluster)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMVPCCluster but got a %T", objValue))
+	}
+	return objValue.validateIBMVPCCluster()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCCluster) ValidateDelete() (admission.Warnings, error) {
-	ibmvpcclusterlog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCCluster) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/api/v1beta2/ibmvpcmachine_webhook.go
+++ b/api/v1beta2/ibmvpcmachine_webhook.go
@@ -17,58 +17,60 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var ibmvpcmachinelog = logf.Log.WithName("ibmvpcmachine-resource")
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcmachines,verbs=create;update,versions=v1beta2,name=mibmvpcmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcmachines,versions=v1beta2,name=vibmvpcmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 func (r *IBMVPCMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&IBMVPCMachine{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcmachines,verbs=create;update,versions=v1beta2,name=mibmvpcmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+var _ webhook.CustomDefaulter = &IBMVPCMachine{}
+var _ webhook.CustomValidator = &IBMVPCMachine{}
 
-var _ webhook.Defaulter = &IBMVPCMachine{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *IBMVPCMachine) Default() {
-	ibmvpcmachinelog.Info("default", "name", r.Name)
-	defaultIBMVPCMachineSpec(&r.Spec)
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (r *IBMVPCMachine) Default(_ context.Context, obj runtime.Object) error {
+	objValue, ok := obj.(*IBMVPCMachine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a IBMVPCMachine but got a %T", obj))
+	}
+	defaultIBMVPCMachineSpec(&objValue.Spec)
+	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcmachines,versions=v1beta2,name=vibmvpcmachine.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &IBMVPCMachine{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCMachine) ValidateCreate() (admission.Warnings, error) {
-	ibmvpcmachinelog.Info("validate create", "name", r.Name)
-
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCMachine) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	objValue, ok := obj.(*IBMVPCMachine)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMVPCMachine but got a %T", obj))
+	}
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, r.validateIBMVPCMachineBootVolume()...)
-
-	return nil, aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
+	allErrs = append(allErrs, objValue.validateIBMVPCMachineBootVolume()...)
+	return nil, aggregateObjErrors(objValue.GroupVersionKind().GroupKind(), objValue.Name, allErrs)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCMachine) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
-	ibmvpcmachinelog.Info("validate update", "name", r.Name)
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCMachine) ValidateUpdate(_ context.Context, _, _ runtime.Object) (warnings admission.Warnings, err error) {
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (r *IBMVPCMachine) ValidateDelete() (admission.Warnings, error) {
-	ibmvpcmachinelog.Info("validate delete", "name", r.Name)
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (r *IBMVPCMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/api/v1beta2/ibmvpcmachine_webhook_test.go
+++ b/api/v1beta2/ibmvpcmachine_webhook_test.go
@@ -22,14 +22,12 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestVPCMachine_default(t *testing.T) {
 	g := NewWithT(t)
 	vpcMachine := &IBMVPCMachine{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine", Namespace: "default"}}
-	t.Run("Defaults for IBMVPCMachine", defaulting.DefaultValidateTest(vpcMachine))
-	vpcMachine.Default()
+	g.Expect(vpcMachine.Default(context.Background(), vpcMachine)).ToNot(HaveOccurred())
 	g.Expect(vpcMachine.Spec.Profile).To(BeEquivalentTo("bx2-2x8"))
 }
 

--- a/api/v1beta2/ibmvpcmachinetemplate_webhook_test.go
+++ b/api/v1beta2/ibmvpcmachinetemplate_webhook_test.go
@@ -17,17 +17,16 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestVPCMachineTemplate_default(t *testing.T) {
 	g := NewWithT(t)
 	vpcMachineTemplate := &IBMVPCMachineTemplate{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine-template", Namespace: "default"}}
-	t.Run("Defaults for IBMVPCMachineTemplate", defaulting.DefaultValidateTest(vpcMachineTemplate))
-	vpcMachineTemplate.Default()
+	g.Expect(vpcMachineTemplate.Default(context.Background(), vpcMachineTemplate)).ToNot(HaveOccurred())
 	g.Expect(vpcMachineTemplate.Spec.Template.Spec.Profile).To(BeEquivalentTo("bx2-2x8"))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

PR removes the deprecated webhook interfaces and adds CustomValidator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2288

**Special notes for your reviewer**:


/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove usage of deprecated webhook admission and validation interfaces
```
