### PR TITLE
Update the cluster templates with the latest changes added in cluster-api version 1.11.0-alpha.2

### DIFF
--- a/templates/bases/powervs/cluster.yaml
+++ b/templates/bases/powervs/cluster.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
         - ${SERVICE_CIDR:="10.128.0.0/12"}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMPowerVSCluster
     name: "${CLUSTER_NAME}"
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: "${CLUSTER_NAME}-control-plane"
 ---

--- a/templates/bases/powervs/kcp.yaml
+++ b/templates/bases/powervs/kcp.yaml
@@ -8,7 +8,7 @@ spec:
   machineTemplate:
     infrastructureRef:
       kind: IBMPowerVSMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
@@ -34,7 +34,6 @@ spec:
       discovery:
         bootstrapToken:
           apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
-          token: ""
           caCertHashes: [ ]
           unsafeSkipCAVerification: false
       nodeRegistration:

--- a/templates/bases/powervs/kubeadm-config.yaml
+++ b/templates/bases/powervs/kubeadm-config.yaml
@@ -11,7 +11,6 @@ spec:
         discovery:
           bootstrapToken:
             apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
-            token: ""
             caCertHashes: []
             unsafeSkipCAVerification: false
         nodeRegistration:

--- a/templates/bases/powervs/md.yaml
+++ b/templates/bases/powervs/md.yaml
@@ -12,11 +12,11 @@ spec:
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMPowerVSMachineTemplate
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/templates/bases/vpc/cluster.yaml
+++ b/templates/bases/vpc/cluster.yaml
@@ -15,15 +15,13 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMVPCCluster
     name: "${CLUSTER_NAME}"
-    namespace: "${NAMESPACE}"
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: "${CLUSTER_NAME}-control-plane"
-    namespace: "${NAMESPACE}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: IBMVPCCluster

--- a/templates/bases/vpc/kcp.yaml
+++ b/templates/bases/vpc/kcp.yaml
@@ -9,12 +9,10 @@ spec:
   machineTemplate:
     infrastructureRef:
       kind: IBMVPCMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       name: "${CLUSTER_NAME}-control-plane"
-      namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      kubernetesVersion: ${KUBERNETES_VERSION}
       controllerManager:
         extraArgs:
         - name: enable-hostpath-provisioner
@@ -23,7 +21,6 @@ spec:
         certSANs: [localhost, 127.0.0.1]
       dns: {}
       etcd: {}
-      networking: {}
       scheduler: {}
     initConfiguration:
       nodeRegistration:

--- a/templates/bases/vpc/md.yaml
+++ b/templates/bases/vpc/md.yaml
@@ -12,11 +12,11 @@ spec:
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMVPCMachineTemplate
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -15,7 +15,8 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   topology:
-    class: ${IBMPOWERVS_CLUSTER_CLASS_NAME}
+    classRef:
+      name: ${IBMPOWERVS_CLUSTER_CLASS_NAME}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
@@ -23,9 +24,9 @@ spec:
       machineDeployments:
       - class: default-worker
         name: md-0
