### PR TITLE
[release-0.10] bump go to 1.23.8 and add CVEs to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,4 @@
 # According to govulncheck we are not using code that is affected by CVEs
+CVE-2025-22869
 CVE-2025-22870
+CVE-2025-22872

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ RELEASE_DIR := out
 OUTPUT_TYPE ?= type=registry
 
 # Go
-GO_VERSION ?=1.22.12
+GO_VERSION ?=1.23.8
 GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 
 # kind

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.22.12"
+GO_VERSION = "1.23.8"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- bump go to 1.23.8 and add CVEs to trivyignore

The [weekly security scan task](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/actions/workflows/weekly-security-scan.yaml) has found two modules that have CVEs in our codebase.
- golang.org/x/crypto
- golang.org/x/net

To bump these to the fixed version (0.35 for crypto and 0.38 for net), we would need to bump the project to use 1.23. We don't generally do this as it'd force anyone consuming the module downstream to upgrade their go as well and that might not work for their projects or timelines. (Hence ignoring those explicitly)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bump go to 1.23.8 and add CVEs to trivyignore
```
