### PR TITLE
Fix VPC cluster templates post CAPI version bump to v1.11.0-beta.0

### DIFF
--- a/templates/bases/vpc/kcp.yaml
+++ b/templates/bases/vpc/kcp.yaml
@@ -19,9 +19,6 @@ spec:
           value: "true"
       apiServer:
         certSANs: [localhost, 127.0.0.1]
-      dns: {}
-      etcd: {}
-      scheduler: {}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -31,7 +28,6 @@ spec:
         - name: eviction-hard
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
     joinConfiguration:
-      discovery: {}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:

--- a/templates/cluster-template-vpc-clusterclass.yaml
+++ b/templates/cluster-template-vpc-clusterclass.yaml
@@ -96,9 +96,6 @@ spec:
               value: "true"
             - name: cloud-provider
               value: external
-          dns: {}
-          etcd: {}
-          scheduler: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
@@ -108,7 +105,6 @@ spec:
             - name: eviction-hard
               value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
         joinConfiguration:
-          discovery: {}
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:

--- a/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-vpc-clusterclass/cluster-with-kcp.yaml
@@ -94,9 +94,6 @@ spec:
                 value: 'true'
               - name: cloud-provider
                 value: external
-          dns: {}
-          etcd: {}
-          scheduler: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
@@ -106,7 +103,6 @@ spec:
               - name: eviction-hard
                 value: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
         joinConfiguration:
-          discovery: {}
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -54,9 +54,6 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-      dns: {}
-      etcd: {}
-      scheduler: {}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -66,7 +63,6 @@ spec:
         - name: eviction-hard
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
     joinConfiguration:
-      discovery: {}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:

--- a/test/e2e/data/templates/cluster-template-vpc.yaml
+++ b/test/e2e/data/templates/cluster-template-vpc.yaml
@@ -334,9 +334,6 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-      dns: {}
-      etcd: {}
-      scheduler: {}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -346,7 +343,6 @@ spec:
         - name: eviction-hard
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
     joinConfiguration:
-      discovery: {}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
VPC cluster deployment is failing with below error after cluster-api version update to 1.11.0-beta.0
```
 KubeadmControlPlane.controlplane.cluster.x-k8s.io "capibm-e2e-4cosq8-control-plane" is invalid: [spec.kubeadmConfigSpec.clusterConfiguration.dns: Invalid value: 0: spec.kubeadmConfigSpec.clusterConfiguration.dns in body should have at least 1 properties, spec.kubeadmConfigSpec.clusterConfiguration.scheduler: Invalid value: 0: spec.kubeadmConfigSpec.clusterConfiguration.scheduler in body should have at least 1 properties, spec.kubeadmConfigSpec.clusterConfiguration.etcd: Invalid value: 0: spec.kubeadmConfigSpec.clusterConfiguration.etcd in body should have at least 1 properties, spec.kubeadmConfigSpec.joinConfiguration.discovery: Invalid value: 0: spec.kubeadmConfigSpec.joinConfiguration.discovery in body should have at least 1 properties]
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VPC cluster templates post CAPI version bump to v1.11.0-beta.0
```
