### PR TITLE
Update cluster-api version to v1.11.0-alpha.0 in e2e test files

### DIFF
--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -9,24 +9,24 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/core-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/core-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/bootstrap-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/bootstrap-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/control-plane-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/control-plane-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"

--- a/test/e2e/config/ibmcloud-e2e-vpc.yaml
+++ b/test/e2e/config/ibmcloud-e2e-vpc.yaml
@@ -9,24 +9,24 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/core-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/core-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/bootstrap-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/bootstrap-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.10.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/control-plane-components.yaml
+    - name: v1.11.0-alpha.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-alpha.0/control-plane-components.yaml
       type: url
       files:
       - sourcePath: "${PWD}/test/e2e/data/shared/metadata.yaml"

--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -6,6 +6,9 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 1
+    minor: 11
+    contract: v1beta2
+  - major: 1
     minor: 10
     contract: v1beta1
   - major: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Update cluster-api version to v1.11.x in e2e test files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #2387 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update cluster-api version to v1.11.x in e2e test files
```