-        replicas: 2
+        replicas: ${WORKER_MACHINE_COUNT}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: ${IBMPOWERVS_CLUSTER_CLASS_NAME:="powervs-cc"}
@@ -37,7 +38,7 @@ spec:
         kind: IBMPowerVSMachineTemplate
         name: ${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane-machinetemplate
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: ${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane
   infrastructure:
@@ -51,7 +52,7 @@ spec:
       template:
         bootstrap:
           ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
             name: ${IBMPOWERVS_CLUSTER_CLASS_NAME}-md-0
         infrastructure:
@@ -74,7 +75,7 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane
@@ -88,12 +89,15 @@ spec:
             - ${IBMPOWERVS_VIP}
             - ${IBMPOWERVS_VIP_EXTERNAL}
             extraArgs:
-              cloud-provider: external
+            - name: cloud-provider
+              value: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:
-              cloud-provider: external
-              enable-hostpath-provisioner: "true"
+            - name: cloud-provider
+              value: external
+            - name: enable-hostpath-provisioner
+              value: "true"
         files:
         - content: |
             apiVersion: v1
@@ -215,21 +219,24 @@ spec:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             name: '{{ v1.local_hostname }}'
         joinConfiguration:
           discovery:
             bootstrapToken:
               apiServerEndpoint: 192.168.167.85:${API_SERVER_PORT:=6443}
               caCertHashes: []
-              token: ""
               unsafeSkipCAVerification: false
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             name: '{{ v1.local_hostname }}'
         preKubeadmCommands:
         - hostname "{{ v1.local_hostname }}"
@@ -240,7 +247,7 @@ spec:
         - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
           do echo "Running script $script"; "$script"; done
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   labels:
@@ -255,13 +262,14 @@ spec:
           bootstrapToken:
             apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
             caCertHashes: []
-            token: ""
             unsafeSkipCAVerification: false
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            cloud-provider: external
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          - name: cloud-provider
+            value: external
+          - name: eviction-hard
+            value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           name: '{{ v1.local_hostname }}'
       preKubeadmCommands:
       - hostname "{{ v1.local_hostname }}"

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -15,7 +15,8 @@ spec:
       cidrBlocks:
         - ${SERVICE_CIDR:="10.128.0.0/12"}
   topology:
-    class: "${IBMPOWERVS_CLUSTER_CLASS_NAME}"
+    classRef:
+      name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}"
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
@@ -23,9 +24,9 @@ spec:
       machineDeployments:
         - class: default-worker
           name: md-0
-          replicas: 2
+          replicas: ${WORKER_MACHINE_COUNT}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: ${IBMPOWERVS_CLUSTER_CLASS_NAME:="powervs-cc"}
@@ -37,7 +38,7 @@ spec:
         kind: IBMPowerVSMachineTemplate
         name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane-machinetemplate"
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane"
   infrastructure:
@@ -51,7 +52,7 @@ spec:
         template:
           bootstrap:
             ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
               kind: KubeadmConfigTemplate
               name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-md-0"
           infrastructure:
@@ -74,7 +75,7 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: "${IBMPOWERVS_CLUSTER_CLASS_NAME}-control-plane"
@@ -88,12 +89,15 @@ spec:
               - "${IBMPOWERVS_VIP}"
               - "${IBMPOWERVS_VIP_EXTERNAL}"
             extraArgs:
-              cloud-provider: external
+              - name: cloud-provider
+                value: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:
-              cloud-provider: external
-              enable-hostpath-provisioner: "true"
+              - name: cloud-provider
+                value: external
+              - name: enable-hostpath-provisioner
+                value: "true"
         files:
           - content: |
               apiVersion: v1
@@ -215,21 +219,24 @@ spec:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+              - name: cloud-provider
+                value: external
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             name: '{{ v1.local_hostname }}'
         joinConfiguration:
           discovery:
             bootstrapToken:
               apiServerEndpoint: 192.168.167.85:${API_SERVER_PORT:=6443}
               caCertHashes: []
-              token: ""
               unsafeSkipCAVerification: false
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+              - name: cloud-provider
+                value: external
+              - name: eviction-hard
+                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             name: '{{ v1.local_hostname }}'
         preKubeadmCommands:
           - hostname "{{ v1.local_hostname }}"

--- a/templates/cluster-template-powervs-clusterclass/md.yaml
+++ b/templates/cluster-template-powervs-clusterclass/md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   labels:
@@ -13,13 +13,14 @@ spec:
           bootstrapToken:
             apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
             caCertHashes: []
-            token: ""
             unsafeSkipCAVerification: false
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            cloud-provider: external
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           name: '{{ v1.local_hostname }}'
       preKubeadmCommands:
         - hostname "{{ v1.local_hostname }}"

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -16,11 +16,11 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMPowerVSCluster
     name: ${CLUSTER_NAME}
 ---
@@ -93,7 +93,7 @@ spec:
     - echo "{{ v1.local_hostname }}" >/etc/hostname
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: IBMPowerVSMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -129,12 +129,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMPowerVSMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -15,11 +15,11 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMPowerVSCluster
     name: ${CLUSTER_NAME}
 ---
@@ -187,7 +187,6 @@ spec:
         bootstrapToken:
           apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           caCertHashes: []
-          token: ""
           unsafeSkipCAVerification: false
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -208,7 +207,7 @@ spec:
       do echo "Running script $script"; "$script"; done
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: IBMPowerVSMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -243,12 +242,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMPowerVSMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}
@@ -286,7 +285,6 @@ spec:
           bootstrapToken:
             apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
             caCertHashes: []
-            token: ""
             unsafeSkipCAVerification: false
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock

