### PR TITLE
⚠️ Update vpc-go-sdk module and replace SecurityGroupProtocolRule from all to icmp_tcp_udp

### DIFF
--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -285,8 +285,8 @@ var (
 )
 
 const (
-	// VPCSecurityGroupRuleProtocolAllType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolAll' type.
-	VPCSecurityGroupRuleProtocolAllType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll"
+	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
+	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
 	// VPCSecurityGroupRuleProtocolIcmpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolIcmp' type.
 	VPCSecurityGroupRuleProtocolIcmpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp"
@@ -318,12 +318,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=all;icmp;tcp;udp
+// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
 type VPCSecurityGroupRuleProtocol string
 
 const (
-	// VPCSecurityGroupRuleProtocolAll defines the Rule is for all network protocols.
-	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAllConst
+	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
+	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.SecurityGroupRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
 	VPCSecurityGroupRuleProtocolIcmp VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpConst
 	// VPCSecurityGroupRuleProtocolTCP defines the Rule is for TCP network protocol.
@@ -519,8 +519,8 @@ type VPCSecurityGroupRuleRemote struct {
 
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
-// +kubebuilder:validation:XValidation:rule="self.protocol == 'all' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolAll protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.
 	// Only used when Protocol is VPCSecurityGroupRuleProtocolIcmp.

--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -1459,13 +1459,13 @@ func (s *PowerVSClusterScope) createVPCSecurityGroupRule(ctx context.Context, se
 	}
 
 	switch reflect.TypeOf(ruleIntf).String() {
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
-		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+		rule := ruleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
+	case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
 		ruleID = rule.ID
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp":
+	case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)
 		ruleID = rule.ID
 	}
@@ -1606,8 +1606,8 @@ func (s *PowerVSClusterScope) validateSecurityGroupRule(originalSecurityGroupRul
 
 	for _, ogRuleIntf := range originalSecurityGroupRules {
 		switch reflect.TypeOf(ogRuleIntf).String() {
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
-			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+		case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 			ruleID = ogRule.ID
 
 			if *ogRule.Direction == string(direction) && *ogRule.Protocol == protocol {
@@ -1618,7 +1618,7 @@ func (s *PowerVSClusterScope) validateSecurityGroupRule(originalSecurityGroupRul
 					return nil, false, err
 				}
 			}
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
+		case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 			portMin := rule.PortRange.MinimumPort
 			portMax := rule.PortRange.MaximumPort
 			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
@@ -1632,7 +1632,7 @@ func (s *PowerVSClusterScope) validateSecurityGroupRule(originalSecurityGroupRul
 					return nil, false, err
 				}
 			}
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp":
+		case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 			icmpCode := rule.ICMPCode
 			icmpType := rule.ICMPType
 			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)

--- a/cloud/scope/powervs_cluster_test.go
+++ b/cloud/scope/powervs_cluster_test.go
@@ -7549,7 +7549,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -7597,7 +7597,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -7864,7 +7864,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 		}
 
 		securityGroupDetails := &vpcv1.SecurityGroup{Name: ptr.To("securityGroupName"), ID: ptr.To("securityGroupID"), VPC: &vpcv1.VPCReference{ID: ptr.To("VPCID")}}
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Protocol: ptr.To("tcp"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Protocol: ptr.To("tcp"), ID: ptr.To("ruleID")}, nil, nil)
 		mockVPC.EXPECT().GetSecurityGroupByName(gomock.Any()).Return(securityGroupDetails, nil)
 		sg, ruleIDs, err := clusterScope.validateVPCSecurityGroup(ctx, vpcSecurityGroup)
 		g.Expect(ruleIDs).To(BeNil())
@@ -7885,7 +7885,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8097,7 +8097,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeFalse())
 		g.Expect(err).ToNot(BeNil())
 	})
-	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll", func(t *testing.T) {
+	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -8111,7 +8111,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8145,7 +8145,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeTrue())
 		g.Expect(err).To(BeNil())
 	})
-	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll", func(t *testing.T) {
+	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -8160,7 +8160,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8194,7 +8194,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeFalse())
 		g.Expect(err).To(BeNil())
 	})
-	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll returns error", func(t *testing.T) {
+	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -8209,7 +8209,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8431,7 +8431,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8477,7 +8477,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8525,7 +8525,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8572,7 +8572,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -8618,7 +8618,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -9093,7 +9093,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, &securityGroupID, ptr.To("outbound"), &protocol, &portMin, &portMax, remote)
 		g.Expect(ruleID).To(BeEquivalentTo(ptr.To("ruleID")))
 		g.Expect(err).To(BeNil())
