### PR TITLE
Fixed bootVolume name bug

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -427,7 +427,7 @@ func (m *MachineScope) volumeToVPCVolumeAttachment(volume *infrav1beta2.VPCVolum
 	}
 
 	if volume.Name != "" {
-		bootVolume.Volume.Name = core.StringPtr(volume.Name)
+		bootVolume.Name = core.StringPtr(volume.Name)
 	}
 
 	if volume.Profile != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2260 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed bug where adding volume name with multiple worker nodes would cause errors due to unique volume name constraint.
```
