### PR TITLE
Initialise IBMPowerVSImage only when ImageRef is set in PowerVS machine controller

### DIFF
--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -144,8 +144,9 @@ func (r *IBMPowerVSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the IBMPowerVSImage.
-	ibmPowerVSImage := &infrav1beta2.IBMPowerVSImage{}
+	var ibmPowerVSImage *infrav1beta2.IBMPowerVSImage
 	if ibmPowerVSMachine.Spec.ImageRef != nil {
+		ibmPowerVSImage = &infrav1beta2.IBMPowerVSImage{}
 		ibmPowerVSImageName := client.ObjectKey{
 			Namespace: ibmPowerVSMachine.Namespace,
 			Name:      ibmPowerVSMachine.Spec.ImageRef.Name,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
With the recent change, cluster installation was requeuing continuously with
```
IBMPowerVSImage is not ready yet, skipping reconciliation
```
since IBMPowerVSImage will not be nil and it expects [scope.IBMPowerVSImage.Status.Ready](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/controllers/ibmpowervsmachine_controller.go#L276-L277) to be true. It should not block and proceed to fetch the image details from `spec.IBMPowerVSImage`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Initialise IBMPowerVSImage only when ImageRef is set in PowerVS machine controller
```