@@ -9207,7 +9207,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, &securityGroupID, ptr.To("outbound"), &protocol, &portMin, &portMax, remote)
 		g.Expect(ruleID).To(BeEquivalentTo(ptr.To("ruleID")))
 		g.Expect(err).To(BeNil())
@@ -9548,7 +9548,7 @@ func TestCreateVPCSecurityGroupRulesAndSetStatus(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		err := clusterScope.createVPCSecurityGroupRulesAndSetStatus(ctx, vpcSecurityGroup.Rules, ptr.To("securityGroupID"), ptr.To("securityGroupName"))
 		g.Expect(err).To(BeNil())
 	})

--- a/cloud/scope/vpc_cluster.go
+++ b/cloud/scope/vpc_cluster.go
@@ -1455,22 +1455,22 @@ func (s *VPCClusterScope) findOrCreateSecurityGroupRule(ctx context.Context, sec
 		for _, existingRuleIntf := range existingSecurityGroupRules.Rules {
 			// Perform analysis of the existingRuleIntf, based on its Protocol type, further analysis is performed based on remaining attributes to find if the specific Rule and Remote match
 			switch reflect.TypeOf(existingRuleIntf).String() {
-			case infrav1.VPCSecurityGroupRuleProtocolAllType:
-				// If our Remote doesn't define all Protocols, we don't need further checks, move on to next Rule
-				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolAll {
+			case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+				// If our Remote doesn't define icmp_tcp_udp Protocols, we don't need further checks, move on to next Rule
+				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP {
 					continue
 				}
-				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 				// If the Remote doesn't have the same Direction as the Rule, no further checks are necessary
 				if securityGroupRule.Direction != infrav1.VPCSecurityGroupRuleDirection(*existingRule.Direction) {
 					continue
 				}
-				if found, err := s.checkSecurityGroupRuleProtocolAll(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
-					return fmt.Errorf("error failure checking security group rule protocol all: %w", err)
+				if found, err := s.checkSecurityGroupRuleProtocolIcmpTCPUDP(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
+					return fmt.Errorf("error failure checking security group rule protocol icmp_tcp_udp: %w", err)
 				} else if found {
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
-					log.V(3).Info("security group rule all protocol match found")
+					log.V(3).Info("security group rule icmp_tcp_udp protocol match found")
 					remoteMatch = true
 					break
 				}
@@ -1527,8 +1527,8 @@ func (s *VPCClusterScope) findOrCreateSecurityGroupRule(ctx context.Context, sec
 	return nil
 }
 
-// checkSecurityGroupRuleProtocolAll analyzes an IBM Cloud Security Group Rule designated for 'all' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'ProtocolAll' Rule.
-func (s *VPCClusterScope) checkSecurityGroupRuleProtocolAll(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll) (bool, error) {
+// checkSecurityGroupRuleProtocolIcmpTCPUDP analyzes an IBM Cloud Security Group Rule designated for 'icmp_tcp_udp' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'icmp_tcp_udp' Rule.
+func (s *VPCClusterScope) checkSecurityGroupRuleProtocolIcmpTCPUDP(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleProtocolIcmptcpudp) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if exists, err := s.checkSecurityGroupRulePrototypeRemote(ctx, securityGroupRuleRemote, existingRule.Remote); err != nil {
 		return false, fmt.Errorf("error failed checking security group rule all remote: %w", err)
@@ -1706,8 +1706,8 @@ func (s *VPCClusterScope) createSecurityGroupRule(ctx context.Context, securityG
 		return fmt.Errorf("error failed to create security group rule remote: %w", err)
 	}
 	switch securityGroupRulePrototype.Protocol {
-	case infrav1.VPCSecurityGroupRuleProtocolAll:
-		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolAll{
+	case infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP:
+		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolIcmptcpudpPrototype{
 			Direction: ptr.To(string(securityGroupRule.Direction)),
 			Protocol:  ptr.To(string(securityGroupRulePrototype.Protocol)),
 			Remote:    prototypeRemote,
@@ -1753,8 +1753,8 @@ func (s *VPCClusterScope) createSecurityGroupRule(ctx context.Context, securityG
 	// Typecast the resulting SecurityGroupRuleIntf, to retrieve the ID for logging
 	var ruleID *string
 	switch reflect.TypeOf(securityGroupRuleIntfDetails).String() {
-	case infrav1.VPCSecurityGroupRuleProtocolAllType:
-		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -702,7 +702,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -776,13 +776,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                           direction:
                             description: direction defines whether the traffic is
@@ -839,7 +839,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -913,13 +913,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                         required:
                         - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -740,7 +740,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -817,13 +817,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                   direction:
                                     description: direction defines whether the traffic
@@ -881,7 +881,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -958,13 +958,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                 required:
                                 - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
@@ -899,7 +899,7 @@ spec:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
                                     enum:
-                                    - all
+                                    - icmp_tcp_udp
                                     - icmp
                                     - tcp
                                     - udp
@@ -973,13 +973,13 @@ spec:
                                     for VPCSecurityGroupRuleProtocolIcmp protocol
                                   rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                     && !has(self.icmpType)) : true'
-                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                    protocol
-                                  rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                    : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                    : true'
+                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                    protocol
+                                  rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                     : true'
                               direction:
                                 description: direction defines whether the traffic
@@ -1036,7 +1036,7 @@ spec:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
                                     enum:
-                                    - all
+                                    - icmp_tcp_udp
                                     - icmp
                                     - tcp
                                     - udp
@@ -1110,13 +1110,13 @@ spec:
                                     for VPCSecurityGroupRuleProtocolIcmp protocol
                                   rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                     && !has(self.icmpType)) : true'
-                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                    protocol
-                                  rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                    : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                    : true'
+                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                    protocol
+                                  rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                     : true'
                             required:
                             - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
@@ -758,7 +758,7 @@ spec:
                                               protocol used for the Security Group
                                               Rule.
                                             enum:
-                                            - all
+                                            - icmp_tcp_udp
                                             - icmp
                                             - tcp
                                             - udp
@@ -842,14 +842,14 @@ spec:
                                             protocol
                                           rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                             && !has(self.icmpType)) : true'
-                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                            protocol
-                                          rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                            : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                            protocol
+                                          rule: 'self.protocol == ''icmp_tcp_udp''
+                                            ? !has(self.portRange) : true'
                                       direction:
                                         description: direction defines whether the
                                           traffic is inbound or outbound for the Security
@@ -908,7 +908,7 @@ spec:
                                               protocol used for the Security Group
                                               Rule.
                                             enum:
-                                            - all
+                                            - icmp_tcp_udp
                                             - icmp
                                             - tcp
                                             - udp
@@ -992,14 +992,14 @@ spec:
                                             protocol
                                           rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                             && !has(self.icmpType)) : true'
-                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                            protocol
-                                          rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                            : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                            protocol
+                                          rule: 'self.protocol == ''icmp_tcp_udp''
+                                            ? !has(self.portRange) : true'
                                     required:
                                     - action
                                     - direction

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.12.4
 	github.com/IBM/networking-go-sdk v0.51.15
 	github.com/IBM/platform-services-go-sdk v0.91.0
-	github.com/IBM/vpc-go-sdk v0.76.2
+	github.com/IBM/vpc-go-sdk v0.78.1
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/ignition/v2 v2.25.1
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/IBM/networking-go-sdk v0.51.15 h1:JEljJvjUYeSL5F091sI3kZzD9wZYDWsnnKJ
 github.com/IBM/networking-go-sdk v0.51.15/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
 github.com/IBM/platform-services-go-sdk v0.91.0 h1:5o4XotMmP9UfCg9BKG0cx/pTAMhBh0KzjyFQQyHZTgE=
 github.com/IBM/platform-services-go-sdk v0.91.0/go.mod h1:KAnBhxKaYsu9It2aVXV6oCPEj78imvTs2qSG0ScZKpM=
-github.com/IBM/vpc-go-sdk v0.76.2 h1:bZ6aHA1X69Ekn9rxd5XyjxuV9dwEneamEPYojDPHZdA=
-github.com/IBM/vpc-go-sdk v0.76.2/go.mod h1:hhgE1EQZRq1Cngdh4A6+LLUaA0kKWW/rgfHpISM+AKg=
+github.com/IBM/vpc-go-sdk v0.78.1 h1:vzc1GIoTYZsQCoDWpvS5Ah13qfBfN7wWgTGnHhpBg0M=
+github.com/IBM/vpc-go-sdk v0.78.1/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxReDDI5ZdY=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR updates the vpc-go-sdk version

The latest release of vpc-go-sdk contains some breaking changes for SecurityGroupRuleProtocal, Its changed from all to icmp_tcp_udp and we are no more able to use 'all' protocal.

From sdk release notes we can see
```
icmp_tcp_udp for ICMP, TCP, and UDP traffic (for API version 2025-12-08 or earlier, the value all is used instead of icmp_tcp_udp)
```

This PR changes the protocol usage from 'all' to 'icmp_tcp_udp'.

The release notes: https://cloud.ibm.com/docs/vpc?topic=vpc-api-change-log#9-december-2025


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2579

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VPC Security Group Rule Protocol 'all' is replaced with 'icmp_tcp_udp'
```
