### PR TITLE
Update cloud-controller-manager container image to latest image

### DIFF
--- a/templates/addons/crs-powervs.yaml
+++ b/templates/addons/crs-powervs.yaml
@@ -234,7 +234,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibmpowervs-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/addons/crs.yaml
+++ b/templates/addons/crs.yaml
@@ -231,7 +231,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibm-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -540,7 +540,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibmpowervs-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -428,7 +428,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibmpowervs-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -530,7 +530,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibmpowervs-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/cluster-template-vpc-clusterclass.yaml
+++ b/templates/cluster-template-vpc-clusterclass.yaml
@@ -392,7 +392,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibm-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -381,7 +381,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibm-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -168,7 +168,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibmpowervs-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -168,7 +168,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: ibm-cloud-controller-manager
-              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:6256ccf
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
               args:
                 - --v=2
                 - --cloud-provider=ibm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Updates the cloud-controller-manager container image to latest image

Image built via PR: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2314
Image promotion is done via PR: https://github.com/kubernetes/k8s.io/pull/8013
Image location: https://console.cloud.google.com/artifacts/docker/k8s-staging-capi-ibmcloud/us/gcr.io/powervs-cloud-controller-manager

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update cloud-controller-manager container image to latest
```
