### PR TITLE
🌱  Remove external cloud-provider flag from apiserver as its removed in k8s v1.33

### DIFF
--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -88,9 +88,6 @@ spec:
             certSANs:
             - ${IBMPOWERVS_VIP}
             - ${IBMPOWERVS_VIP_EXTERNAL}
-            extraArgs:
-            - name: cloud-provider
-              value: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -88,9 +88,6 @@ spec:
             certSANs:
               - "${IBMPOWERVS_VIP}"
               - "${IBMPOWERVS_VIP_EXTERNAL}"
-            extraArgs:
-              - name: cloud-provider
-                value: external
           controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
           controllerManager:
             extraArgs:

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -57,10 +57,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controllerManager:
         extraArgs:
         - name: cloud-provider

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -48,9 +48,6 @@ spec:
         certSANs:
         - ${IBMPOWERVS_VIP}
         - ${IBMPOWERVS_VIP_EXTERNAL}
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-powervs/kcp.yaml
+++ b/templates/cluster-template-powervs/kcp.yaml
@@ -5,10 +5,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controllerManager:
         extraArgs:
         - name: cloud-provider

--- a/templates/cluster-template-vpc-clusterclass.yaml
+++ b/templates/cluster-template-vpc-clusterclass.yaml
@@ -90,9 +90,6 @@ spec:
             certSANs:
             - localhost
             - 127.0.0.1
-            extraArgs:
-            - name: cloud-provider
-              value: external
           controllerManager:
             extraArgs:
             - name: enable-hostpath-provisioner

--- a/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
@@ -88,9 +88,6 @@ spec:
         clusterConfiguration:
           apiServer:
             certSANs: [localhost, 127.0.0.1]
-            extraArgs:
-              - name: cloud-provider
-                value: external
           controllerManager:
             extraArgs:
               - name: enable-hostpath-provisioner

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -50,9 +50,6 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controllerManager:
         extraArgs:
         - name: cloud-provider

--- a/templates/cluster-template/kcp.yaml
+++ b/templates/cluster-template/kcp.yaml
@@ -10,7 +10,3 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-      apiServer:
-        extraArgs:
-        - name: cloud-provider
-          value: external

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -354,9 +354,6 @@ spec:
         certSANs:
         - ${IBMPOWERVS_VIP}
         - ${IBMPOWERVS_VIP_EXTERNAL}
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controlPlaneEndpoint: ${IBMPOWERVS_VIP}:${API_SERVER_PORT:=6443}
       controllerManager:
         extraArgs:

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -330,9 +330,6 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        extraArgs:
-        - name: cloud-provider
-          value: external
       controllerManager:
         extraArgs:
         - name: cloud-provider


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Since the flag is not supported, setting this flag in v1.33 leads to apiserver not starting as unknown flag error.

K8s reference: https://github.com/kubernetes/kubernetes/pull/130162

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # part of #2416

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove apiserver cloud-provider: external flag as its removed in k8s v1.33
```
