### PR TITLE
Move wehbooks out of api directory to seperate directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY controllers/ controllers/
 COPY cloud/ cloud/
 COPY pkg/ pkg/
 COPY util/ util/
+COPY internal/ internal/
 
 # Build
 ARG TARGETOS

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -1069,7 +1069,7 @@ func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember() (*vpcv1.LoadBala
 				ID: loadBalancer.ID,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to fetch VPC load balancer details with ID: %s error: %v", *loadBalancer.ID, err)
+				return nil, fmt.Errorf("failed to fetch VPC load balancer details with ID: %s error: %v", *lbID, err)
 			}
 			if *loadBalancer.ProvisioningStatus != string(infrav1beta2.VPCLoadBalancerStateActive) {
 				m.V(3).Info("Unable to update pool for VPC load balancer as it is not in active state", "loadbalancer", *loadBalancer.Name, "state", *loadBalancer.ProvisioningStatus)

--- a/cloud/scope/suite_test.go
+++ b/cloud/scope/suite_test.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/internal/webhooks"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/test/helpers"
 )
 
@@ -56,32 +57,31 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	if err := (&infrav1beta2.IBMPowerVSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSCluster webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSMachine webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSMachineTemplate webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSImage{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSImage{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSImage webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCCluster{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCCluster webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCMachine{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCMachine webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCMachineTemplate webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSClusterTemplate webhook: %v", err))
 	}
 	go func() {
-		fmt.Println("Starting the manager")
 		if err := testEnv.StartManager(ctx); err != nil {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/internal/webhooks"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/test/helpers"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -57,32 +58,31 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	if err := (&infrav1beta2.IBMPowerVSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSCluster{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSCluster webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSMachine{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSMachine webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSMachineTemplate webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSImage{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSImage{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSImage webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCCluster{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCCluster{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCCluster webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCMachine{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCMachine{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCMachine webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMVPCMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMVPCMachineTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMVPCMachineTemplate webhook: %v", err))
 	}
-	if err := (&infrav1beta2.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
+	if err := (&webhooks.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Unable to setup IBMPowerVSClusterTemplate webhook: %v", err))
 	}
 	go func() {
-		fmt.Println("Starting the manager")
 		if err := testEnv.StartManager(ctx); err != nil {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}

--- a/internal/webhooks/common.go
+++ b/internal/webhooks/common.go
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
-func defaultIBMPowerVSMachineSpec(spec *IBMPowerVSMachineSpec) {
+func defaultIBMPowerVSMachineSpec(spec *infrav1beta2.IBMPowerVSMachineSpec) {
 	if spec.MemoryGiB == 0 {
 		spec.MemoryGiB = 2
 	}
@@ -34,18 +36,18 @@ func defaultIBMPowerVSMachineSpec(spec *IBMPowerVSMachineSpec) {
 		spec.SystemType = "s922"
 	}
 	if spec.ProcessorType == "" {
-		spec.ProcessorType = PowerVSProcessorTypeShared
+		spec.ProcessorType = infrav1beta2.PowerVSProcessorTypeShared
 	}
 }
 
-func validateIBMPowerVSResourceReference(res IBMPowerVSResourceReference, resType string) (bool, *field.Error) {
+func validateIBMPowerVSResourceReference(res infrav1beta2.IBMPowerVSResourceReference, resType string) (bool, *field.Error) {
 	if res.ID != nil && res.Name != nil {
 		return false, field.Invalid(field.NewPath("spec", resType), res, "Only one of "+resType+" - ID or Name may be specified")
 	}
 	return true, nil
 }
 
-func validateIBMPowerVSNetworkReference(res IBMPowerVSResourceReference) (bool, *field.Error) {
+func validateIBMPowerVSNetworkReference(res infrav1beta2.IBMPowerVSResourceReference) (bool, *field.Error) {
 	if (res.ID != nil && res.Name != nil) || (res.ID != nil && res.RegEx != nil) || (res.Name != nil && res.RegEx != nil) {
 		return false, field.Invalid(field.NewPath("spec", "Network"), res, "Only one of Network - ID, Name or RegEx can be specified")
 	}
@@ -74,13 +76,13 @@ func validateIBMPowerVSProcessorValues(resValue intstr.IntOrString) bool {
 	return true
 }
 
-func defaultIBMVPCMachineSpec(spec *IBMVPCMachineSpec) {
+func defaultIBMVPCMachineSpec(spec *infrav1beta2.IBMVPCMachineSpec) {
 	if spec.Profile == "" {
 		spec.Profile = "bx2-2x8"
 	}
 }
 
-func validateBootVolume(spec IBMVPCMachineSpec) field.ErrorList {
+func validateBootVolume(spec infrav1beta2.IBMVPCMachineSpec) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if spec.BootVolume == nil {

--- a/internal/webhooks/common_test.go
+++ b/internal/webhooks/common_test.go
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
 func TestValidateIBMPowerVSMemoryValues(t *testing.T) {
@@ -113,48 +115,48 @@ func TestValidateIBMPowerVSProcessorValues(t *testing.T) {
 func Test_validateBootVolume(t *testing.T) {
 	tests := []struct {
 		name      string
-		spec      IBMVPCMachineSpec
+		spec      infrav1beta2.IBMVPCMachineSpec
 		wantError bool
 	}{
 		{
 			name: "Nil bootvolume",
-			spec: IBMVPCMachineSpec{
+			spec: infrav1beta2.IBMVPCMachineSpec{
 				BootVolume: nil,
 			},
 			wantError: false,
 		},
 		{
 			name: "valid sizeGiB",
-			spec: IBMVPCMachineSpec{
-				BootVolume: &VPCVolume{SizeGiB: 20},
+			spec: infrav1beta2.IBMVPCMachineSpec{
+				BootVolume: &infrav1beta2.VPCVolume{SizeGiB: 20},
 			},
 			wantError: false,
 		},
 		{
 			name: "Invalid sizeGiB",
-			spec: IBMVPCMachineSpec{
-				BootVolume: &VPCVolume{SizeGiB: 1},
+			spec: infrav1beta2.IBMVPCMachineSpec{
+				BootVolume: &infrav1beta2.VPCVolume{SizeGiB: 1},
 			},
 			wantError: true,
 		},
 		{
 			name: "Valid Iops",
-			spec: IBMVPCMachineSpec{
-				BootVolume: &VPCVolume{Iops: 1000, Profile: "custom"},
+			spec: infrav1beta2.IBMVPCMachineSpec{
+				BootVolume: &infrav1beta2.VPCVolume{Iops: 1000, Profile: "custom"},
 			},
 			wantError: true,
 		},
 		{
 			name: "Invalid Iops",
-			spec: IBMVPCMachineSpec{
-				BootVolume: &VPCVolume{Iops: 1234, Profile: "general-purpose"},
+			spec: infrav1beta2.IBMVPCMachineSpec{
+				BootVolume: &infrav1beta2.VPCVolume{Iops: 1234, Profile: "general-purpose"},
 			},
 			wantError: true,
 		},
 		{
 			name: "Missing Iops for custom profile",
-			spec: IBMVPCMachineSpec{
-				BootVolume: &VPCVolume{Profile: "general-purpose"},
+			spec: infrav1beta2.IBMVPCMachineSpec{
+				BootVolume: &infrav1beta2.VPCVolume{Profile: "general-purpose"},
 			},
 			wantError: true,
 		},

--- a/internal/webhooks/doc.go
+++ b/internal/webhooks/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,22 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
-
-import (
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-)
-
-func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
-	if len(allErrs) == 0 {
-		return nil
-	}
-
-	return apierrors.NewInvalid(
-		gk,
-		name,
-		allErrs,
-	)
-}
+// Package webhooks contains external webhook implementations for some of our API types.
+package webhooks

--- a/internal/webhooks/ibmpowervscluster_test.go
+++ b/internal/webhooks/ibmpowervscluster_test.go
@@ -14,27 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
 func TestIBMPowerVSCluster_create(t *testing.T) {
 	tests := []struct {
 		name           string
-		powervsCluster *IBMPowerVSCluster
+		powervsCluster *infrav1beta2.IBMPowerVSCluster
 		wantErr        bool
 	}{
 		{
 			name: "Should allow if either Network ID or name is set",
-			powervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
 				},
@@ -43,10 +45,10 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 		},
 		{
 			name: "Should error if both Network ID and name are set",
-			powervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net"),
 					},
@@ -56,10 +58,10 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 		},
 		{
 			name: "Should error if all Network ID, name and regex are set",
-			powervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			powervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID:    ptr.To("capi-net-id"),
 						Name:  ptr.To("capi-net"),
 						RegEx: ptr.To("^capi$"),
@@ -88,24 +90,24 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 func TestIBMPowerVSCluster_update(t *testing.T) {
 	tests := []struct {
 		name              string
-		oldPowervsCluster *IBMPowerVSCluster
-		newPowervsCluster *IBMPowerVSCluster
+		oldPowervsCluster *infrav1beta2.IBMPowerVSCluster
+		newPowervsCluster *infrav1beta2.IBMPowerVSCluster
 		wantErr           bool
 	}{
 		{
 			name: "Should allow if either Network ID or name is set",
-			oldPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			oldPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
 				},
 			},
-			newPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			newPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
 				},
@@ -114,18 +116,18 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 		},
 		{
 			name: "Should error if both Network ID and name are set",
-			oldPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			oldPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
 				},
 			},
-			newPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			newPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net-name"),
 					},
@@ -135,18 +137,18 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 		},
 		{
 			name: "Should allow if Network ID is set",
-			oldPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			oldPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						RegEx: ptr.To("^capi-net-id$"),
 					},
 				},
 			},
-			newPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			newPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						RegEx: ptr.To("^capi-net-id$"),
 					},
 				},
@@ -155,18 +157,18 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 		},
 		{
 			name: "Should error if all Network ID, name and regex are set",
-			oldPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			oldPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
 				},
 			},
-			newPowervsCluster: &IBMPowerVSCluster{
-				Spec: IBMPowerVSClusterSpec{
+			newPowervsCluster: &infrav1beta2.IBMPowerVSCluster{
+				Spec: infrav1beta2.IBMPowerVSClusterSpec{
 					ServiceInstanceID: "capi-si-id",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID:    ptr.To("capi-net-id"),
 						Name:  ptr.To("capi-net-name"),
 						RegEx: ptr.To("^capi-net-id$"),

--- a/internal/webhooks/ibmpowervsclustertemplate.go
+++ b/internal/webhooks/ibmpowervsclustertemplate.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
@@ -27,6 +27,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclustertemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsclustertemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -34,11 +36,14 @@ import (
 
 func (r *IBMPowerVSClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&IBMPowerVSClusterTemplate{}).
+		For(&infrav1beta2.IBMPowerVSClusterTemplate{}).
 		WithValidator(r).
 		WithDefaulter(r).
 		Complete()
 }
+
+// IBMPowerVSClusterTemplate implements a validation and defaulting webhook for IBMPowerVSClusterTemplate.
+type IBMPowerVSClusterTemplate struct{}
 
 var _ webhook.CustomDefaulter = &IBMPowerVSClusterTemplate{}
 var _ webhook.CustomValidator = &IBMPowerVSClusterTemplate{}
@@ -55,11 +60,11 @@ func (r *IBMPowerVSClusterTemplate) ValidateCreate(_ context.Context, _ runtime.
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (r *IBMPowerVSClusterTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	oldObjValue, ok := oldObj.(*IBMPowerVSClusterTemplate)
+	oldObjValue, ok := oldObj.(*infrav1beta2.IBMPowerVSClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IBMPowerVSClusterTemplate but got a %T", oldObj))
 	}
-	newObjValue, ok := newObj.(*IBMPowerVSClusterTemplate)
+	newObjValue, ok := newObj.(*infrav1beta2.IBMPowerVSClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IBMPowerVSClusterTemplate but got a %T", newObj))
 	}

--- a/internal/webhooks/ibmpowervsclustertemplate_test.go
+++ b/internal/webhooks/ibmpowervsclustertemplate_test.go
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"testing"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 
 	. "github.com/onsi/gomega"
 )
@@ -27,25 +29,25 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		newTemplate *IBMPowerVSClusterTemplate
-		oldTemplate *IBMPowerVSClusterTemplate
+		newTemplate *infrav1beta2.IBMPowerVSClusterTemplate
+		oldTemplate *infrav1beta2.IBMPowerVSClusterTemplate
 		wantErr     bool
 	}{
 		{
 			name: "IBMPowerVSClusterTemplate with immutable spec",
-			newTemplate: &IBMPowerVSClusterTemplate{
-				Spec: IBMPowerVSClusterTemplateSpec{
-					Template: IBMPowerVSClusterTemplateResource{
-						Spec: IBMPowerVSClusterSpec{
+			newTemplate: &infrav1beta2.IBMPowerVSClusterTemplate{
+				Spec: infrav1beta2.IBMPowerVSClusterTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSClusterTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSClusterSpec{
 							ServiceInstanceID: "test-instance1",
 						},
 					},
 				},
 			},
-			oldTemplate: &IBMPowerVSClusterTemplate{
-				Spec: IBMPowerVSClusterTemplateSpec{
-					Template: IBMPowerVSClusterTemplateResource{
-						Spec: IBMPowerVSClusterSpec{
+			oldTemplate: &infrav1beta2.IBMPowerVSClusterTemplate{
+				Spec: infrav1beta2.IBMPowerVSClusterTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSClusterTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSClusterSpec{
 							ServiceInstanceID: "test-instance1",
 						},
 					},
@@ -55,19 +57,19 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: " IBMPowerVSClusterTemplate with mutable spec",
-			newTemplate: &IBMPowerVSClusterTemplate{
-				Spec: IBMPowerVSClusterTemplateSpec{
-					Template: IBMPowerVSClusterTemplateResource{
-						Spec: IBMPowerVSClusterSpec{
+			newTemplate: &infrav1beta2.IBMPowerVSClusterTemplate{
+				Spec: infrav1beta2.IBMPowerVSClusterTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSClusterTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSClusterSpec{
 							ServiceInstanceID: "test-instance1",
 						},
 					},
 				},
 			},
-			oldTemplate: &IBMPowerVSClusterTemplate{
-				Spec: IBMPowerVSClusterTemplateSpec{
-					Template: IBMPowerVSClusterTemplateResource{
-						Spec: IBMPowerVSClusterSpec{
+			oldTemplate: &infrav1beta2.IBMPowerVSClusterTemplate{
+				Spec: infrav1beta2.IBMPowerVSClusterTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSClusterTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSClusterSpec{
 							ServiceInstanceID: "test-instance2",
 						},
 					},
@@ -78,7 +80,8 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(_ *testing.T) {
-			_, err := test.newTemplate.ValidateUpdate(ctx, test.oldTemplate, test.newTemplate)
+			ibmPowerVSClusterTemplate := IBMPowerVSClusterTemplate{}
+			_, err := ibmPowerVSClusterTemplate.ValidateUpdate(ctx, test.oldTemplate, test.newTemplate)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/webhooks/ibmpowervsimage.go
+++ b/internal/webhooks/ibmpowervsimage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
@@ -24,6 +24,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsimages,verbs=create;update,versions=v1beta2,name=mibmpowervsimage.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -31,11 +33,14 @@ import (
 
 func (r *IBMPowerVSImage) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&IBMPowerVSImage{}).
+		For(&infrav1beta2.IBMPowerVSImage{}).
 		WithValidator(r).
 		WithDefaulter(r).
 		Complete()
 }
+
+// IBMPowerVSImage implements a validation and defaulting webhook for IBMPowerVSImage.
+type IBMPowerVSImage struct{}
 
 var _ webhook.CustomDefaulter = &IBMPowerVSImage{}
 var _ webhook.CustomValidator = &IBMPowerVSImage{}

--- a/internal/webhooks/ibmpowervsmachine_test.go
+++ b/internal/webhooks/ibmpowervsmachine_test.go
@@ -14,53 +14,56 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestIBMPowerVSMachine_default(t *testing.T) {
 	g := NewWithT(t)
-	powervsMachine := &IBMPowerVSMachine{
+	powervsMachine := &infrav1beta2.IBMPowerVSMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "capi-machine",
 			Namespace: "default",
 		},
-		Spec: IBMPowerVSMachineSpec{
+		Spec: infrav1beta2.IBMPowerVSMachineSpec{
 			MemoryGiB:  4,
 			Processors: intstr.FromString("0.5"),
-			Image: &IBMPowerVSResourceReference{
+			Image: &infrav1beta2.IBMPowerVSResourceReference{
 				ID: ptr.To("capi-image"),
 			},
 		},
 	}
-	g.Expect(powervsMachine.Default(context.Background(), powervsMachine)).ToNot(HaveOccurred())
+	g.Expect((&IBMPowerVSMachine{}).Default(context.Background(), powervsMachine)).ToNot(HaveOccurred())
 	g.Expect(powervsMachine.Spec.SystemType).To(BeEquivalentTo("s922"))
-	g.Expect(powervsMachine.Spec.ProcessorType).To(BeEquivalentTo(PowerVSProcessorTypeShared))
+	g.Expect(powervsMachine.Spec.ProcessorType).To(BeEquivalentTo(infrav1beta2.PowerVSProcessorTypeShared))
 }
 
 func TestIBMPowerVSMachine_create(t *testing.T) {
 	tests := []struct {
 		name           string
-		powervsMachine *IBMPowerVSMachine
+		powerVSMachine *infrav1beta2.IBMPowerVSMachine
 		wantErr        bool
 	}{
 		{
 			name: "Should fail to validate IBMPowerVSMachine - incorrect spec values",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "a890",
 					ProcessorType:     "unknown",
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net"),
 					},
@@ -70,12 +73,12 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachine - no Image or Imagref in Spec",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
-					Network: IBMPowerVSResourceReference{
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
 				},
@@ -84,15 +87,15 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachine - both Image and Imagref specified in Spec",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
-					Network: IBMPowerVSResourceReference{
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image:    &IBMPowerVSResourceReference{},
+					Image:    &infrav1beta2.IBMPowerVSResourceReference{},
 					ImageRef: &corev1.LocalObjectReference{},
 				},
 			},
@@ -100,15 +103,15 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachine - Both Id and Name specified in Spec",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
-					Network: IBMPowerVSResourceReference{
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-image-id"),
 						Name: ptr.To("capi-image"),
 					},
@@ -118,15 +121,15 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachine - invalid memory and processor values",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
-					Network: IBMPowerVSResourceReference{
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-image"),
 					},
 					Processors: intstr.FromString("two"),
@@ -137,15 +140,15 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 		},
 		{
 			name: "Should successfully validate IBMPowerVSMachine - valid spec",
-			powervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			powerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
-					Network: IBMPowerVSResourceReference{
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 					Processors: intstr.FromString("0.25"),
@@ -157,7 +160,7 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			machine := tc.powervsMachine.DeepCopy()
+			machine := tc.powerVSMachine.DeepCopy()
 			machine.ObjectMeta = metav1.ObjectMeta{
 				GenerateName: "capi-machine-",
 				Namespace:    "default",
@@ -173,38 +176,38 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 func TestIBMPowerVSMachine_update(t *testing.T) {
 	tests := []struct {
 		name              string
-		oldPowervsMachine *IBMPowerVSMachine
-		newPowervsMachine *IBMPowerVSMachine
+		oldPowerVSMachine *infrav1beta2.IBMPowerVSMachine
+		newPowerVSMachine *infrav1beta2.IBMPowerVSMachine
 		wantErr           bool
 	}{
 		{
 			name: "Should fail to update IBMPowerVSMachine with invalid ProcessorType",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "e980",
 					ProcessorType:     "invalid",
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
@@ -213,33 +216,33 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachine with invalid Network",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 						ID:   ptr.To("capi-net-ID"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
@@ -248,32 +251,32 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachine with invalid Image",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-image-id"),
 						Name: ptr.To("capi-image"),
 					},
@@ -283,32 +286,32 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachine with invalid memory",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         int32(-8),
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
@@ -317,32 +320,32 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachine with invalid processors",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("two"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
@@ -351,29 +354,29 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 		},
 		{
 			name: "Should successfully update IBMPowerVSMachine",
-			oldPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			oldPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         4,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image-id"),
 					},
 				},
 			},
-			newPowervsMachine: &IBMPowerVSMachine{
-				Spec: IBMPowerVSMachineSpec{
+			newPowerVSMachine: &infrav1beta2.IBMPowerVSMachine{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					ServiceInstanceID: "capi-si-id",
 					SystemType:        "s922",
-					ProcessorType:     PowerVSProcessorTypeShared,
+					ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 					MemoryGiB:         8,
 					Processors:        intstr.FromString("0.25"),
-					Network: IBMPowerVSResourceReference{
+					Network: infrav1beta2.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
 					ImageRef: &corev1.LocalObjectReference{
@@ -386,7 +389,7 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			machine := tc.oldPowervsMachine.DeepCopy()
+			machine := tc.oldPowerVSMachine.DeepCopy()
 			machine.ObjectMeta = metav1.ObjectMeta{
 				GenerateName: "capi-machine-",
 				Namespace:    "default",
@@ -394,7 +397,7 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			if err := testEnv.Create(ctx, machine); err != nil {
 				t.Errorf("failed to create machine: %v", err)
 			}
-			machine.Spec = tc.newPowervsMachine.Spec
+			machine.Spec = tc.newPowerVSMachine.Spec
 			if err := testEnv.Update(ctx, machine); (err != nil) != tc.wantErr {
 				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/internal/webhooks/ibmpowervsmachinetemplate.go
+++ b/internal/webhooks/ibmpowervsmachinetemplate.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 )
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsmachinetemplates,verbs=create;update,versions=v1beta2,name=mibmpowervsmachinetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -35,18 +37,21 @@ import (
 
 func (r *IBMPowerVSMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&IBMPowerVSMachineTemplate{}).
+		For(&infrav1beta2.IBMPowerVSMachineTemplate{}).
 		WithValidator(r).
 		WithDefaulter(r).
 		Complete()
 }
+
+// IBMPowerVSMachineTemplate implements a validation and defaulting webhook for IBMPowerVSMachineTemplate.
+type IBMPowerVSMachineTemplate struct{}
 
 var _ webhook.CustomDefaulter = &IBMPowerVSMachineTemplate{}
 var _ webhook.CustomValidator = &IBMPowerVSMachineTemplate{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
 func (r *IBMPowerVSMachineTemplate) Default(_ context.Context, obj runtime.Object) error {
-	objValue, ok := obj.(*IBMPowerVSMachineTemplate)
+	objValue, ok := obj.(*infrav1beta2.IBMPowerVSMachineTemplate)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", obj))
 	}
@@ -56,20 +61,20 @@ func (r *IBMPowerVSMachineTemplate) Default(_ context.Context, obj runtime.Objec
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (r *IBMPowerVSMachineTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	objValue, ok := obj.(*IBMPowerVSMachineTemplate)
+	objValue, ok := obj.(*infrav1beta2.IBMPowerVSMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", obj))
 	}
-	return objValue.validateIBMPowerVSMachineTemplate()
+	return validateIBMPowerVSMachineTemplate(objValue)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (r *IBMPowerVSMachineTemplate) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	objValue, ok := newObj.(*IBMPowerVSMachineTemplate)
+	objValue, ok := newObj.(*infrav1beta2.IBMPowerVSMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IBMPowerVSMachineTemplate but got a %T", newObj))
 	}
-	return objValue.validateIBMPowerVSMachineTemplate()
+	return validateIBMPowerVSMachineTemplate(objValue)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
@@ -77,18 +82,18 @@ func (r *IBMPowerVSMachineTemplate) ValidateDelete(_ context.Context, _ runtime.
 	return nil, nil
 }
 
-func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplate() (admission.Warnings, error) {
+func validateIBMPowerVSMachineTemplate(machineTemplate *infrav1beta2.IBMPowerVSMachineTemplate) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	if err := r.validateIBMPowerVSMachineTemplateNetwork(); err != nil {
+	if err := validateIBMPowerVSMachineTemplateNetwork(machineTemplate); err != nil {
 		allErrs = append(allErrs, err)
 	}
-	if err := r.validateIBMPowerVSMachineTemplateImage(); err != nil {
+	if err := validateIBMPowerVSMachineTemplateImage(machineTemplate); err != nil {
 		allErrs = append(allErrs, err)
 	}
-	if err := r.validateIBMPowerVSMachineTemplateMemory(); err != nil {
+	if err := validateIBMPowerVSMachineTemplateMemory(machineTemplate); err != nil {
 		allErrs = append(allErrs, err)
 	}
-	if err := r.validateIBMPowerVSMachineTemplateProcessors(); err != nil {
+	if err := validateIBMPowerVSMachineTemplateProcessors(machineTemplate); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if len(allErrs) == 0 {
@@ -97,18 +102,18 @@ func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplate() (admissi
 
 	return nil, apierrors.NewInvalid(
 		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: "IBMPowerVSMachineTemplate"},
-		r.Name, allErrs)
+		machineTemplate.Name, allErrs)
 }
 
-func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplateNetwork() *field.Error {
-	if res, err := validateIBMPowerVSNetworkReference(r.Spec.Template.Spec.Network); !res {
+func validateIBMPowerVSMachineTemplateNetwork(machineTemplate *infrav1beta2.IBMPowerVSMachineTemplate) *field.Error {
+	if res, err := validateIBMPowerVSNetworkReference(machineTemplate.Spec.Template.Spec.Network); !res {
 		return err
 	}
 	return nil
 }
 
-func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplateImage() *field.Error {
-	mt := r.Spec.Template
+func validateIBMPowerVSMachineTemplateImage(machineTemplate *infrav1beta2.IBMPowerVSMachineTemplate) *field.Error {
+	mt := machineTemplate.Spec.Template
 
 	if mt.Spec.Image == nil && mt.Spec.ImageRef == nil {
 		return field.Invalid(field.NewPath(""), "", "One of - Image or ImageRef must be specified")
@@ -127,16 +132,16 @@ func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplateImage() *fi
 	return nil
 }
 
-func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplateMemory() *field.Error {
-	if res := validateIBMPowerVSMemoryValues(r.Spec.Template.Spec.MemoryGiB); !res {
-		return field.Invalid(field.NewPath("spec", "template", "spec", "memoryGiB"), r.Spec.Template.Spec.MemoryGiB, "Invalid Memory value - must be a positive integer no lesser than 2")
+func validateIBMPowerVSMachineTemplateMemory(machineTemplate *infrav1beta2.IBMPowerVSMachineTemplate) *field.Error {
+	if res := validateIBMPowerVSMemoryValues(machineTemplate.Spec.Template.Spec.MemoryGiB); !res {
+		return field.Invalid(field.NewPath("spec", "template", "spec", "memoryGiB"), machineTemplate.Spec.Template.Spec.MemoryGiB, "Invalid Memory value - must be a positive integer no lesser than 2")
 	}
 	return nil
 }
 
-func (r *IBMPowerVSMachineTemplate) validateIBMPowerVSMachineTemplateProcessors() *field.Error {
-	if res := validateIBMPowerVSProcessorValues(r.Spec.Template.Spec.Processors); !res {
-		return field.Invalid(field.NewPath("spec", "template", "spec", "processors"), r.Spec.Template.Spec.Processors, "Invalid Processors value - must be non-empty and positive floating-point number no lesser than 0.25")
+func validateIBMPowerVSMachineTemplateProcessors(machineTemplate *infrav1beta2.IBMPowerVSMachineTemplate) *field.Error {
+	if res := validateIBMPowerVSProcessorValues(machineTemplate.Spec.Template.Spec.Processors); !res {
+		return field.Invalid(field.NewPath("spec", "template", "spec", "processors"), machineTemplate.Spec.Template.Spec.Processors, "Invalid Processors value - must be non-empty and positive floating-point number no lesser than 0.25")
 	}
 	return nil
 }

--- a/internal/webhooks/ibmpowervsmachinetemplate_test.go
+++ b/internal/webhooks/ibmpowervsmachinetemplate_test.go
@@ -14,59 +14,62 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestIBMPowerVSMachineTemplate_default(t *testing.T) {
 	g := NewWithT(t)
-	powervsMachineTemplate := &IBMPowerVSMachineTemplate{
+	powervsMachineTemplate := &infrav1beta2.IBMPowerVSMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "capi-machine-template",
 			Namespace: "default",
 		},
-		Spec: IBMPowerVSMachineTemplateSpec{
-			Template: IBMPowerVSMachineTemplateResource{
-				Spec: IBMPowerVSMachineSpec{
+		Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+			Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+				Spec: infrav1beta2.IBMPowerVSMachineSpec{
 					MemoryGiB:  4,
 					Processors: intstr.FromString("0.5"),
-					Image: &IBMPowerVSResourceReference{
+					Image: &infrav1beta2.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image"),
 					},
 				},
 			},
 		},
 	}
-	g.Expect(powervsMachineTemplate.Default(context.Background(), powervsMachineTemplate)).ToNot(HaveOccurred())
+	g.Expect((&IBMPowerVSMachineTemplate{}).Default(context.Background(), powervsMachineTemplate)).ToNot(HaveOccurred())
 	g.Expect(powervsMachineTemplate.Spec.Template.Spec.SystemType).To(BeEquivalentTo("s922"))
-	g.Expect(powervsMachineTemplate.Spec.Template.Spec.ProcessorType).To(BeEquivalentTo(PowerVSProcessorTypeShared))
+	g.Expect(powervsMachineTemplate.Spec.Template.Spec.ProcessorType).To(BeEquivalentTo(infrav1beta2.PowerVSProcessorTypeShared))
 }
 
 func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 	tests := []struct {
 		name                   string
-		powervsMachineTemplate *IBMPowerVSMachineTemplate
+		powervsMachineTemplate *infrav1beta2.IBMPowerVSMachineTemplate
 		wantErr                bool
 	}{
 		{
 			name: "Should fail to validate IBMPowerVSMachineTemplate - incorrect spec values",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "a890",
 							ProcessorType:     "unknown",
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								ID:   ptr.To("capi-net-id"),
 								Name: ptr.To("capi-net"),
 							},
@@ -78,14 +81,14 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachineTemplate - no Image or Imagref in Spec",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
-							Network: IBMPowerVSResourceReference{
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
 						},
@@ -96,17 +99,17 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachineTemplate - both Image and Imagref specified in Spec",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
-							Network: IBMPowerVSResourceReference{
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image:    &IBMPowerVSResourceReference{},
+							Image:    &infrav1beta2.IBMPowerVSResourceReference{},
 							ImageRef: &corev1.LocalObjectReference{},
 						},
 					},
@@ -116,17 +119,17 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachineTemplate - Both ID and Name specified for Image",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
-							Network: IBMPowerVSResourceReference{
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID:   ptr.To("capi-image-id"),
 								Name: ptr.To("capi-image"),
 							},
@@ -138,17 +141,17 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 		},
 		{
 			name: "Should fail to validate IBMPowerVSMachineTemplate - invalid memory and processor values",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
-							Network: IBMPowerVSResourceReference{
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-image"),
 							},
 							Processors: intstr.FromString("two"),
@@ -161,17 +164,17 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 		},
 		{
 			name: "Should successfully validate IBMPowerVSMachineTemplate - valid spec",
-			powervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			powervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
-							Network: IBMPowerVSResourceReference{
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 							Processors: intstr.FromString("0.25"),
@@ -202,44 +205,44 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 	tests := []struct {
 		name                      string
-		oldPowervsMachineTemplate *IBMPowerVSMachineTemplate
-		newPowervsMachineTemplate *IBMPowerVSMachineTemplate
+		oldPowervsMachineTemplate *infrav1beta2.IBMPowerVSMachineTemplate
+		newPowervsMachineTemplate *infrav1beta2.IBMPowerVSMachineTemplate
 		wantErr                   bool
 	}{
 		{
 			name: "Should fail to update IBMPowerVSMachineTemplate with invalid ProcessorType",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "e980",
 							ProcessorType:     "invalid",
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
@@ -250,39 +253,39 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachineTemplate with invalid Network",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 								ID:   ptr.To("capi-net-ID"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
@@ -293,38 +296,38 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachineTemplate with invalid Image",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID:   ptr.To("capi-image-id"),
 								Name: ptr.To("capi-image"),
 							},
@@ -336,38 +339,38 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachineTemplate with invalid memory",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         int32(-8),
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
@@ -378,38 +381,38 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 		},
 		{
 			name: "Should fail to update IBMPowerVSMachineTemplate with invalid processors",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("two"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
@@ -420,38 +423,38 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 		},
 		{
 			name: "Should successfully update IBMPowerVSMachineTemplate",
-			oldPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			oldPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         4,
 							Processors:        intstr.FromString("0.25"),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},
 					},
 				},
 			},
-			newPowervsMachineTemplate: &IBMPowerVSMachineTemplate{
-				Spec: IBMPowerVSMachineTemplateSpec{
-					Template: IBMPowerVSMachineTemplateResource{
-						Spec: IBMPowerVSMachineSpec{
+			newPowervsMachineTemplate: &infrav1beta2.IBMPowerVSMachineTemplate{
+				Spec: infrav1beta2.IBMPowerVSMachineTemplateSpec{
+					Template: infrav1beta2.IBMPowerVSMachineTemplateResource{
+						Spec: infrav1beta2.IBMPowerVSMachineSpec{
 							ServiceInstanceID: "capi-si-id",
 							SystemType:        "s922",
-							ProcessorType:     PowerVSProcessorTypeShared,
+							ProcessorType:     infrav1beta2.PowerVSProcessorTypeShared,
 							MemoryGiB:         8,
 							Processors:        intstr.FromInt(2),
-							Network: IBMPowerVSResourceReference{
+							Network: infrav1beta2.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
-							Image: &IBMPowerVSResourceReference{
+							Image: &infrav1beta2.IBMPowerVSResourceReference{
 								ID: ptr.To("capi-image-id"),
 							},
 						},

--- a/internal/webhooks/ibmvpcmachine_test.go
+++ b/internal/webhooks/ibmvpcmachine_test.go
@@ -14,46 +14,49 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"context"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestVPCMachine_default(t *testing.T) {
 	g := NewWithT(t)
-	vpcMachine := &IBMVPCMachine{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine", Namespace: "default"}}
-	g.Expect(vpcMachine.Default(context.Background(), vpcMachine)).ToNot(HaveOccurred())
+	vpcMachine := &infrav1beta2.IBMVPCMachine{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine", Namespace: "default"}}
+	g.Expect((&IBMVPCMachine{}).Default(context.Background(), vpcMachine)).ToNot(HaveOccurred())
 	g.Expect(vpcMachine.Spec.Profile).To(BeEquivalentTo("bx2-2x8"))
 }
 
 func TestIBMVPCMachine_Create(t *testing.T) {
 	tests := []struct {
 		name    string
-		machine *IBMVPCMachine
+		machine *infrav1beta2.IBMVPCMachine
 		wantErr bool
 	}{
 		{
 			name: "Create a IBMVPCMachine with valid SizeGiB BootVolume",
-			machine: &IBMVPCMachine{
-				Spec: IBMVPCMachineSpec{
-					BootVolume: &VPCVolume{
+			machine: &infrav1beta2.IBMVPCMachine{
+				Spec: infrav1beta2.IBMVPCMachineSpec{
+					BootVolume: &infrav1beta2.VPCVolume{
 						SizeGiB: 10,
 					},
-					Image: &IBMVPCResourceReference{},
+					Image: &infrav1beta2.IBMVPCResourceReference{},
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "Create a IBMVPCMachine with invalid SizeGiB BootVolume",
-			machine: &IBMVPCMachine{
-				Spec: IBMVPCMachineSpec{
-					BootVolume: &VPCVolume{
+			machine: &infrav1beta2.IBMVPCMachine{
+				Spec: infrav1beta2.IBMVPCMachineSpec{
+					BootVolume: &infrav1beta2.VPCVolume{
 						SizeGiB: 1,
 					},
 				},

--- a/internal/webhooks/ibmvpcmachinetemplate_test.go
+++ b/internal/webhooks/ibmvpcmachinetemplate_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestVPCMachineTemplate_default(t *testing.T) {
+	g := NewWithT(t)
+	vpcMachineTemplate := &infrav1beta2.IBMVPCMachineTemplate{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine-template", Namespace: "default"}}
+	g.Expect((&IBMVPCMachineTemplate{}).Default(context.Background(), vpcMachineTemplate)).ToNot(HaveOccurred())
+	g.Expect(vpcMachineTemplate.Spec.Template.Spec.Profile).To(BeEquivalentTo("bx2-2x8"))
+}

--- a/internal/webhooks/suite_test.go
+++ b/internal/webhooks/suite_test.go
@@ -14,18 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
 	"fmt"
 	"os"
 	"path"
+
 	"testing"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/test/helpers"
 )
 
@@ -43,7 +45,7 @@ func TestMain(m *testing.M) {
 
 // Setting up the test environment.
 func setup() {
-	utilruntime.Must(AddToScheme(scheme.Scheme))
+	utilruntime.Must(infrav1beta2.AddToScheme(scheme.Scheme))
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration([]string{
 		path.Join("config", "crd", "bases"),
 	},

--- a/internal/webhooks/util.go
+++ b/internal/webhooks/util.go
@@ -14,19 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta2
+package webhooks
 
 import (
-	"context"
-	"testing"
-
-	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func TestVPCMachineTemplate_default(t *testing.T) {
-	g := NewWithT(t)
-	vpcMachineTemplate := &IBMVPCMachineTemplate{ObjectMeta: metav1.ObjectMeta{Name: "capi-machine-template", Namespace: "default"}}
-	g.Expect(vpcMachineTemplate.Default(context.Background(), vpcMachineTemplate)).ToNot(HaveOccurred())
-	g.Expect(vpcMachineTemplate.Spec.Template.Spec.Profile).To(BeEquivalentTo("bx2-2x8"))
+// aggregateObjErrors aggregates a list of field errors into a single Invalid API error.
+func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		gk,
+		name,
+		allErrs,
+	)
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	infrav1beta1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1"
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/controllers"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/internal/webhooks"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
@@ -315,35 +316,35 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, serviceEndpoint []e
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&infrav1beta2.IBMVPCCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMVPCCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMVPCCluster")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMVPCMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMVPCMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMVPCMachine")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMVPCMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMVPCMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMVPCMachineTemplate")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMPowerVSCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMPowerVSCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMPowerVSCluster")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMPowerVSMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMPowerVSMachine")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMPowerVSMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMPowerVSMachineTemplate")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMPowerVSImage{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMPowerVSImage{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMPowerVSImage")
 		os.Exit(1)
 	}
-	if err := (&infrav1beta2.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.IBMPowerVSClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IBMPowerVSClusterTemplate")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Its a work towards https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2286

This PR moves the webhooks from api directory to separate webhooks directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move webhooks out of api directory.
```
