### PR TITLE
Add the e1050 System Type

### DIFF
--- a/api/v1beta2/ibmpowervsmachine_types.go
+++ b/api/v1beta2/ibmpowervsmachine_types.go
@@ -77,13 +77,11 @@ type IBMPowerVSMachineSpec struct {
 
 	// systemType is the System type used to host the instance.
 	// systemType determines the number of cores and memory that is available.
-	// Few of the supported SystemTypes are s922,e880,e980.
-	// e880 systemType available only in Dallas Datacenters.
-	// e980 systemType available in Datacenters except Dallas and Washington.
+	// Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
 	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
-	// +kubebuilder:validation:Enum:="s922";"e880";"e980";"s1022";""
+	// +kubebuilder:validation:Enum:="s922";"e980";"s1022";"e1050";"e1080";""
 	// +optional
 	SystemType string `json:"systemType,omitempty"`
 
@@ -101,10 +99,8 @@ type IBMPowerVSMachineSpec struct {
 
 	// processors is the number of virtual processors in a virtual machine.
 	// when the processorType is selected as Dedicated the processors value cannot be fractional.
-	// maximum value for the Processors depends on the selected SystemType.
-	// when SystemType is set to e880 or e980 maximum Processors value is 143.
-	// when SystemType is set to s922 maximum Processors value is 15.
-	// minimum value for Processors depends on the selected ProcessorType.
+	// maximum value for the Processors depends on the selected SystemType,
+	// and minimum value for Processors depends on the selected ProcessorType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud.
 	// when ProcessorType is set as Shared or Capped, The minimum processors is 0.25.
 	// when ProcessorType is set as Dedicated, The minimum processors is 1.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
@@ -115,10 +111,7 @@ type IBMPowerVSMachineSpec struct {
 	Processors intstr.IntOrString `json:"processors,omitempty"`
 
 	// memoryGiB is the size of a virtual machine's memory, in GiB.
-	// maximum value for the MemoryGiB depends on the selected SystemType.
-	// when SystemType is set to e880 maximum MemoryGiB value is 7463 GiB.
-	// when SystemType is set to e980 maximum MemoryGiB value is 15307 GiB.
-	// when SystemType is set to s922 maximum MemoryGiB value is 942 GiB.
+	// maximum value for the MemoryGiB depends on the selected SystemType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud
 	// The minimum memory is 2 GiB.
 	// When omitted, this means the user has no opinion and the platform is left to choose a reasonable
 	// default, which is subject to change over time. The current default is 2.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -389,10 +389,7 @@ spec:
               memoryGiB:
                 description: |-
                   memoryGiB is the size of a virtual machine's memory, in GiB.
-                  maximum value for the MemoryGiB depends on the selected SystemType.
-                  when SystemType is set to e880 maximum MemoryGiB value is 7463 GiB.
-                  when SystemType is set to e980 maximum MemoryGiB value is 15307 GiB.
-                  when SystemType is set to s922 maximum MemoryGiB value is 942 GiB.
+                  maximum value for the MemoryGiB depends on the selected SystemType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud
                   The minimum memory is 2 GiB.
                   When omitted, this means the user has no opinion and the platform is left to choose a reasonable
                   default, which is subject to change over time. The current default is 2.
@@ -441,10 +438,8 @@ spec:
                 description: |-
                   processors is the number of virtual processors in a virtual machine.
                   when the processorType is selected as Dedicated the processors value cannot be fractional.
-                  maximum value for the Processors depends on the selected SystemType.
-                  when SystemType is set to e880 or e980 maximum Processors value is 143.
-                  when SystemType is set to s922 maximum Processors value is 15.
-                  minimum value for Processors depends on the selected ProcessorType.
+                  maximum value for the Processors depends on the selected SystemType,
+                  and minimum value for Processors depends on the selected ProcessorType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud.
                   when ProcessorType is set as Shared or Capped, The minimum processors is 0.25.
                   when ProcessorType is set as Dedicated, The minimum processors is 1.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
@@ -494,16 +489,15 @@ spec:
                 description: |-
                   systemType is the System type used to host the instance.
                   systemType determines the number of cores and memory that is available.
-                  Few of the supported SystemTypes are s922,e880,e980.
-                  e880 systemType available only in Dallas Datacenters.
-                  e980 systemType available in Datacenters except Dallas and Washington.
+                  Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
                   reasonable default, which is subject to change over time. The current default is s922 which is generally available.
                 enum:
                 - s922
-                - e880
                 - e980
                 - s1022
+                - e1050
+                - e1080
                 - ""
                 type: string
             required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
@@ -236,10 +236,7 @@ spec:
                       memoryGiB:
                         description: |-
                           memoryGiB is the size of a virtual machine's memory, in GiB.
-                          maximum value for the MemoryGiB depends on the selected SystemType.
-                          when SystemType is set to e880 maximum MemoryGiB value is 7463 GiB.
-                          when SystemType is set to e980 maximum MemoryGiB value is 15307 GiB.
-                          when SystemType is set to s922 maximum MemoryGiB value is 942 GiB.
+                          maximum value for the MemoryGiB depends on the selected SystemType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud
                           The minimum memory is 2 GiB.
                           When omitted, this means the user has no opinion and the platform is left to choose a reasonable
                           default, which is subject to change over time. The current default is 2.
@@ -288,10 +285,8 @@ spec:
                         description: |-
                           processors is the number of virtual processors in a virtual machine.
                           when the processorType is selected as Dedicated the processors value cannot be fractional.
-                          maximum value for the Processors depends on the selected SystemType.
-                          when SystemType is set to e880 or e980 maximum Processors value is 143.
-                          when SystemType is set to s922 maximum Processors value is 15.
-                          minimum value for Processors depends on the selected ProcessorType.
+                          maximum value for the Processors depends on the selected SystemType,
+                          and minimum value for Processors depends on the selected ProcessorType, which can be found here: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-pricing-virtual-server-on-cloud.
                           when ProcessorType is set as Shared or Capped, The minimum processors is 0.25.
                           when ProcessorType is set as Dedicated, The minimum processors is 1.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
@@ -341,16 +336,15 @@ spec:
                         description: |-
                           systemType is the System type used to host the instance.
                           systemType determines the number of cores and memory that is available.
-                          Few of the supported SystemTypes are s922,e880,e980.
-                          e880 systemType available only in Dallas Datacenters.
-                          e980 systemType available in Datacenters except Dallas and Washington.
+                          Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
                           reasonable default, which is subject to change over time. The current default is s922 which is generally available.
                         enum:
                         - s922
-                        - e880
                         - e980
                         - s1022
+                        - e1050
+                        - e1080
                         - ""
                         type: string
                     required:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
-	github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247 h1:XY7lIZaLKFDyETNfTTiYmaXO+mk9apox4otFel88nUk=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db h1:Fy2pmDLfLq2H0N77KD2LpNoCWbDGP0BknZU/odPx2+c=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=


### PR DESCRIPTION
This PR fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2167

The respective PR for powervs-utils is merged: https://github.com/ppc64le-cloud/powervs-utils/pull/18
