### PR TITLE
cleanup: remove deprecated ClusterResourceSet feature gate references

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -84,7 +84,6 @@ enable_providers:
 - kubeadm-control-plane
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
-  EXP_CLUSTER_RESOURCE_SET: "true"
 ```
 
 Add following extra_args to log PowerVS REST API Requests/Responses
@@ -101,7 +100,7 @@ extra_args:
 
 ### 1.  Configuration to deploy workload cluster from ClusterClass template
 
-To deploy workload cluster with [clusterclass-template](../topics/powervs/creating-a-cluster.md#deploy-a-powervs-cluster-with-cluster-class), enable the feature gates `EXP_CLUSTER_RESOURCE_SET` and `CLUSTER_TOPOLOGY` to `true` under kustomize_substitutions.
+To deploy workload cluster with [clusterclass-template](../topics/powervs/creating-a-cluster.md#deploy-a-powervs-cluster-with-cluster-class), enable the feature gate `CLUSTER_TOPOLOGY` to `true` under kustomize_substitutions.
 
 ```yaml
 default_registry: "localhost:5001"
@@ -113,7 +112,6 @@ enable_providers:
 - kubeadm-control-plane
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
-  EXP_CLUSTER_RESOURCE_SET: "true"
   CLUSTER_TOPOLOGY: "true"
 ```
 
@@ -153,7 +151,6 @@ enable_providers:
   - kubeadm-control-plane
 kustomize_substitutions:
   IBMCLOUD_API_KEY: "XXXXXXXXXXXXXXXXXX"
-  EXP_CLUSTER_RESOURCE_SET: "true"
 extra_args:
    core:
       - "--logging-format=json"

--- a/docs/book/src/topics/powervs/creating-a-cluster.md
+++ b/docs/book/src/topics/powervs/creating-a-cluster.md
@@ -38,7 +38,6 @@ following the steps below.
   **Replace the following snippet with the template of your choice.**
 
     > **Note:**
-    > - Set `EXP_CLUSTER_RESOURCE_SET` to `true` as the cluster will be deployed with external cloud provider which will create the resources to run the cloud controller manager.
     > - The `IBMPOWERVS_IMAGE_NAME` value below should reflect the name of the custom image and the `kubernetes-version` value below should reflect the kubernetes version of the custom image.
     > - While working with unreleased versions like from main branch, instead of `--flavor=powervs` use `--from=./templates/cluster-template-powervs.yaml`.
     > - Refer detailed information on PowerVS variables [here](#note-refer-below-for-more-detailed-information-on-powervs-variables)

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -177,7 +177,6 @@ main(){
     # Set common variables
     export DOCKER_BUILDKIT=1
     export PROVIDER_ID_FORMAT=v2
-    export EXP_CLUSTER_RESOURCE_SET=true
     export IBMACCOUNT_ID=${IBMACCOUNT_ID:-"7cfbd5381a434af7a09289e795840d4e"}
     export BASE64_API_KEY=$(tr -d '\n' <<<"$IBMCLOUD_API_KEY" | base64)
     export CUSTOM_KIND_NODE_IMAGE=${CUSTOM_KIND_NODE_IMAGE:-}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,9 +1,6 @@
 Render the template via clusterctl
 ==================================
 
-> **Note:**
-> Set `EXP_CLUSTER_RESOURCE_SET` to `true` as the cluster will be deployed with external cloud provider for both VPC and PowerVS, which will create the resources to run the cloud controller manager.
-
 ## VPC
 
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Upstream Cluster API (CAPI) has permanently enabled the ClusterResourceSet feature and removed the associated feature gate in PR kubernetes-sigs/cluster-api#12950.

This PR cleans up our repository to align with this upstream change by removing "dead code" references:

- `scripts/ci-e2e.sh`: Removed the unused export `EXP_CLUSTER_RESOURCE_SET=true`.
- `docs/book/src/developer/tilt.md`: Removed instructions to set the feature gate in Tilt.
- `templates/README.md` & `creating-a-cluster.md`: Removed notes instructing users to manually enable this feature.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: I performed an impact analysis to ensure no breaking changes were introduced:

- Go Code: Verified that we do not import the removed feature.ClusterResourceSet constant. 
`grep -r "feature.ClusterResourceSet" .` returned 0 results.
- Manifests: Verified that we are not passing the deprecated `--feature-gates=ClusterResourceSet=true` flag to the manager binary.
`grep -r "feature-gates" .` confirmed the flag is not currently in use.

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed deprecated EXP_CLUSTER_RESOURCE_SET feature gate references from documentation and CI scripts.
```
