### PR TITLE
Fix revive package name conventions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,10 +121,6 @@ linters:
       - linters:
           - revive
         text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
-        # To be fixed: This is done to unblock the bumping of golint.
-      - linters:
-          - revive
-        text: 'var-naming: avoid meaningless package names'
       - linters:
           - errcheck
         text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?(S|s)?etenv). is not checked

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY cloud/ cloud/
 COPY pkg/ pkg/
-COPY util/ util/
 COPY internal/ internal/
 
 # Build

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -35,9 +35,9 @@ import (
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch" //nolint:staticcheck
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
 )
 
@@ -181,7 +181,7 @@ func (s *ClusterScope) ensureVPCUnique(vpcName string) (*vpcv1.VPC, error) {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -286,7 +286,7 @@ func (s *ClusterScope) getSubnetAddrPrefix(vpcID, zone string) (string, error) {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return "", err
 	}
 
@@ -327,7 +327,7 @@ func (s *ClusterScope) ensureSubnetUnique(subnetName string) (*vpcv1.Subnet, err
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -374,7 +374,7 @@ func (s *ClusterScope) DeleteSubnet(ctx context.Context) error {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return err
 	}
 
@@ -556,7 +556,7 @@ func (s *ClusterScope) getLoadBalancerByHostname(loadBalancerHostname string) (*
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -594,7 +594,7 @@ func (s *ClusterScope) ensureLoadBalancerUnique(loadBalancerName string) (*vpcv1
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -642,7 +642,7 @@ func (s *ClusterScope) DeleteLoadBalancer() (bool, error) {
 			return true, "", nil
 		}
 
-		if err := utils.PagingHelper(f); err != nil {
+		if err := pagingutils.PagingHelper(f); err != nil {
 			return false, err
 		}
 	}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -40,12 +40,13 @@ import (
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch" //nolint:staticcheck
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/globaltagging"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
 )
 
@@ -503,7 +504,7 @@ func (m *MachineScope) ensureInstanceUnique(instanceName string) (*vpcv1.Instanc
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -950,7 +951,7 @@ func fetchKeyID(ctx context.Context, key *infrav1.IBMVPCResourceReference, m *Ma
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -1008,7 +1009,7 @@ func fetchImageID(ctx context.Context, image *infrav1.IBMVPCResourceReference, m
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -1094,7 +1095,7 @@ func (m *MachineScope) SetNotReady() {
 func (m *MachineScope) SetProviderID(id *string) error {
 	// Based on the ProviderIDFormat version the providerID format will be decided.
 	if options.ProviderIDFormatType(options.ProviderIDFormat) == options.ProviderIDFormatV2 {
-		accountID, err := utils.GetAccountIDWrapper()
+		accountID, err := accounts.GetAccountIDWrapper()
 		if err != nil {
 			return fmt.Errorf("failed to get cloud account id: %w", err)
 		}

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc/mock"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/options"
 
@@ -140,7 +140,7 @@ func TestSetVPCProviderID(t *testing.T) {
 		g := NewWithT(t)
 		scope := setupMachineScope(clusterName, machineName, mock.NewMockVpc(gomock.NewController(t)))
 		options.ProviderIDFormat = string("v2")
-		utils.GetAccountIDFunc = func() (string, error) {
+		accounts.GetAccountIDFunc = func() (string, error) {
 			return "dummy-account-id", nil // Return dummy value
 		}
 		err := scope.SetProviderID(ptr.To(providerID))
@@ -151,7 +151,7 @@ func TestSetVPCProviderID(t *testing.T) {
 		g := NewWithT(t)
 		scope := setupMachineScope(clusterName, machineName, mock.NewMockVpc(gomock.NewController(t)))
 		options.ProviderIDFormat = string("v2")
-		utils.GetAccountIDFunc = func() (string, error) {
+		accounts.GetAccountIDFunc = func() (string, error) {
 			return "", errors.New("error getting accountID") // Return dummy error
 		}
 		err := scope.SetProviderID(ptr.To(providerID))

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -49,16 +49,16 @@ import (
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch" //nolint:staticcheck
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/internal/genutil"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/cos"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/resourcecontroller"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/resourcemanager"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/transitgateway"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
-	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
 )
 
 const (
@@ -1993,7 +1993,7 @@ func (s *PowerVSClusterScope) createTransitGateway(ctx context.Context) error {
 		return fmt.Errorf("failed to proeceed with transit gateway creation as either one of VPC or PowerVS service instance reconciliation is not successful")
 	}
 
-	location, globalRouting, err := genUtil.GetTransitGatewayLocationAndRouting(s.Zone(), s.VPC().Region)
+	location, globalRouting, err := genutil.GetTransitGatewayLocationAndRouting(s.Zone(), s.VPC().Region)
 	if err != nil {
 		return fmt.Errorf("failed to get transit gateway location and routing: %w", err)
 	}
@@ -2419,7 +2419,7 @@ func (s *PowerVSClusterScope) fetchResourceGroupID() (string, error) {
 		return "", err
 	}
 
-	account, err := utils.GetAccount(auth)
+	account, err := accounts.GetAccount(auth)
 	if err != nil {
 		return "", err
 	}

--- a/cloud/scope/powervs_cluster_test.go
+++ b/cloud/scope/powervs_cluster_test.go
@@ -39,7 +39,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/cos"
 	mockcos "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/cos/mock"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
@@ -240,7 +240,7 @@ func TestGetDHCPServerID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			dhcpServerID := tc.clusterScope.GetDHCPServerID()
-			g.Expect(utils.DereferencePointer(dhcpServerID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(dhcpServerID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -276,7 +276,7 @@ func TestGetVPCID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			vpcID := tc.clusterScope.GetVPCID()
-			g.Expect(utils.DereferencePointer(vpcID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(vpcID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -355,7 +355,7 @@ func TestGetVPCSubnetID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			subnetID := tc.clusterScope.GetVPCSubnetID(tc.subnetName)
-			g.Expect(utils.DereferencePointer(subnetID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(subnetID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -475,7 +475,7 @@ func TestVPCSecurityGroupByName(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			sgID, _, _ := tc.clusterScope.GetVPCSecurityGroupByName(tc.sgName)
-			g.Expect(utils.DereferencePointer(sgID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(sgID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -554,7 +554,7 @@ func TestVPCSecurityGroupByID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			sgID, _, _ := tc.clusterScope.GetVPCSecurityGroupByID(tc.sgID)
-			g.Expect(utils.DereferencePointer(sgID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(sgID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -601,7 +601,7 @@ func TestGetTransitGatewayID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			tgID := tc.clusterScope.GetTransitGatewayID()
-			g.Expect(utils.DereferencePointer(tgID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(tgID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }
@@ -680,7 +680,7 @@ func TestGetLoadBalancerID(t *testing.T) {
 		g := NewWithT(t)
 		t.Run(tc.name, func(_ *testing.T) {
 			lbID := tc.clusterScope.GetLoadBalancerID(tc.lbName)
-			g.Expect(utils.DereferencePointer(lbID)).To(Equal(utils.DereferencePointer(tc.expectedID)))
+			g.Expect(pointer.Dereference(lbID)).To(Equal(pointer.Dereference(tc.expectedID)))
 		})
 	}
 }

--- a/cmd/capibmadm/cliutils/utils.go
+++ b/cmd/capibmadm/cliutils/utils.go
@@ -14,14 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package utils contains utility and printer functions for cli.
-package utils
+// Package cliutils contains utility functions for cli.
+package cliutils
 
 import (
 	"context"
 	"fmt"
-
-	"github.com/go-openapi/strfmt"
 
 	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 
@@ -54,38 +52,4 @@ func GetResourceGroupID(ctx context.Context, resourceGroup string, accountID str
 
 	err = fmt.Errorf("could not retrieve resource group id for %s", resourceGroup)
 	return "", err
-}
-
-// DereferencePointer dereferences pointer.
-func DereferencePointer(value interface{}) interface{} {
-	switch v := value.(type) {
-	case *string:
-		if v != nil {
-			return *v
-		}
-		return ""
-	case *int, *int8, *int16, *int32, *int64:
-		i := value.(*int64)
-		if i != nil {
-			return *i
-		}
-		return 0
-	case *strfmt.DateTime:
-		if v != nil {
-			return *v
-		}
-		return strfmt.DateTime{}
-	case *bool:
-		if v != nil {
-			return *v
-		}
-		return false
-	case *float32, *float64:
-		f := value.(*float64)
-		if f != nil {
-			return *f
-		}
-		return 0
-	}
-	return nil
 }

--- a/cmd/capibmadm/cmd/powervs/image/import.go
+++ b/cmd/capibmadm/cmd/powervs/image/import.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type imageImportOptions struct {
@@ -107,7 +107,7 @@ func importimage(ctx context.Context, imageImportOption imageImportOptions) erro
 	log := logf.Log
 	log.Info("Importing PowerVS images: ", "service-instance-id", options.GlobalOptions.ServiceInstanceID)
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/image/list.go
+++ b/cmd/capibmadm/cmd/powervs/image/list.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // ListCommand powervs image list command.
@@ -57,7 +57,7 @@ func listimage(ctx context.Context) error {
 	log := logf.Log
 	log.Info("Listing PowerVS images", "service-instance-id", options.GlobalOptions.ServiceInstanceID)
 
-	accountID, err := pkgUtils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}
@@ -83,14 +83,14 @@ func listimage(ctx context.Context) error {
 
 	for _, image := range images.Images {
 		imageToAppend := ImgSpec{
-			ImageID:        utils.DereferencePointer(image.ImageID).(string),
-			Name:           utils.DereferencePointer(image.Name).(string),
-			Description:    utils.DereferencePointer(image.Description).(string),
-			State:          utils.DereferencePointer(image.State).(string),
-			StoragePool:    utils.DereferencePointer(image.StoragePool).(string),
-			StorageType:    utils.DereferencePointer(image.StorageType).(string),
-			CreationDate:   utils.DereferencePointer(image.CreationDate).(strfmt.DateTime),
-			LastUpdateDate: utils.DereferencePointer(image.LastUpdateDate).(strfmt.DateTime),
+			ImageID:        pointer.Dereference(image.ImageID).(string),
+			Name:           pointer.Dereference(image.Name).(string),
+			Description:    pointer.Dereference(image.Description).(string),
+			State:          pointer.Dereference(image.State).(string),
+			StoragePool:    pointer.Dereference(image.StoragePool).(string),
+			StorageType:    pointer.Dereference(image.StorageType).(string),
+			CreationDate:   pointer.Dereference(image.CreationDate).(strfmt.DateTime),
+			LastUpdateDate: pointer.Dereference(image.LastUpdateDate).(strfmt.DateTime),
 		}
 		if image.Specifications != nil {
 			imageToAppend.Architecture = image.Specifications.Architecture

--- a/cmd/capibmadm/cmd/powervs/key/create.go
+++ b/cmd/capibmadm/cmd/powervs/key/create.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type keyCreateOptions struct {
@@ -89,7 +89,7 @@ func createSSHKey(ctx context.Context, keyCreateOption keyCreateOptions) error {
 	logger := log.Log
 	logger.Info("Creating SSH key...")
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/key/delete.go
+++ b/cmd/capibmadm/cmd/powervs/key/delete.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // DeleteSSHKeyCommand - child command of 'key' to delete an SSH key.
@@ -56,7 +56,7 @@ func deleteSSHKey(ctx context.Context, keyName string) error {
 	logger := log.Log
 	logger.Info("Deleting SSH key...")
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/key/list.go
+++ b/cmd/capibmadm/cmd/powervs/key/list.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // ListSSHKeyCommand function to list PowerVS SSH Keys.
@@ -56,7 +56,7 @@ func listSSHKeys(ctx context.Context) error {
 	log := logf.Log
 	log.Info("Listing PowerVS SSH Keys", "service-instance-id", options.GlobalOptions.ServiceInstanceID, "zone", options.GlobalOptions.PowerVSZone)
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/network/create.go
+++ b/cmd/capibmadm/cmd/powervs/network/create.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type networkCreateOptions struct {
@@ -84,7 +84,7 @@ func createNetwork(ctx context.Context, netCreateOption networkCreateOptions) er
 	log := logf.Log
 	log.Info("Creating PowerVS network", "service-instance-id", options.GlobalOptions.ServiceInstanceID, "zone", options.GlobalOptions.PowerVSZone)
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/network/delete.go
+++ b/cmd/capibmadm/cmd/powervs/network/delete.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // DeleteCommand function to delete network.
@@ -56,7 +56,7 @@ func deleteNetwork(ctx context.Context, networkID string) error {
 	log := logf.Log
 	log.Info("Deleting PowerVS network", "service-instance-id", options.GlobalOptions.ServiceInstanceID, "zone", options.GlobalOptions.PowerVSZone)
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/network/list.go
+++ b/cmd/capibmadm/cmd/powervs/network/list.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // ListCommand function to create PowerVS network.
@@ -56,7 +56,7 @@ func listNetwork(ctx context.Context) error {
 	log := logf.Log
 	log.Info("Listing PowerVS networks", "service-instance-id", options.GlobalOptions.ServiceInstanceID, "zone", options.GlobalOptions.PowerVSZone)
 
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/port/create.go
+++ b/cmd/capibmadm/cmd/powervs/port/create.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type portCreateOptions struct {
@@ -68,7 +68,7 @@ capibmadm powervs port create --network <netword-id/network-name> --description 
 func createPort(ctx context.Context, portCreateOption portCreateOptions) error {
 	logger := log.Log
 	logger.Info("Creating Port ", "Network ID/Name", portCreateOption.network, "IP Address", portCreateOption.ipAddress, "Description", portCreateOption.description, "service-instance-id", options.GlobalOptions.ServiceInstanceID, "zone", options.GlobalOptions.PowerVSZone)
-	accountID, err := pkgUtils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}
@@ -100,12 +100,12 @@ func createPort(ctx context.Context, portCreateOption portCreateOptions) error {
 	}
 
 	portInfo.Items = append(portInfo.Items, PSpec{
-		Description: utils.DereferencePointer(port.Description).(string),
+		Description: pointer.Dereference(port.Description).(string),
 		ExternalIP:  port.ExternalIP,
-		IPAddress:   utils.DereferencePointer(port.IPAddress).(string),
-		MacAddress:  utils.DereferencePointer(port.MacAddress).(string),
-		PortID:      utils.DereferencePointer(port.PortID).(string),
-		Status:      utils.DereferencePointer(port.Status).(string),
+		IPAddress:   pointer.Dereference(port.IPAddress).(string),
+		MacAddress:  pointer.Dereference(port.MacAddress).(string),
+		PortID:      pointer.Dereference(port.PortID).(string),
+		Status:      pointer.Dereference(port.Status).(string),
 	})
 
 	printerObj, err := printer.New(options.GlobalOptions.Output, os.Stdout)

--- a/cmd/capibmadm/cmd/powervs/port/delete.go
+++ b/cmd/capibmadm/cmd/powervs/port/delete.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type portDeleteOptions struct {
@@ -62,7 +62,7 @@ capibmadm powervs port delete --port-id <port-id> --network <network-name/networ
 func deletePort(ctx context.Context, portDeleteOption portDeleteOptions) error {
 	log := logf.Log
 	log.Info("Deleting PowerVS network port", "network", portDeleteOption.network, "service-instance-id", options.GlobalOptions.ServiceInstanceID, "port-id", portDeleteOption.portID)
-	accountID, err := utils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}

--- a/cmd/capibmadm/cmd/powervs/port/list.go
+++ b/cmd/capibmadm/cmd/powervs/port/list.go
@@ -30,9 +30,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 // ListCommand powervs port list command.
@@ -63,7 +63,7 @@ func listPorts(ctx context.Context, network string) error {
 	log := logf.Log
 	log.Info("Listing PowerVS ports", "service-instance-id", options.GlobalOptions.ServiceInstanceID, "network", network)
 
-	accountID, err := pkgUtils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}
@@ -91,12 +91,12 @@ func listPorts(ctx context.Context, network string) error {
 
 	for _, port := range portListResp.Ports {
 		portList.Items = append(portList.Items, PSpec{
-			Description: utils.DereferencePointer(port.Description).(string),
+			Description: pointer.Dereference(port.Description).(string),
 			ExternalIP:  port.ExternalIP,
-			IPAddress:   utils.DereferencePointer(port.IPAddress).(string),
-			MacAddress:  utils.DereferencePointer(port.MacAddress).(string),
-			PortID:      utils.DereferencePointer(port.PortID).(string),
-			Status:      utils.DereferencePointer(port.Status).(string),
+			IPAddress:   pointer.Dereference(port.IPAddress).(string),
+			MacAddress:  pointer.Dereference(port.MacAddress).(string),
+			PortID:      pointer.Dereference(port.PortID).(string),
+			Status:      pointer.Dereference(port.Status).(string),
 		})
 	}
 

--- a/cmd/capibmadm/cmd/vpc/image/list.go
+++ b/cmd/capibmadm/cmd/vpc/image/list.go
@@ -27,10 +27,12 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/vpc"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/cliutils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 )
 
 // ListCommand vpc image list command.
@@ -59,14 +61,14 @@ func listImages(ctx context.Context, resourceGroupName string) error {
 		return err
 	}
 
-	accountID, err := pkgUtils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}
 
 	var resourceGroupID string
 	if resourceGroupName != "" {
-		resourceGroupID, err = utils.GetResourceGroupID(ctx, resourceGroupName, accountID)
+		resourceGroupID, err = cliutils.GetResourceGroupID(ctx, resourceGroupName, accountID)
 		if err != nil {
 			return err
 		}
@@ -96,7 +98,7 @@ func listImages(ctx context.Context, resourceGroupName string) error {
 		return true, "", nil
 	}
 
-	if err = pkgUtils.PagingHelper(f); err != nil {
+	if err = pagingutils.PagingHelper(f); err != nil {
 		return err
 	}
 
@@ -108,34 +110,34 @@ func display(imageNesList []*vpcv1.ImageCollection) error {
 	for _, imageL := range imageNesList {
 		for _, image := range imageL.Images {
 			imageToAppend := Image{
-				ID:         utils.DereferencePointer(image.ID).(string),
-				Name:       utils.DereferencePointer(image.Name).(string),
-				Status:     utils.DereferencePointer(image.Status).(string),
-				CreatedAt:  utils.DereferencePointer(image.CreatedAt).(strfmt.DateTime),
-				Visibility: utils.DereferencePointer(image.Visibility).(string),
-				Encryption: utils.DereferencePointer(image.Encryption).(string),
+				ID:         pointer.Dereference(image.ID).(string),
+				Name:       pointer.Dereference(image.Name).(string),
+				Status:     pointer.Dereference(image.Status).(string),
+				CreatedAt:  pointer.Dereference(image.CreatedAt).(strfmt.DateTime),
+				Visibility: pointer.Dereference(image.Visibility).(string),
+				Encryption: pointer.Dereference(image.Encryption).(string),
 			}
 
 			if image.File != nil {
-				imageToAppend.FileSize = utils.DereferencePointer(image.File.Size).(int64)
+				imageToAppend.FileSize = pointer.Dereference(image.File.Size).(int64)
 			}
 
 			if image.ResourceGroup != nil {
-				imageToAppend.ResourceGroupName = utils.DereferencePointer(image.ResourceGroup.Name).(string)
+				imageToAppend.ResourceGroupName = pointer.Dereference(image.ResourceGroup.Name).(string)
 			}
 
 			if image.OperatingSystem != nil {
-				imageToAppend.OperatingSystemName = utils.DereferencePointer(image.OperatingSystem.DisplayName).(string)
-				imageToAppend.OperatingSystemVersion = utils.DereferencePointer(image.OperatingSystem.Version).(string)
-				imageToAppend.Arch = utils.DereferencePointer(image.OperatingSystem.Architecture).(string)
+				imageToAppend.OperatingSystemName = pointer.Dereference(image.OperatingSystem.DisplayName).(string)
+				imageToAppend.OperatingSystemVersion = pointer.Dereference(image.OperatingSystem.Version).(string)
+				imageToAppend.Arch = pointer.Dereference(image.OperatingSystem.Architecture).(string)
 			}
 
 			if image.SourceVolume != nil {
-				imageToAppend.SourceVolumeName = utils.DereferencePointer(image.SourceVolume.Name).(string)
+				imageToAppend.SourceVolumeName = pointer.Dereference(image.SourceVolume.Name).(string)
 			}
 
 			if image.CatalogOffering != nil {
-				imageToAppend.CatalogOffering = utils.DereferencePointer(image.CatalogOffering.Managed).(bool)
+				imageToAppend.CatalogOffering = pointer.Dereference(image.CatalogOffering.Managed).(bool)
 			}
 
 			imageListToDisplay = append(imageListToDisplay, imageToAppend)

--- a/cmd/capibmadm/cmd/vpc/key/create.go
+++ b/cmd/capibmadm/cmd/vpc/key/create.go
@@ -30,9 +30,9 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/iam"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/vpc"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/cliutils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 )
 
 type keyCreateOptions struct {
@@ -93,7 +93,7 @@ func createKey(ctx context.Context, keyCreateOption keyCreateOptions) error {
 		return err
 	}
 
-	accountID, err := pkgUtils.GetAccount(iam.GetIAMAuth())
+	accountID, err := accounts.GetAccount(iam.GetIAMAuth())
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func createKey(ctx context.Context, keyCreateOption keyCreateOptions) error {
 	options.SetPublicKey(keyCreateOption.publicKey)
 
 	if keyCreateOption.resourceGroupName != "" {
-		resourceGroupID, err := utils.GetResourceGroupID(ctx, keyCreateOption.resourceGroupName, accountID)
+		resourceGroupID, err := cliutils.GetResourceGroupID(ctx, keyCreateOption.resourceGroupName, accountID)
 		if err != nil {
 			return err
 		}

--- a/cmd/capibmadm/cmd/vpc/key/list.go
+++ b/cmd/capibmadm/cmd/vpc/key/list.go
@@ -27,9 +27,9 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/clients/vpc"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/options"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/pointer"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/printer"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/cmd/capibmadm/utils"
-	pkgUtils "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 )
 
 // ListCommand vpc key list command.
@@ -79,7 +79,7 @@ func listKeys(ctx context.Context) error {
 		return true, "", nil
 	}
 
-	if err = pkgUtils.PagingHelper(f); err != nil {
+	if err = pagingutils.PagingHelper(f); err != nil {
 		return err
 	}
 
@@ -91,16 +91,16 @@ func display(keyNesList []*vpcv1.KeyCollection) error {
 	for _, keyL := range keyNesList {
 		for _, key := range keyL.Keys {
 			keyToAppend := Key{
-				CreatedAt:   utils.DereferencePointer(key.CreatedAt).(strfmt.DateTime),
-				ID:          utils.DereferencePointer(key.ID).(string),
-				Name:        utils.DereferencePointer(key.Name).(string),
-				Type:        utils.DereferencePointer(key.Type).(string),
-				Length:      utils.DereferencePointer(key.Length).(int64),
-				FingerPrint: utils.DereferencePointer(key.Fingerprint).(string),
+				CreatedAt:   pointer.Dereference(key.CreatedAt).(strfmt.DateTime),
+				ID:          pointer.Dereference(key.ID).(string),
+				Name:        pointer.Dereference(key.Name).(string),
+				Type:        pointer.Dereference(key.Type).(string),
+				Length:      pointer.Dereference(key.Length).(int64),
+				FingerPrint: pointer.Dereference(key.Fingerprint).(string),
 			}
 
 			if key.ResourceGroup != nil {
-				keyToAppend.ResourceGroup = utils.DereferencePointer(key.ResourceGroup.Name).(string)
+				keyToAppend.ResourceGroup = pointer.Dereference(key.ResourceGroup.Name).(string)
 			}
 
 			keyListToDisplay = append(keyListToDisplay, keyToAppend)

--- a/cmd/capibmadm/pointer/doc.go
+++ b/cmd/capibmadm/pointer/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pointer is the utility package for the pointer operations.
+package pointer

--- a/cmd/capibmadm/pointer/pointer.go
+++ b/cmd/capibmadm/pointer/pointer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pointer
+
+import "github.com/go-openapi/strfmt"
+
+// Dereference dereferences pointer.
+func Dereference(value interface{}) interface{} {
+	switch v := value.(type) {
+	case *string:
+		if v != nil {
+			return *v
+		}
+		return ""
+	case *int, *int8, *int16, *int32, *int64:
+		i := value.(*int64)
+		if i != nil {
+			return *i
+		}
+		return 0
+	case *strfmt.DateTime:
+		if v != nil {
+			return *v
+		}
+		return strfmt.DateTime{}
+	case *bool:
+		if v != nil {
+			return *v
+		}
+		return false
+	case *float32, *float64:
+		f := value.(*float64)
+		if f != nil {
+			return *f
+		}
+		return 0
+	}
+	return nil
+}

--- a/controllers/ibmvpcmachine_controller_test.go
+++ b/controllers/ibmvpcmachine_controller_test.go
@@ -39,8 +39,8 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	gtmock "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/globaltagging/mock"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	vpcmock "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc/mock"
 
 	. "github.com/onsi/gomega"
@@ -327,7 +327,7 @@ func TestIBMVPCMachineLBReconciler_reconcile(t *testing.T) {
 		return gomock.NewController(t), mockvpc, mockgt, machineScope, reconciler
 	}
 
-	utils.GetAccountIDFunc = func() (string, error) {
+	accounts.GetAccountIDFunc = func() (string, error) {
 		return "dummy-account-id", nil // Return dummy value
 	}
 

--- a/internal/genutil/doc.go
+++ b/internal/genutil/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package utils implements utils code.
-package utils
+// Package genutil implements general utility code.
+package genutil

--- a/internal/genutil/util.go
+++ b/internal/genutil/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package genutil
 
 import (
 	"fmt"

--- a/internal/webhooks/ibmpowervscluster.go
+++ b/internal/webhooks/ibmpowervscluster.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
-	genUtil "sigs.k8s.io/cluster-api-provider-ibmcloud/util"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/internal/genutil"
 )
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster,mutating=true,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=create;update,versions=v1beta2,name=mibmpowervscluster.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
@@ -183,7 +183,7 @@ func validateIBMPowerVSClusterTransitGateway(cluster *infrav1.IBMPowerVSCluster)
 	if cluster.Spec.TransitGateway == nil {
 		return nil
 	}
-	if _, globalRouting, _ := genUtil.GetTransitGatewayLocationAndRouting(cluster.Spec.Zone, cluster.Spec.VPC.Region); cluster.Spec.TransitGateway.GlobalRouting != nil && !*cluster.Spec.TransitGateway.GlobalRouting && globalRouting != nil && *globalRouting {
+	if _, globalRouting, _ := genutil.GetTransitGatewayLocationAndRouting(cluster.Spec.Zone, cluster.Spec.VPC.Region); cluster.Spec.TransitGateway.GlobalRouting != nil && !*cluster.Spec.TransitGateway.GlobalRouting && globalRouting != nil && *globalRouting {
 		return field.Invalid(field.NewPath("spec.transitGateway.globalRouting"), cluster.Spec.TransitGateway.GlobalRouting, "global routing is required since PowerVS and VPC region are from different region")
 	}
 	return nil

--- a/pkg/cloud/services/accounts/accounts.go
+++ b/pkg/cloud/services/accounts/accounts.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package accounts
 
 import (
 	"context"

--- a/pkg/cloud/services/accounts/doc.go
+++ b/pkg/cloud/services/accounts/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package util implements util code.
-package util
+// Package accounts implements account utility helpers.
+package accounts

--- a/pkg/cloud/services/globaltagging/service.go
+++ b/pkg/cloud/services/globaltagging/service.go
@@ -25,8 +25,8 @@ import (
 
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 )
 
 // Service holds the IBM Cloud Global Tagging Service specific information.
@@ -51,7 +51,7 @@ func (s *Service) AttachTag(options *globaltaggingv1.AttachTagOptions) (*globalt
 
 // GetTagByName returns the Tag with the provided name, if found.
 func (s *Service) GetTagByName(tagName string) (*globaltaggingv1.Tag, error) {
-	accountID, err := utils.GetAccountID()
+	accountID, err := accounts.GetAccountID()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -26,8 +26,8 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 )
 
 var _ PowerVS = &Service{}
@@ -59,7 +59,7 @@ func NewService(options ServiceOptions) (PowerVS, error) {
 		options.Authenticator = auth
 	}
 	if options.UserAccount == "" {
-		account, err := utils.GetAccount(options.Authenticator)
+		account, err := accounts.GetAccount(options.Authenticator)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/services/resourcecontroller/service.go
+++ b/pkg/cloud/services/resourcecontroller/service.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 )
 
 const (
@@ -132,7 +132,7 @@ func (s *Service) GetServiceInstance(id, name string, zone *string) (*resourceco
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, fmt.Errorf("error listing service instances %v", err)
 	}
 	switch len(serviceInstancesList) {
@@ -177,7 +177,7 @@ func (s *Service) GetInstanceByName(name, resourceID, planID string) (*resourcec
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, fmt.Errorf("error listing COS instances %v", err)
 	}
 	switch len(serviceInstancesList) {

--- a/pkg/cloud/services/resourcemanager/service.go
+++ b/pkg/cloud/services/resourcemanager/service.go
@@ -23,8 +23,8 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/accounts"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 )
 
 // Service holds the IBM Cloud Resource Manager Service specific information.
@@ -65,7 +65,7 @@ func (s *Service) ListResourceGroups(listResourceGroupsOptions *resourcemanagerv
 
 // GetResourceGroupByName returns the Resource Group with the provided name, if found.
 func (s *Service) GetResourceGroupByName(rgName string) (*resourcemanagerv2.ResourceGroup, error) {
-	accountID, err := utils.GetAccountID()
+	accountID, err := accounts.GetAccountID()
 	if err != nil {
 		return nil, fmt.Errorf("failed getting account id for resource group lookup: %w", err)
 	}

--- a/pkg/cloud/services/transitgateway/service.go
+++ b/pkg/cloud/services/transitgateway/service.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 )
 
 var currentDate = fmt.Sprintf("%d-%02d-%02d", time.Now().Year(), time.Now().Month(), time.Now().Day())
@@ -94,7 +94,7 @@ func (s *Service) GetTransitGatewayByName(name string) (*tgapiv1.TransitGateway,
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 	return &transitGateway, nil

--- a/pkg/cloud/services/vpc/service.go
+++ b/pkg/cloud/services/vpc/service.go
@@ -23,7 +23,7 @@ import (
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/pagingutils"
 )
 
 // SecurityGroupByNameNotFound represents an error when security group is not found by name.
@@ -92,7 +92,7 @@ func (s *Service) GetDedicatedHostByName(dHostName string) (*vpcv1.DedicatedHost
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -266,7 +266,7 @@ func (s *Service) GetVPCByName(vpcName string) (*vpcv1.VPC, error) {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -305,7 +305,7 @@ func (s *Service) GetImageByName(imageName string) (*vpcv1.Image, error) {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -344,7 +344,7 @@ func (s *Service) GetVPCPublicGatewayByName(publicGatewayName string, resourceGr
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -388,7 +388,7 @@ func (s *Service) GetVPCSubnetByName(subnetName string) (*vpcv1.Subnet, error) {
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 
@@ -448,7 +448,7 @@ func (s *Service) GetLoadBalancerByName(loadBalancerName string) (*vpcv1.LoadBal
 		return true, "", nil
 	}
 
-	if err := utils.PagingHelper(f); err != nil {
+	if err := pagingutils.PagingHelper(f); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pagingutils/doc.go
+++ b/pkg/pagingutils/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package pagingutils provides utilities for handling pagination while listing resources.
+It includes helper functions to parse pagination tokens and iterate over paginated resources.
+*/
+package pagingutils

--- a/pkg/pagingutils/paging.go
+++ b/pkg/pagingutils/paging.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package pagingutils
 
 import (
 	"fmt"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR addresses the revive package naming convention issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2458

**Special notes for your reviewer**:
/kind cleanup
/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
This PR is for fixing the linting issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Fix revive package name conventions
```

**Validation**

After running `make lint`

`
INFO [runner] linters took 5.793821833s with stages: goanalysis_metalinter: 5.771707958s 
0 issues.
INFO File cache stats: 3 entries of total size 17.5KiB 
INFO Memory: 72 samples, avg is 1216.4MB, max is 2175.7MB 
INFO Execution took 7.086381416s  `