--- a/templates/cluster-template-vpc-clusterclass.yaml
+++ b/templates/cluster-template-vpc-clusterclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -16,7 +16,8 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   topology:
-    class: ${IBMVPC_CLUSTER_CLASS_NAME}
+    classRef:
+      name: ${IBMVPC_CLUSTER_CLASS_NAME}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
@@ -26,7 +27,7 @@ spec:
         name: md-0
         replicas: ${WORKER_MACHINE_COUNT}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: ${IBMVPC_CLUSTER_CLASS_NAME:="vpc-cc"}
@@ -37,25 +38,22 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: IBMVPCMachineTemplate
         name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane-machinetemplate
-        namespace: ${NAMESPACE}
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane
-      namespace: ${NAMESPACE}
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: IBMVPCClusterTemplate
       name: ${IBMVPC_CLUSTER_CLASS_NAME}-cluster-template
-      namespace: ${NAMESPACE}
   workers:
     machineDeployments:
     - class: default-worker
       template:
         bootstrap:
           ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
             name: ${IBMVPC_CLUSTER_CLASS_NAME}-md-0
         infrastructure:
@@ -78,7 +76,7 @@ spec:
       vpc: ${IBMVPC_NAME}
       zone: ${IBMVPC_ZONE}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane
@@ -93,31 +91,36 @@ spec:
             - localhost
             - 127.0.0.1
             extraArgs:
-              cloud-provider: external
+            - name: cloud-provider
+              value: external
           controllerManager:
             extraArgs:
-              cloud-provider: external
-              enable-hostpath-provisioner: "true"
+            - name: enable-hostpath-provisioner
+              value: "true"
+            - name: cloud-provider
+              value: external
           dns: {}
           etcd: {}
-          kubernetesVersion: ${KUBERNETES_VERSION}
-          networking: {}
           scheduler: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
         joinConfiguration:
           discovery: {}
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${IBMVPC_CLUSTER_CLASS_NAME}-md-0
@@ -127,8 +130,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          - name: cloud-provider
+            value: external
+          - name: eviction-hard
+            value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: IBMVPCMachineTemplate

--- a/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -16,7 +16,8 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   topology:
-    class: ${IBMVPC_CLUSTER_CLASS_NAME}
+    classRef:
+      name: ${IBMVPC_CLUSTER_CLASS_NAME}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
@@ -26,7 +27,7 @@ spec:
           name: md-0
           replicas: ${WORKER_MACHINE_COUNT}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: ${IBMVPC_CLUSTER_CLASS_NAME:="vpc-cc"}
@@ -37,25 +38,22 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: IBMVPCMachineTemplate
         name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane-machinetemplate
-        namespace: ${NAMESPACE}
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane
-      namespace: ${NAMESPACE}
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: IBMVPCClusterTemplate
       name: ${IBMVPC_CLUSTER_CLASS_NAME}-cluster-template
-      namespace: ${NAMESPACE}
   workers:
     machineDeployments:
       - class: default-worker
         template:
           bootstrap:
             ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
               kind: KubeadmConfigTemplate
               name: ${IBMVPC_CLUSTER_CLASS_NAME}-md-0
           infrastructure:
@@ -78,7 +76,7 @@ spec:
       vpc: ${IBMVPC_NAME}
       zone: ${IBMVPC_ZONE}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${IBMVPC_CLUSTER_CLASS_NAME}-control-plane
@@ -88,29 +86,34 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          kubernetesVersion: ${KUBERNETES_VERSION}
           apiServer:
             certSANs: [localhost, 127.0.0.1]
             extraArgs:
-              cloud-provider: external
+              - name: cloud-provider
+                value: external
           controllerManager:
             extraArgs:
-              enable-hostpath-provisioner: 'true'
-              cloud-provider: external
+              - name: enable-hostpath-provisioner
+                value: 'true'
+              - name: cloud-provider
+                value: external
           dns: {}
           etcd: {}
-          networking: {}
           scheduler: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              - name: cloud-provider
+                value: external
+              - name: eviction-hard
+                value: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
         joinConfiguration:
           discovery: {}
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              cloud-provider: external
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              - name: cloud-provider
+                value: external
+              - name: eviction-hard
+                value: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'

