### PR TITLE
Fixed additionalvolume fields in e2e template

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -132,8 +132,8 @@ spec:
       additionalVolumes:
       - name: additional-volume-1
         profile: general-purpose
-        sizeGiB: 25
-      - iops: 3000
+        sizeGiB: 50
+      - iops: 100
         name: additional-volume-2
         profile: custom
         sizeGiB: 50

--- a/templates/cluster-template/md.yaml
+++ b/templates/cluster-template/md.yaml
@@ -8,10 +8,10 @@ spec:
       additionalVolumes:
       - name: additional-volume-1
         profile: general-purpose
-        sizeGiB: 25
+        sizeGiB: 50
       - name: additional-volume-2
         profile: custom
         sizeGiB: 50
-        iops: 3000
+        iops: 100
       bootVolume:
         sizeGiB: ${IBMVPC_WORKER_BOOT_VOLUME_SIZEGIB:=20}

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -403,8 +403,8 @@ spec:
       additionalVolumes:
       - name: additional-volume-1
         profile: general-purpose
-        sizeGiB: 25
-      - iops: 3000
+        sizeGiB: 50
+      - iops: 100
         name: additional-volume-2
         profile: custom
         sizeGiB: 50


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: 
The iops given in the additionalvolumes fields in e2e template is invalid, this PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed additionalvolume fields in e2e template
```
