### PR TITLE
Enhance UT for ReconcileCOSInstance method

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -2307,7 +2307,7 @@ func (s *PowerVSClusterScope) ReconcileCOSInstance(ctx context.Context) error {
 		},
 	}
 
-	cosClient, err := cos.NewService(cosOptions, apiKey, *cosServiceInstanceStatus.GUID)
+	cosClient, err := cos.NewServiceWrapper(cosOptions, apiKey, *cosServiceInstanceStatus.GUID)
 	if err != nil {
 		return fmt.Errorf("failed to create COS client: %w", err)
 	}

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -548,7 +548,7 @@ func (m *PowerVSMachineScope) DeleteMachineIgnition(ctx context.Context) error {
 }
 
 // createCOSClient creates a new cosClient from the supplied parameters.
-func (m *PowerVSMachineScope) createCOSClient(ctx context.Context) (*cos.Service, error) {
+func (m *PowerVSMachineScope) createCOSClient(ctx context.Context) (cos.Cos, error) {
 	log := ctrl.LoggerFrom(ctx)
 	var cosInstanceName string
 	if m.IBMPowerVSCluster.Spec.CosInstance == nil || m.IBMPowerVSCluster.Spec.CosInstance.Name == "" {

--- a/pkg/cloud/services/cos/service.go
+++ b/pkg/cloud/services/cos/service.go
@@ -90,8 +90,16 @@ func (s *Service) PutPublicAccessBlock(input *s3.PutPublicAccessBlockInput) (*s3
 	return s.client.PutPublicAccessBlock(input)
 }
 
+// NewServiceFunc is a variable that will hold the function reference.
+var NewServiceFunc = NewService // Default to the original function
+
+// NewServiceWrapper returns a new service for the IBM Cloud COS api client, useful in unit testing.
+func NewServiceWrapper(options ServiceOptions, apikey, serviceInstance string) (Cos, error) {
+	return NewServiceFunc(options, apikey, serviceInstance)
+}
+
 // NewService returns a new service for the IBM Cloud Resource Controller api client.
-func NewService(options ServiceOptions, apikey, serviceInstance string) (*Service, error) {
+func NewService(options ServiceOptions, apikey, serviceInstance string) (Cos, error) {
 	if options.Options == nil {
 		options.Options = &cosSession.Options{}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds the missing UT to ReconcileServiceInstance method by adding ability to override the COSClient.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2034

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhance UT for ReconcileCOSInstance method
```