--- a/templates/cluster-template-vpc-clusterclass/md.yaml
+++ b/templates/cluster-template-vpc-clusterclass/md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: "${IBMVPC_CLUSTER_CLASS_NAME}-md-0"
@@ -8,8 +8,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            - name: cloud-provider
+              value: external
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: IBMVPCMachineTemplate

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -16,15 +16,13 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
-    namespace: ${NAMESPACE}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMVPCCluster
     name: ${CLUSTER_NAME}
-    namespace: ${NAMESPACE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: IBMVPCCluster
@@ -61,8 +59,6 @@ spec:
           value: external
       dns: {}
       etcd: {}
-      kubernetesVersion: ${KUBERNETES_VERSION}
-      networking: {}
       scheduler: {}
     initConfiguration:
       nodeRegistration:
@@ -83,10 +79,9 @@ spec:
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: IBMVPCMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
-      namespace: ${NAMESPACE}
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
@@ -117,12 +112,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMVPCMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -277,7 +277,6 @@ spec:
           bootstrapToken:
             apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
             caCertHashes: []
-            token: ""
             unsafeSkipCAVerification: false
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
@@ -311,11 +310,11 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMPowerVSCluster
     name: ${CLUSTER_NAME}
 ---
@@ -334,12 +333,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMPowerVSMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}
@@ -494,7 +493,6 @@ spec:
         bootstrapToken:
           apiServerEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           caCertHashes: []
-          token: ""
           unsafeSkipCAVerification: false
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -515,7 +513,7 @@ spec:
       do echo "Running script $script"; "$script"; done
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: IBMPowerVSMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -289,15 +289,13 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:="10.128.0.0/12"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
-    namespace: ${NAMESPACE}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: IBMVPCCluster
     name: ${CLUSTER_NAME}
-    namespace: ${NAMESPACE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
@@ -310,12 +308,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: IBMVPCMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}
@@ -341,8 +339,6 @@ spec:
           value: external
       dns: {}
       etcd: {}
-      kubernetesVersion: ${KUBERNETES_VERSION}
-      networking: {}
       scheduler: {}
     initConfiguration:
       nodeRegistration:
@@ -363,10 +359,9 @@ spec:
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: IBMVPCMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
-      namespace: ${NAMESPACE}
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Update the cluster templates with the latest changes added in cluster-api version 1.11.0-alpha.2

errors on template deployment
```
Error from server (BadRequest): error when creating "first.yaml": Cluster in version "v1beta2" cannot be handled as a Cluster: strict decoding error: unknown field "spec.controlPlaneRef.apiVersion", unknown field "spec.infrastructureRef.apiVersion"
Error from server (BadRequest): error when creating "first.yaml": KubeadmControlPlane in version "v1beta2" cannot be handled as a KubeadmControlPlane: strict decoding error: unknown field "spec.machineTemplate.infrastructureRef.apiVersion"
Error from server (BadRequest): error when creating "first.yaml": MachineDeployment in version "v1beta2" cannot be handled as a MachineDeployment: strict decoding error: unknown field "spec.template.spec.bootstrap.configRef.apiVersion", unknown field "spec.template.spec.infrastructureRef.apiVersion"
Error from server (Invalid): error when creating "first.yaml": KubeadmConfigTemplate.bootstrap.cluster.x-k8s.io "ibm-powervs-1-md-0" is invalid: spec.template.spec.joinConfiguration.discovery.bootstrapToken.token: Invalid value: "": spec.template.spec.joinConfiguration.discovery.bootstrapToken.token in body should be at least 1 chars long

Error from server (BadRequest): error when creating "vpc-cc.yaml": Cluster in version "v1beta2" cannot be handled as a Cluster: strict decoding error: unknown field "spec.topology.class"
Error from server (BadRequest): error when creating "vpc-cc.yaml": ClusterClass in version "v1beta2" cannot be handled as a ClusterClass: strict decoding error: unknown field "spec.controlPlane.machineInfrastructure.ref.namespace", unknown field "spec.controlPlane.ref.namespace", unknown field "spec.infrastructure.ref.namespace"
Error from server (BadRequest): error when creating "vpc-cc.yaml": KubeadmControlPlaneTemplate in version "v1beta2" cannot be handled as a KubeadmControlPlaneTemplate: strict decoding error: unknown field "spec.template.spec.kubeadmConfigSpec.clusterConfiguration.kubernetesVersion"
```

PR which introduced most of the changes - https://github.com/kubernetes-sigs/cluster-api/pull/12356
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the cluster templates with the latest changes added in cluster-api version 1.11.0-alpha.2
```
