### PR TITLE
Update vpc-go-sdk module and introduce the new SecurityGroupRule types

### DIFF
--- a/api/powervs/v1beta2/types.go
+++ b/api/powervs/v1beta2/types.go
@@ -285,8 +285,8 @@ var (
 )
 
 const (
-	// VPCSecurityGroupRuleProtocolAllType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolAll' type.
-	VPCSecurityGroupRuleProtocolAllType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll"
+	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
+	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
 	// VPCSecurityGroupRuleProtocolIcmpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolIcmp' type.
 	VPCSecurityGroupRuleProtocolIcmpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp"
@@ -318,12 +318,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=all;icmp;tcp;udp
+// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
 type VPCSecurityGroupRuleProtocol string
 
 const (
-	// VPCSecurityGroupRuleProtocolAll defines the Rule is for all network protocols.
-	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAllConst
+	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
+	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
 	VPCSecurityGroupRuleProtocolIcmp VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpConst
 	// VPCSecurityGroupRuleProtocolTCP defines the Rule is for TCP network protocol.
@@ -446,8 +446,8 @@ type VPCSecurityGroupRuleRemote struct {
 
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
-// +kubebuilder:validation:XValidation:rule="self.protocol == 'all' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolAll protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.
 	// Only used when Protocol is VPCSecurityGroupRuleProtocolIcmp.

--- a/api/powervs/v1beta2/types.go
+++ b/api/powervs/v1beta2/types.go
@@ -285,6 +285,9 @@ var (
 )
 
 const (
+	// VPCSecurityGroupRuleProtocolAnyType is a string representation of the 'SecurityGroupRuleProtocolAny' type.
+	VPCSecurityGroupRuleProtocolAnyType = "*vpcv1.SecurityGroupRuleProtocolAny"
+
 	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
 	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
@@ -293,6 +296,9 @@ const (
 
 	// VPCSecurityGroupRuleProtocolTcpudpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolTcpudp' type.
 	VPCSecurityGroupRuleProtocolTcpudpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp"
+
+	// VPCSecurityGroupRuleProtocolIndividualType is a string representation of the 'SecurityGroupRuleProtocolIndividual' type.
+	VPCSecurityGroupRuleProtocolIndividualType = "*vpcv1.SecurityGroupRuleProtocolIndividual"
 )
 
 // VPCSecurityGroupRuleAction represents the actions for a Security Group Rule.
@@ -318,10 +324,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
+// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
+	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
+	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
 	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
@@ -447,6 +455,7 @@ type VPCSecurityGroupRuleRemote struct {
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="(self.protocol != 'tcp' && self.protocol != 'udp') ? !has(self.portRange) : true",message="portRange is not valid for protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.

--- a/api/powervs/v1beta2/types.go
+++ b/api/powervs/v1beta2/types.go
@@ -324,10 +324,14 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
+// +kubebuilder:validation:Pattern=`^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
+	// VPCSecurityGroupRuleProtocolAll is DEPRECATED: Use VPCSecurityGroupRuleProtocolIcmpTCPUDP instead.
+	// This constant is maintained for backward compatibility.
+	// It will be removed in a future version.
+	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = "all"
 	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
 	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.

--- a/api/powervs/v1beta3/types.go
+++ b/api/powervs/v1beta3/types.go
@@ -273,6 +273,9 @@ var (
 )
 
 const (
+	// VPCSecurityGroupRuleProtocolAnyType is a string representation of the 'SecurityGroupRuleProtocolAny' type.
+	VPCSecurityGroupRuleProtocolAnyType = "*vpcv1.SecurityGroupRuleProtocolAny"
+
 	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
 	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
@@ -281,6 +284,9 @@ const (
 
 	// VPCSecurityGroupRuleProtocolTcpudpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolTcpudp' type.
 	VPCSecurityGroupRuleProtocolTcpudpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp"
+
+	// VPCSecurityGroupRuleProtocolIndividualType is a string representation of the 'SecurityGroupRuleProtocolIndividual' type.
+	VPCSecurityGroupRuleProtocolIndividualType = "*vpcv1.SecurityGroupRuleProtocolIndividual"
 )
 
 // VPCSecurityGroupRuleAction represents the actions for a Security Group Rule.
@@ -306,10 +312,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
+// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
+	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
+	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
 	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
@@ -435,6 +443,7 @@ type VPCSecurityGroupRuleRemote struct {
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="(self.protocol != 'tcp' && self.protocol != 'udp') ? !has(self.portRange) : true",message="portRange is not valid for protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.

--- a/api/powervs/v1beta3/types.go
+++ b/api/powervs/v1beta3/types.go
@@ -312,12 +312,16 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
+// +kubebuilder:validation:Pattern=`^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
 	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
 	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
+	// VPCSecurityGroupRuleProtocolAll is DEPRECATED: Use VPCSecurityGroupRuleProtocolIcmpTCPUDP instead.
+	// This constant is maintained for backward compatibility.
+	// It will be removed in a future version.
+	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = "all"
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
 	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.

--- a/api/powervs/v1beta3/types.go
+++ b/api/powervs/v1beta3/types.go
@@ -273,8 +273,8 @@ var (
 )
 
 const (
-	// VPCSecurityGroupRuleProtocolAllType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolAll' type.
-	VPCSecurityGroupRuleProtocolAllType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll"
+	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
+	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
 	// VPCSecurityGroupRuleProtocolIcmpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolIcmp' type.
 	VPCSecurityGroupRuleProtocolIcmpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp"
@@ -306,12 +306,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=all;icmp;tcp;udp
+// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
 type VPCSecurityGroupRuleProtocol string
 
 const (
-	// VPCSecurityGroupRuleProtocolAll defines the Rule is for all network protocols.
-	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAllConst
+	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
+	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
 	VPCSecurityGroupRuleProtocolIcmp VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpConst
 	// VPCSecurityGroupRuleProtocolTCP defines the Rule is for TCP network protocol.
@@ -434,8 +434,8 @@ type VPCSecurityGroupRuleRemote struct {
 
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
-// +kubebuilder:validation:XValidation:rule="self.protocol == 'all' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolAll protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.
 	// Only used when Protocol is VPCSecurityGroupRuleProtocolIcmp.

--- a/api/vpc/v1beta2/types.go
+++ b/api/vpc/v1beta2/types.go
@@ -164,6 +164,9 @@ var (
 )
 
 const (
+	// VPCSecurityGroupRuleProtocolAnyType is a string representation of the 'SecurityGroupRuleProtocolAny' type.
+	VPCSecurityGroupRuleProtocolAnyType = "*vpcv1.SecurityGroupRuleProtocolAny"
+
 	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
 	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
@@ -172,6 +175,9 @@ const (
 
 	// VPCSecurityGroupRuleProtocolTcpudpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolTcpudp' type.
 	VPCSecurityGroupRuleProtocolTcpudpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp"
+
+	// VPCSecurityGroupRuleProtocolIndividualType is a string representation of the 'SecurityGroupRuleProtocolIndividual' type.
+	VPCSecurityGroupRuleProtocolIndividualType = "*vpcv1.SecurityGroupRuleProtocolIndividual"
 )
 
 // VPCSecurityGroupRuleAction represents the actions for a Security Group Rule.
@@ -197,10 +203,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
+// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
+	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
+	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
 	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
@@ -399,6 +407,7 @@ type VPCSecurityGroupRuleRemote struct {
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="(self.protocol != 'tcp' && self.protocol != 'udp') ? !has(self.portRange) : true",message="portRange is not valid for protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.

--- a/api/vpc/v1beta2/types.go
+++ b/api/vpc/v1beta2/types.go
@@ -164,8 +164,8 @@ var (
 )
 
 const (
-	// VPCSecurityGroupRuleProtocolAllType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolAll' type.
-	VPCSecurityGroupRuleProtocolAllType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll"
+	// VPCSecurityGroupRuleProtocolIcmptcpudpType is a string representation of the 'SecurityGroupRuleProtocolIcmptcpudp' type.
+	VPCSecurityGroupRuleProtocolIcmptcpudpType = "*vpcv1.SecurityGroupRuleProtocolIcmptcpudp"
 
 	// VPCSecurityGroupRuleProtocolIcmpType is a string representation of the 'SecurityGroupRuleSecurityGroupRuleProtocolIcmp' type.
 	VPCSecurityGroupRuleProtocolIcmpType = "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp"
@@ -197,12 +197,12 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Enum=all;icmp;tcp;udp
+// +kubebuilder:validation:Enum=icmp_tcp_udp;icmp;tcp;udp
 type VPCSecurityGroupRuleProtocol string
 
 const (
-	// VPCSecurityGroupRuleProtocolAll defines the Rule is for all network protocols.
-	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAllConst
+	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
+	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.
 	VPCSecurityGroupRuleProtocolIcmp VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpConst
 	// VPCSecurityGroupRuleProtocolTCP defines the Rule is for TCP network protocol.
@@ -398,8 +398,8 @@ type VPCSecurityGroupRuleRemote struct {
 
 // VPCSecurityGroupRulePrototype defines a VPC Security Group Rule's traffic specifics for a series of remotes (destinations or sources).
 // +kubebuilder:validation:XValidation:rule="self.protocol != 'icmp' ? (!has(self.icmpCode) && !has(self.icmpType)) : true",message="icmpCode and icmpType are only supported for VPCSecurityGroupRuleProtocolIcmp protocol"
-// +kubebuilder:validation:XValidation:rule="self.protocol == 'all' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolAll protocol"
 // +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmp protocol"
+// +kubebuilder:validation:XValidation:rule="self.protocol == 'icmp_tcp_udp' ? !has(self.portRange) : true",message="portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP protocol"
 type VPCSecurityGroupRulePrototype struct {
 	// icmpCode is the ICMP code for the Rule.
 	// Only used when Protocol is VPCSecurityGroupRuleProtocolIcmp.

--- a/api/vpc/v1beta2/types.go
+++ b/api/vpc/v1beta2/types.go
@@ -203,12 +203,16 @@ const (
 )
 
 // VPCSecurityGroupRuleProtocol represents the protocols for a Security Group Rule.
-// +kubebuilder:validation:Pattern=`^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
+// +kubebuilder:validation:Pattern=`^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$`
 type VPCSecurityGroupRuleProtocol string
 
 const (
 	// VPCSecurityGroupRuleProtocolAny defines the Rule is for any network protocols.
 	VPCSecurityGroupRuleProtocolAny VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolAnyConst
+	// VPCSecurityGroupRuleProtocolAll is DEPRECATED: Use VPCSecurityGroupRuleProtocolIcmpTCPUDP instead.
+	// This constant is maintained for backward compatibility.
+	// It will be removed in a future version.
+	VPCSecurityGroupRuleProtocolAll VPCSecurityGroupRuleProtocol = "all"
 	// VPCSecurityGroupRuleProtocolIcmpTCPUDP defines the Rule is for ICMP, TCP and UDP protocols.
 	VPCSecurityGroupRuleProtocolIcmpTCPUDP VPCSecurityGroupRuleProtocol = vpcv1.NetworkACLRuleProtocolIcmpTCPUDPConst
 	// VPCSecurityGroupRuleProtocolIcmp defiens the Rule is for ICMP network protocol.

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -2158,13 +2158,13 @@ func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityG
 	}
 
 	switch reflect.TypeOf(ruleIntf).String() {
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
-		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+		rule := ruleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
+	case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
 		ruleID = rule.ID
-	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp":
+	case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)
 		ruleID = rule.ID
 	}
@@ -2305,8 +2305,8 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 
 	for _, ogRuleIntf := range originalSecurityGroupRules {
 		switch reflect.TypeOf(ogRuleIntf).String() {
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
-			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+		case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 			ruleID = ogRule.ID
 
 			if *ogRule.Direction == string(direction) && *ogRule.Protocol == protocol {
@@ -2317,7 +2317,7 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 					return nil, false, err
 				}
 			}
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
+		case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 			portMin := rule.PortRange.MinimumPort
 			portMax := rule.PortRange.MaximumPort
 			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
@@ -2331,7 +2331,7 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 					return nil, false, err
 				}
 			}
-		case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp":
+		case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 			icmpCode := rule.ICMPCode
 			icmpType := rule.ICMPType
 			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -2185,6 +2185,12 @@ func (s *ClusterScope) createVPCSecurityGroupRules(ctx context.Context, ogSecuri
 	log.V(3).Info("Creating VPC security group rules")
 
 	for _, rule := range ogSecurityGroupRules {
+		// Work on a copy with normalized prototypes so the deprecated 'all' protocol is
+		// translated without mutating the cluster spec.
+		rule := *rule
+		rule.Destination = normalizedVPCSecurityGroupRulePrototype(rule.Destination)
+		rule.Source = normalizedVPCSecurityGroupRulePrototype(rule.Source)
+
 		var protocol *string
 		var portMax, portMin *int64
 
@@ -2307,6 +2313,9 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 		err = fmt.Errorf("failed to validate VPC security group rule's remote: %w", e)
 	}
 
+	// Normalize the deprecated 'all' protocol so the comparison matches existing IBM Cloud
+	// rules. Returns a copy, so the cluster spec is not mutated.
+	rule = normalizedVPCSecurityGroupRulePrototype(rule)
 	protocol := string(rule.Protocol)
 
 	for _, ogRuleIntf := range originalSecurityGroupRules {

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -2158,6 +2158,9 @@ func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityG
 	}
 
 	switch reflect.TypeOf(ruleIntf).String() {
+	case infrav1.VPCSecurityGroupRuleProtocolAnyType:
+		rule := ruleIntf.(*vpcv1.SecurityGroupRuleProtocolAny)
+		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
@@ -2166,6 +2169,9 @@ func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityG
 		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 		rule := ruleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)
+		ruleID = rule.ID
+	case infrav1.VPCSecurityGroupRuleProtocolIndividualType:
+		rule := ruleIntf.(*vpcv1.SecurityGroupRuleProtocolIndividual)
 		ruleID = rule.ID
 	}
 	log.Info("Created VPC security group rule", "ruleID", *ruleID)
@@ -2296,7 +2302,7 @@ func (s *ClusterScope) validateVPCSecurityGroupRuleRemote(originalSGRemote *vpcv
 }
 
 // validateSecurityGroupRule compares a specific security group's rule with the spec and existing security group's rule.
-func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vpcv1.SecurityGroupRuleIntf, direction infrav1.VPCSecurityGroupRuleDirection, rule *infrav1.VPCSecurityGroupRulePrototype, remote infrav1.VPCSecurityGroupRuleRemote) (ruleID *string, match bool, err error) {
+func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vpcv1.SecurityGroupRuleIntf, direction infrav1.VPCSecurityGroupRuleDirection, rule *infrav1.VPCSecurityGroupRulePrototype, remote infrav1.VPCSecurityGroupRuleRemote) (ruleID *string, match bool, err error) { //nolint: gocyclo
 	updateError := func(e error) {
 		err = fmt.Errorf("failed to validate VPC security group rule's remote: %w", e)
 	}
@@ -2305,6 +2311,18 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 
 	for _, ogRuleIntf := range originalSecurityGroupRules {
 		switch reflect.TypeOf(ogRuleIntf).String() {
+		case infrav1.VPCSecurityGroupRuleProtocolAnyType:
+			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleProtocolAny)
+			ruleID = ogRule.ID
+
+			if *ogRule.Direction == string(direction) && *ogRule.Protocol == protocol {
+				ogRemote := ogRule.Remote.(*vpcv1.SecurityGroupRuleRemote)
+				match, err = s.validateVPCSecurityGroupRuleRemote(ogRemote, remote)
+				if err != nil {
+					updateError(err)
+					return nil, false, err
+				}
+			}
 		case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
 			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 			ruleID = ogRule.ID
@@ -2338,6 +2356,18 @@ func (s *ClusterScope) validateSecurityGroupRule(originalSecurityGroupRules []vp
 			ruleID = ogRule.ID
 
 			if *ogRule.Direction == string(direction) && *ogRule.Protocol == protocol && *ogRule.Code == *icmpCode && *ogRule.Type == *icmpType {
+				ogRemote := ogRule.Remote.(*vpcv1.SecurityGroupRuleRemote)
+				match, err = s.validateVPCSecurityGroupRuleRemote(ogRemote, remote)
+				if err != nil {
+					updateError(err)
+					return nil, false, err
+				}
+			}
+		case infrav1.VPCSecurityGroupRuleProtocolIndividualType:
+			ogRule := ogRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIndividual)
+			ruleID = ogRule.ID
+
+			if *ogRule.Direction == string(direction) && *ogRule.Protocol == protocol {
 				ogRemote := ogRule.Remote.(*vpcv1.SecurityGroupRuleRemote)
 				match, err = s.validateVPCSecurityGroupRuleRemote(ogRemote, remote)
 				if err != nil {

--- a/cloud/scope/powervs/powervs_cluster_test.go
+++ b/cloud/scope/powervs/powervs_cluster_test.go
@@ -4484,6 +4484,356 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeFalse())
 		g.Expect(err).ToNot(BeNil())
 	})
+	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleProtocolAny", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: infrav1.VPCSecurityGroupRuleProtocolAny,
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolAny{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("any"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				CIDRBlock: ptr.To("0.0.0.0/0"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(err).To(BeNil())
+		g.Expect(match).To(BeTrue())
+		g.Expect(ruleID).ToNot(BeNil())
+		g.Expect(*ruleID).To(BeEquivalentTo("ruleID"))
+	})
+	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleProtocolAny", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			Address:    ptr.To("192.168.0.1/24"),
+			RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAddress,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: infrav1.VPCSecurityGroupRuleProtocolAny,
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolAny{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("any"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				Address: ptr.To("192.168.1.1/24"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(err).To(BeNil())
+		g.Expect(match).To(BeFalse())
+		g.Expect(ruleID).To(BeNil())
+	})
+
+	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleProtocolAny returns error", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			CIDRSubnetName: ptr.To("CIDRSubnetName"),
+			RemoteType:     infrav1.VPCSecurityGroupRuleRemoteTypeCIDR,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: infrav1.VPCSecurityGroupRuleProtocolAny,
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolAny{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("any"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				CIDRBlock: ptr.To("192.168.1.0/24"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, errors.New("failed to get VPC subnet"))
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(match).To(BeFalse())
+		g.Expect(ruleID).To(BeNil())
+		g.Expect(err).ToNot(BeNil())
+	})
+	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleProtocolIndividual", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: "gre",
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIndividual{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("gre"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				CIDRBlock: ptr.To("0.0.0.0/0"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(err).To(BeNil())
+		g.Expect(match).To(BeTrue())
+		g.Expect(ruleID).ToNot(BeNil())
+		g.Expect(*ruleID).To(BeEquivalentTo("ruleID"))
+	})
+	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleProtocolIndividual", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			Address:    ptr.To("192.168.0.1/24"),
+			RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAddress,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: "gre",
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIndividual{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("gre"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				Address: ptr.To("192.168.1.1/24"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(err).To(BeNil())
+		g.Expect(match).To(BeFalse())
+		g.Expect(ruleID).To(BeNil())
+	})
+	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleProtocolIndividual returns error", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			CIDRSubnetName: ptr.To("CIDRSubnetName"),
+			RemoteType:     infrav1.VPCSecurityGroupRuleRemoteTypeCIDR,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: "gre",
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIndividual{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("gre"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				CIDRBlock: ptr.To("192.168.1.0/24"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, errors.New("failed to get VPC subnet"))
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(match).To(BeFalse())
+		g.Expect(ruleID).To(BeNil())
+		g.Expect(err).ToNot(BeNil())
+	})
+	t.Run("When spec uses deprecated protocol 'all', it matches an existing icmp_tcp_udp rule without mutating the spec", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		remote := infrav1.VPCSecurityGroupRuleRemote{
+			RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny,
+		}
+		rules := infrav1.VPCSecurityGroupRule{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionOutbound,
+			Destination: &infrav1.VPCSecurityGroupRulePrototype{
+				Remotes:  append([]infrav1.VPCSecurityGroupRuleRemote{}, remote),
+				Protocol: infrav1.VPCSecurityGroupRuleProtocolAll,
+			},
+		}
+
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
+			Direction: ptr.To("outbound"),
+			Protocol:  ptr.To("icmp_tcp_udp"),
+			Remote: &vpcv1.SecurityGroupRuleRemote{
+				CIDRBlock: ptr.To("0.0.0.0/0"),
+			},
+			ID: ptr.To("ruleID"),
+		}
+
+		vpcSecurityGroupRules := []vpcv1.SecurityGroupRuleIntf{&vpcSecurityGroupRule}
+
+		vpcSecurityGroup := infrav1.VPCSecurityGroup{
+			ID:    ptr.To("securityGroupID"),
+			Rules: append([]*infrav1.VPCSecurityGroupRule{}, &rules),
+		}
+		clusterScope := ClusterScope{
+			IBMVPCClient: mockVPC,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					VPC: infrav1.VPCStatus{ID: "VPCID"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					VPCSecurityGroups: append([]infrav1.VPCSecurityGroup{}, vpcSecurityGroup),
+				},
+			},
+		}
+
+		ruleID, match, err := clusterScope.validateSecurityGroupRule(vpcSecurityGroupRules, rules.Direction, rules.Destination, remote)
+		g.Expect(err).To(BeNil())
+		g.Expect(match).To(BeTrue())
+		g.Expect(ruleID).ToNot(BeNil())
+		g.Expect(*ruleID).To(BeEquivalentTo("ruleID"))
+		g.Expect(rules.Destination.Protocol).To(Equal(infrav1.VPCSecurityGroupRuleProtocolAll))
+	})
 }
 
 func TestValidateVPCSecurityGroupRules(t *testing.T) {

--- a/cloud/scope/powervs/powervs_cluster_test.go
+++ b/cloud/scope/powervs/powervs_cluster_test.go
@@ -3669,7 +3669,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -3715,7 +3715,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -3966,7 +3966,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 		}
 
 		securityGroupDetails := &vpcv1.SecurityGroup{Name: ptr.To("securityGroupName"), ID: ptr.To("securityGroupID"), VPC: &vpcv1.VPCReference{ID: ptr.To("VPCID")}}
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Protocol: ptr.To("tcp"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Protocol: ptr.To("tcp"), ID: ptr.To("ruleID")}, nil, nil)
 		mockVPC.EXPECT().GetSecurityGroupByName(gomock.Any()).Return(securityGroupDetails, nil)
 		sg, ruleIDs, err := clusterScope.validateVPCSecurityGroup(ctx, vpcSecurityGroup)
 		g.Expect(ruleIDs).To(BeNil())
@@ -3987,7 +3987,7 @@ func TestValidateVPCSecurityGroup(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4191,7 +4191,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeFalse())
 		g.Expect(err).ToNot(BeNil())
 	})
-	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll", func(t *testing.T) {
+	t.Run("When it matches SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -4205,7 +4205,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4237,7 +4237,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeTrue())
 		g.Expect(err).To(BeNil())
 	})
-	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll", func(t *testing.T) {
+	t.Run("When it doesn't match SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -4252,7 +4252,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4284,7 +4284,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 		g.Expect(match).To(BeFalse())
 		g.Expect(err).To(BeNil())
 	})
-	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleSecurityGroupRuleProtocolAll returns error", func(t *testing.T) {
+	t.Run("When SecurityGroupRule of protocolType SecurityGroupRuleProtocolIcmptcpudp returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -4299,7 +4299,7 @@ func TestValidateVPCSecurityGroupRule(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4513,7 +4513,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4557,7 +4557,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4603,7 +4603,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("inbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4648,7 +4648,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -4692,7 +4692,7 @@ func TestValidateVPCSecurityGroupRules(t *testing.T) {
 				Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
 			},
 		}
-		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{
+		vpcSecurityGroupRule := vpcv1.SecurityGroupRuleProtocolIcmptcpudp{
 			Direction: ptr.To("outbound"),
 			Protocol:  ptr.To("tcp"),
 			Remote: &vpcv1.SecurityGroupRuleRemote{
@@ -5143,7 +5143,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, &securityGroupID, ptr.To("outbound"), &protocol, &portMin, &portMax, remote)
 		g.Expect(ruleID).To(BeEquivalentTo(ptr.To("ruleID")))
 		g.Expect(err).To(BeNil())
@@ -5251,7 +5251,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, &securityGroupID, ptr.To("outbound"), &protocol, &portMin, &portMax, remote)
 		g.Expect(ruleID).To(BeEquivalentTo(ptr.To("ruleID")))
 		g.Expect(err).To(BeNil())
@@ -5576,7 +5576,7 @@ func TestCreateVPCSecurityGroupRulesAndSetStatus(t *testing.T) {
 			},
 		}
 
-		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
 		err := clusterScope.createVPCSecurityGroupRulesAndSetStatus(ctx, vpcSecurityGroup.Rules, ptr.To("securityGroupID"), ptr.To("securityGroupName"))
 		g.Expect(err).To(BeNil())
 	})

--- a/cloud/scope/powervs/util.go
+++ b/cloud/scope/powervs/util.go
@@ -46,3 +46,16 @@ func fetchBucketRegion(cos infrav1.COSInstanceSource, vpc infrav1.VPCStatus) str
 	}
 	return vpc.Region
 }
+
+// normalizedVPCSecurityGroupRulePrototype translates the deprecated 'all' protocol value to
+// 'icmp_tcp_udp'. This ensures backward compatibility with YAMLs using the old value.
+// The prototype is returned unchanged unless it uses 'all', in which case a normalized copy
+// is returned.
+func normalizedVPCSecurityGroupRulePrototype(prototype *infrav1.VPCSecurityGroupRulePrototype) *infrav1.VPCSecurityGroupRulePrototype {
+	if prototype == nil || prototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolAll {
+		return prototype
+	}
+	normalized := prototype.DeepCopy()
+	normalized.Protocol = infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP
+	return normalized
+}

--- a/cloud/scope/powervs/util_test.go
+++ b/cloud/scope/powervs/util_test.go
@@ -104,3 +104,31 @@ func TestFetchBucketRegion(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizedVPCSecurityGroupRulePrototype(t *testing.T) {
+	t.Run("When prototype is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(normalizedVPCSecurityGroupRulePrototype(nil)).To(BeNil())
+	})
+	t.Run("When protocol is not deprecated, the prototype is returned unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		prototype := &infrav1.VPCSecurityGroupRulePrototype{
+			Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
+		}
+		g.Expect(normalizedVPCSecurityGroupRulePrototype(prototype)).To(BeIdenticalTo(prototype))
+	})
+	t.Run("When protocol is deprecated 'all', a normalized copy is returned and the input is not mutated", func(t *testing.T) {
+		g := NewWithT(t)
+		prototype := &infrav1.VPCSecurityGroupRulePrototype{
+			Protocol: infrav1.VPCSecurityGroupRuleProtocolAll,
+			Remotes: []infrav1.VPCSecurityGroupRuleRemote{
+				{RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny},
+			},
+		}
+		normalized := normalizedVPCSecurityGroupRulePrototype(prototype)
+		g.Expect(normalized).ToNot(BeIdenticalTo(prototype))
+		g.Expect(normalized.Protocol).To(Equal(infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP))
+		g.Expect(normalized.Remotes).To(Equal(prototype.Remotes))
+		g.Expect(prototype.Protocol).To(Equal(infrav1.VPCSecurityGroupRuleProtocolAll))
+	})
+}

--- a/cloud/scope/vpc/cluster_v2.go
+++ b/cloud/scope/vpc/cluster_v2.go
@@ -1455,22 +1455,22 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 		for _, existingRuleIntf := range existingSecurityGroupRules.Rules {
 			// Perform analysis of the existingRuleIntf, based on its Protocol type, further analysis is performed based on remaining attributes to find if the specific Rule and Remote match
 			switch reflect.TypeOf(existingRuleIntf).String() {
-			case infrav1.VPCSecurityGroupRuleProtocolAllType:
-				// If our Remote doesn't define all Protocols, we don't need further checks, move on to next Rule
-				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolAll {
+			case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+				// If our Remote doesn't define icmp_tcp_udp Protocols, we don't need further checks, move on to next Rule
+				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP {
 					continue
 				}
-				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 				// If the Remote doesn't have the same Direction as the Rule, no further checks are necessary
 				if securityGroupRule.Direction != infrav1.VPCSecurityGroupRuleDirection(*existingRule.Direction) {
 					continue
 				}
-				if found, err := s.checkSecurityGroupRuleProtocolAll(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
-					return fmt.Errorf("error failure checking security group rule protocol all: %w", err)
+				if found, err := s.checkSecurityGroupRuleProtocolIcmpTCPUDP(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
+					return fmt.Errorf("error failure checking security group rule protocol icmp_tcp_udp: %w", err)
 				} else if found {
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
-					log.V(3).Info("security group rule all protocol match found")
+					log.V(3).Info("security group rule icmp_tcp_udp protocol match found")
 					remoteMatch = true
 					break
 				}
@@ -1527,8 +1527,8 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 	return nil
 }
 
-// checkSecurityGroupRuleProtocolAll analyzes an IBM Cloud Security Group Rule designated for 'all' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'ProtocolAll' Rule.
-func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolAll(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll) (bool, error) {
+// checkSecurityGroupRuleProtocolIcmpTCPUDP analyzes an IBM Cloud Security Group Rule designated for 'icmp_tcp_udp' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'icmp_tcp_udp' Rule.
+func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolIcmpTCPUDP(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleProtocolIcmptcpudp) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if exists, err := s.checkSecurityGroupRulePrototypeRemote(ctx, securityGroupRuleRemote, existingRule.Remote); err != nil {
 		return false, fmt.Errorf("error failed checking security group rule all remote: %w", err)
@@ -1706,8 +1706,8 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 		return fmt.Errorf("error failed to create security group rule remote: %w", err)
 	}
 	switch securityGroupRulePrototype.Protocol {
-	case infrav1.VPCSecurityGroupRuleProtocolAll:
-		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolAll{
+	case infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP:
+		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolIcmptcpudpPrototype{
 			Direction: ptr.To(string(securityGroupRule.Direction)),
 			Protocol:  ptr.To(string(securityGroupRulePrototype.Protocol)),
 			Remote:    prototypeRemote,
@@ -1753,8 +1753,8 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 	// Typecast the resulting SecurityGroupRuleIntf, to retrieve the ID for logging
 	var ruleID *string
 	switch reflect.TypeOf(securityGroupRuleIntfDetails).String() {
-	case infrav1.VPCSecurityGroupRuleProtocolAllType:
-		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
+		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp)

--- a/cloud/scope/vpc/cluster_v2.go
+++ b/cloud/scope/vpc/cluster_v2.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 
 	"github.com/go-logr/logr"
 
@@ -61,6 +62,14 @@ const (
 	privateLBSuffix = "private"
 	// publicLBSuffix is used to tag a default Load Balancer name as public.
 	publicLBSuffix = "public"
+
+	// individualSgrRegex is used to check if the VPCSecurityGroupRuleProtocolIndividual is valid.
+	individualSgrRegex = "^(ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$"
+)
+
+var (
+	// Compile the regexp object for the VPCSecurityGroupRuleProtocolIndividualType.
+	individualSgrRegexp = regexp.MustCompile(individualSgrRegex)
 )
 
 // ClusterScopeParamsV2 defines the input parameters used to create a new ClusterScopeV2.
@@ -1455,6 +1464,25 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 		for _, existingRuleIntf := range existingSecurityGroupRules.Rules {
 			// Perform analysis of the existingRuleIntf, based on its Protocol type, further analysis is performed based on remaining attributes to find if the specific Rule and Remote match
 			switch reflect.TypeOf(existingRuleIntf).String() {
+			case infrav1.VPCSecurityGroupRuleProtocolAnyType:
+				// If our Remote doesn't define the Any Protocol, we don't need further checks, move on to next Rule
+				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolAny {
+					continue
+				}
+				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleProtocolAny)
+				// If the Remote doesn't have the same Direction as the Rule, no further checks are necessary
+				if securityGroupRule.Direction != infrav1.VPCSecurityGroupRuleDirection(*existingRule.Direction) {
+					continue
+				}
+				if found, err := s.checkSecurityGroupRuleProtocolAny(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
+					return fmt.Errorf("error failure checking security group rule protocol any: %w", err)
+				} else if found {
+					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
+					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
+					log.V(3).Info("security group rule any protocol match found")
+					remoteMatch = true
+					break
+				}
 			case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
 				// If our Remote doesn't define icmp_tcp_udp Protocols, we don't need further checks, move on to next Rule
 				if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP {
@@ -1469,7 +1497,6 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					return fmt.Errorf("error failure checking security group rule protocol icmp_tcp_udp: %w", err)
 				} else if found {
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
-					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
 					log.V(3).Info("security group rule icmp_tcp_udp protocol match found")
 					remoteMatch = true
 					break
@@ -1510,6 +1537,26 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					remoteMatch = true
 					break
 				}
+			case infrav1.VPCSecurityGroupRuleProtocolIndividualType:
+				matched := individualSgrRegexp.MatchString(string(securityGroupRulePrototype.Protocol))
+
+				// If our Remote doesn't define one of the individual Protocol, we don't need further checks, move on to next Rule
+				if !matched {
+					continue
+				}
+				existingRule := existingRuleIntf.(*vpcv1.SecurityGroupRuleProtocolIndividual)
+				// If the Remote doesn't have the same Direction as the Rule, no further checks are necessary
+				if securityGroupRule.Direction != infrav1.VPCSecurityGroupRuleDirection(*existingRule.Direction) {
+					continue
+				}
+				if found, err := s.checkSecurityGroupRuleProtocolIndividual(ctx, securityGroupRulePrototype, remote, existingRule); err != nil {
+					return fmt.Errorf("error failure checking security group rule protocol %s: %w", string(securityGroupRulePrototype.Protocol), err)
+				} else if found {
+					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
+					log.V(3).Info("security group rule individual protocol match found", "protocol", string(securityGroupRulePrototype.Protocol))
+					remoteMatch = true
+					break
+				}
 			default:
 				// This is an unexpected IBM Cloud Security Group Rule Prototype, log it and move on
 				log.V(3).Info("unexpected security group rule prototype", "securityGroupRulePrototype", reflect.TypeOf(existingRuleIntf).String())
@@ -1527,13 +1574,25 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 	return nil
 }
 
+// checkSecurityGroupRuleProtocolAny analyzes an IBM Cloud Security Group Rule designated for 'any' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'any' Rule.
+func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolAny(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleProtocolAny) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if exists, err := s.checkSecurityGroupRulePrototypeRemote(ctx, securityGroupRuleRemote, existingRule.Remote); err != nil {
+		return false, fmt.Errorf("error failed checking security group rule any remote: %w", err)
+	} else if exists {
+		log.V(3).Info("security group rule any protocol matches")
+		return true, nil
+	}
+	return false, nil
+}
+
 // checkSecurityGroupRuleProtocolIcmpTCPUDP analyzes an IBM Cloud Security Group Rule designated for 'icmp_tcp_udp' protocols, to verify if the supplied Rule and Remote match the attributes from the existing 'icmp_tcp_udp' Rule.
 func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolIcmpTCPUDP(ctx context.Context, _ infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleProtocolIcmptcpudp) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if exists, err := s.checkSecurityGroupRulePrototypeRemote(ctx, securityGroupRuleRemote, existingRule.Remote); err != nil {
-		return false, fmt.Errorf("error failed checking security group rule all remote: %w", err)
+		return false, fmt.Errorf("error failed checking security group rule icmp-tcp-udp remote: %w", err)
 	} else if exists {
-		log.V(3).Info("security group rule all protocols match")
+		log.V(3).Info("security group rule icmp-tcp-udp protocol matches")
 		return true, nil
 	}
 	return false, nil
@@ -1579,6 +1638,23 @@ func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolTcpudp(ctx context.Contex
 				return true, nil
 			}
 		}
+	}
+	return false, nil
+}
+
+// checkSecurityGroupRuleProtocolIndividual analyzes an IBM Cloud Security Group Rule designated for individual protocols, to verify if the supplied Rule and Remote match the attributes from the existing individual Rule.
+func (s *ClusterScopeV2) checkSecurityGroupRuleProtocolIndividual(ctx context.Context, securityGroupRulePrototype infrav1.VPCSecurityGroupRulePrototype, securityGroupRuleRemote infrav1.VPCSecurityGroupRuleRemote, existingRule *vpcv1.SecurityGroupRuleProtocolIndividual) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	// Check the protocol next to verify it matches
+	if securityGroupRulePrototype.Protocol != infrav1.VPCSecurityGroupRuleProtocol(*existingRule.Protocol) {
+		return false, nil
+	}
+
+	if exists, err := s.checkSecurityGroupRulePrototypeRemote(ctx, securityGroupRuleRemote, existingRule.Remote); err != nil {
+		return false, fmt.Errorf("error failed checking security group rule %s remote: %w", string(securityGroupRulePrototype.Protocol), err)
+	} else if exists {
+		log.V(3).Info("security group rule individual protocol matches", "protocol", string(securityGroupRulePrototype.Protocol))
+		return true, nil
 	}
 	return false, nil
 }
@@ -1706,6 +1782,13 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 		return fmt.Errorf("error failed to create security group rule remote: %w", err)
 	}
 	switch securityGroupRulePrototype.Protocol {
+	case infrav1.VPCSecurityGroupRuleProtocolAny:
+		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolAnyPrototype{
+			Direction: ptr.To(string(securityGroupRule.Direction)),
+			Protocol:  ptr.To(string(securityGroupRulePrototype.Protocol)),
+			Remote:    prototypeRemote,
+		}
+		options.SetSecurityGroupRulePrototype(prototype)
 	case infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP:
 		prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolIcmptcpudpPrototype{
 			Direction: ptr.To(string(securityGroupRule.Direction)),
@@ -1738,8 +1821,21 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 		}
 		options.SetSecurityGroupRulePrototype(prototype)
 	default:
-		// This should not be possible, provided the strict kubebuilder enforcements
-		return fmt.Errorf("error failed creating security group rule, unknown protocol")
+		// Check if protocol is part of the supported list else error
+		// If part of the supported list add it as Individual prototype
+		matched := individualSgrRegexp.MatchString(string(securityGroupRulePrototype.Protocol))
+
+		if matched {
+			prototype := &vpcv1.SecurityGroupRulePrototypeSecurityGroupRuleProtocolIndividualPrototype{
+				Direction: ptr.To(string(securityGroupRule.Direction)),
+				Protocol:  ptr.To(string(securityGroupRulePrototype.Protocol)),
+				Remote:    prototypeRemote,
+			}
+			options.SetSecurityGroupRulePrototype(prototype)
+		} else {
+			// This should not be possible, provided the strict kubebuilder enforcements
+			return fmt.Errorf("error failed creating security group rule, unknown protocol")
+		}
 	}
 
 	log.V(3).Info("Creating Security Group Rule for Security Group", "securityGroupID", securityGroupID, "direction", securityGroupRule.Direction, "protocol", securityGroupRulePrototype.Protocol, "prototypeRemote", prototypeRemote)
@@ -1753,6 +1849,9 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 	// Typecast the resulting SecurityGroupRuleIntf, to retrieve the ID for logging
 	var ruleID *string
 	switch reflect.TypeOf(securityGroupRuleIntfDetails).String() {
+	case infrav1.VPCSecurityGroupRuleProtocolAnyType:
+		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleProtocolAny)
+		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
 		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleProtocolIcmptcpudp)
 		ruleID = rule.ID
@@ -1761,6 +1860,9 @@ func (s *ClusterScopeV2) createSecurityGroupRule(ctx context.Context, securityGr
 		ruleID = rule.ID
 	case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
+		ruleID = rule.ID
+	case infrav1.VPCSecurityGroupRuleProtocolIndividualType:
+		rule := securityGroupRuleIntfDetails.(*vpcv1.SecurityGroupRuleProtocolIndividual)
 		ruleID = rule.ID
 	}
 	log.V(3).Info("Created Security Group Rule", "ruleID", ruleID)

--- a/cloud/scope/vpc/cluster_v2.go
+++ b/cloud/scope/vpc/cluster_v2.go
@@ -1415,6 +1415,12 @@ func (s *ClusterScopeV2) reconcileSecurityGroupRules(ctx context.Context, securi
 // reconcileSecurityGroupRule will attempt to reconcile a defined SecurityGroupRule, with one or more Remotes, for a SecurityGroup. If the IBM Cloud Security Group contains no Rules, simply attempt to create the defined Rule (via the Remote(s) provided).
 func (s *ClusterScopeV2) reconcileSecurityGroupRule(ctx context.Context, securityGroupID string, securityGroupRule infrav1.VPCSecurityGroupRule) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	// securityGroupRule is a local copy, so repointing its prototypes at normalized
+	// copies leaves the cluster spec untouched.
+	securityGroupRule.Destination = normalizedVPCSecurityGroupRulePrototype(securityGroupRule.Destination)
+	securityGroupRule.Source = normalizedVPCSecurityGroupRulePrototype(securityGroupRule.Source)
+
 	existingSecurityGroupRuleIntfs, _, err := s.VPCClient.ListSecurityGroupRules(&vpcv1.ListSecurityGroupRulesOptions{
 		SecurityGroupID: ptr.To(securityGroupID),
 	})

--- a/cloud/scope/vpc/util.go
+++ b/cloud/scope/vpc/util.go
@@ -19,6 +19,8 @@ package vpc
 import (
 	"fmt"
 	"strings"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/vpc/v1beta2"
 )
 
 // CRN is a local duplicate of IBM Cloud CRN for parsing and references.
@@ -74,4 +76,17 @@ func parseCRN(s string) (*CRN, error) {
 	}
 
 	return crn, nil
+}
+
+// normalizedVPCSecurityGroupRulePrototype translates the deprecated 'all' protocol value to
+// 'icmp_tcp_udp'. This ensures backward compatibility with YAMLs using the old value.
+// The prototype is returned unchanged unless it uses 'all', in which case a normalized copy
+// is returned.
+func normalizedVPCSecurityGroupRulePrototype(prototype *infrav1.VPCSecurityGroupRulePrototype) *infrav1.VPCSecurityGroupRulePrototype {
+	if prototype == nil || prototype.Protocol != infrav1.VPCSecurityGroupRuleProtocolAll {
+		return prototype
+	}
+	normalized := prototype.DeepCopy()
+	normalized.Protocol = infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP
+	return normalized
 }

--- a/cloud/scope/vpc/util_test.go
+++ b/cloud/scope/vpc/util_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpc
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/vpc/v1beta2"
+)
+
+func TestNormalizedVPCSecurityGroupRulePrototype(t *testing.T) {
+	t.Run("When prototype is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(normalizedVPCSecurityGroupRulePrototype(nil)).To(BeNil())
+	})
+	t.Run("When protocol is not deprecated, the prototype is returned unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		prototype := &infrav1.VPCSecurityGroupRulePrototype{
+			Protocol: infrav1.VPCSecurityGroupRuleProtocolTCP,
+		}
+		g.Expect(normalizedVPCSecurityGroupRulePrototype(prototype)).To(BeIdenticalTo(prototype))
+	})
+	t.Run("When protocol is deprecated 'all', a normalized copy is returned and the input is not mutated", func(t *testing.T) {
+		g := NewWithT(t)
+		prototype := &infrav1.VPCSecurityGroupRulePrototype{
+			Protocol: infrav1.VPCSecurityGroupRuleProtocolAll,
+			Remotes: []infrav1.VPCSecurityGroupRuleRemote{
+				{RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny},
+			},
+		}
+		normalized := normalizedVPCSecurityGroupRulePrototype(prototype)
+		g.Expect(normalized).ToNot(BeIdenticalTo(prototype))
+		g.Expect(normalized.Protocol).To(Equal(infrav1.VPCSecurityGroupRuleProtocolIcmpTCPUDP))
+		g.Expect(normalized.Remotes).To(Equal(prototype.Remotes))
+		g.Expect(prototype.Protocol).To(Equal(infrav1.VPCSecurityGroupRuleProtocolAll))
+	})
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -599,11 +599,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                enum:
-                                - icmp_tcp_udp
-                                - icmp
-                                - tcp
-                                - udp
+                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -678,6 +674,9 @@ spec:
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                 : true'
+                            - message: portRange is not valid for protocol
+                              rule: '(self.protocol != ''tcp'' && self.protocol !=
+                                ''udp'') ? !has(self.portRange) : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                 protocol
                               rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -736,11 +735,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                enum:
-                                - icmp_tcp_udp
-                                - icmp
-                                - tcp
-                                - udp
+                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -815,6 +810,9 @@ spec:
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                 : true'
+                            - message: portRange is not valid for protocol
+                              rule: '(self.protocol != ''tcp'' && self.protocol !=
+                                ''udp'') ? !has(self.portRange) : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                 protocol
                               rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -2086,11 +2084,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                enum:
-                                - icmp_tcp_udp
-                                - icmp
-                                - tcp
-                                - udp
+                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -2165,6 +2159,9 @@ spec:
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                 : true'
+                            - message: portRange is not valid for protocol
+                              rule: '(self.protocol != ''tcp'' && self.protocol !=
+                                ''udp'') ? !has(self.portRange) : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                 protocol
                               rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -2223,11 +2220,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                enum:
-                                - icmp_tcp_udp
-                                - icmp
-                                - tcp
-                                - udp
+                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -2302,6 +2295,9 @@ spec:
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                 : true'
+                            - message: portRange is not valid for protocol
+                              rule: '(self.protocol != ''tcp'' && self.protocol !=
+                                ''udp'') ? !has(self.portRange) : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                 protocol
                               rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -600,7 +600,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -674,13 +674,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                           direction:
                             description: direction defines whether the traffic is
@@ -737,7 +737,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -811,13 +811,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                         required:
                         - action
@@ -2087,7 +2087,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -2161,13 +2161,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                           direction:
                             description: direction defines whether the traffic is
@@ -2224,7 +2224,7 @@ spec:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
                                 enum:
-                                - all
+                                - icmp_tcp_udp
                                 - icmp
                                 - tcp
                                 - udp
@@ -2298,13 +2298,13 @@ spec:
                                 VPCSecurityGroupRuleProtocolIcmp protocol
                               rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                 && !has(self.icmpType)) : true'
-                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                protocol
-                              rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                : true'
                             - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                 protocol
                               rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                : true'
+                            - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                protocol
+                              rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                 : true'
                         required:
                         - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -599,7 +599,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -735,7 +735,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -2084,7 +2084,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-
@@ -2220,7 +2220,7 @@ spec:
                               protocol:
                                 description: protocol defines the traffic protocol
                                   used for the Security Group Rule.
-                                pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                 type: string
                               remotes:
                                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -623,11 +623,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        enum:
-                                        - icmp_tcp_udp
-                                        - icmp
-                                        - tcp
-                                        - udp
+                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -705,6 +701,9 @@ spec:
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                         : true'
+                                    - message: portRange is not valid for protocol
+                                      rule: '(self.protocol != ''tcp'' && self.protocol
+                                        != ''udp'') ? !has(self.portRange) : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                         protocol
                                       rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -764,11 +763,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        enum:
-                                        - icmp_tcp_udp
-                                        - icmp
-                                        - tcp
-                                        - udp
+                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -846,6 +841,9 @@ spec:
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                         : true'
+                                    - message: portRange is not valid for protocol
+                                      rule: '(self.protocol != ''tcp'' && self.protocol
+                                        != ''udp'') ? !has(self.portRange) : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                         protocol
                                       rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -1863,11 +1861,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        enum:
-                                        - icmp_tcp_udp
-                                        - icmp
-                                        - tcp
-                                        - udp
+                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -1945,6 +1939,9 @@ spec:
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                         : true'
+                                    - message: portRange is not valid for protocol
+                                      rule: '(self.protocol != ''tcp'' && self.protocol
+                                        != ''udp'') ? !has(self.portRange) : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                         protocol
                                       rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -2004,11 +2001,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        enum:
-                                        - icmp_tcp_udp
-                                        - icmp
-                                        - tcp
-                                        - udp
+                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -2086,6 +2079,9 @@ spec:
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                         : true'
+                                    - message: portRange is not valid for protocol
+                                      rule: '(self.protocol != ''tcp'' && self.protocol
+                                        != ''udp'') ? !has(self.portRange) : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                         protocol
                                       rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -623,7 +623,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                        pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -763,7 +763,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                        pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -1861,7 +1861,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                        pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-
@@ -2001,7 +2001,7 @@ spec:
                                       protocol:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
-                                        pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                        pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                         type: string
                                       remotes:
                                         description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -624,7 +624,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -701,13 +701,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                   direction:
                                     description: direction defines whether the traffic
@@ -765,7 +765,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -842,13 +842,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                 required:
                                 - action
@@ -1864,7 +1864,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -1941,13 +1941,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                   direction:
                                     description: direction defines whether the traffic
@@ -2005,7 +2005,7 @@ spec:
                                         description: protocol defines the traffic
                                           protocol used for the Security Group Rule.
                                         enum:
-                                        - all
+                                        - icmp_tcp_udp
                                         - icmp
                                         - tcp
                                         - udp
@@ -2082,13 +2082,13 @@ spec:
                                         for VPCSecurityGroupRuleProtocolIcmp protocol
                                       rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                         && !has(self.icmpType)) : true'
-                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                        protocol
-                                      rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                        : true'
                                     - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                         protocol
                                       rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                        : true'
+                                    - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                        protocol
+                                      rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                         : true'
                                 required:
                                 - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
@@ -897,7 +897,7 @@ spec:
                                   protocol:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
-                                    pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                    pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                     type: string
                                   remotes:
                                     description: |-
@@ -1033,7 +1033,7 @@ spec:
                                   protocol:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
-                                    pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                    pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                     type: string
                                   remotes:
                                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
@@ -898,7 +898,7 @@ spec:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
                                     enum:
-                                    - all
+                                    - icmp_tcp_udp
                                     - icmp
                                     - tcp
                                     - udp
@@ -972,13 +972,13 @@ spec:
                                     for VPCSecurityGroupRuleProtocolIcmp protocol
                                   rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                     && !has(self.icmpType)) : true'
-                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                    protocol
-                                  rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                    : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                    : true'
+                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                    protocol
+                                  rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                     : true'
                               direction:
                                 description: direction defines whether the traffic
@@ -1035,7 +1035,7 @@ spec:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
                                     enum:
-                                    - all
+                                    - icmp_tcp_udp
                                     - icmp
                                     - tcp
                                     - udp
@@ -1109,13 +1109,13 @@ spec:
                                     for VPCSecurityGroupRuleProtocolIcmp protocol
                                   rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                     && !has(self.icmpType)) : true'
-                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                    protocol
-                                  rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                    : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
+                                    : true'
+                                - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                    protocol
+                                  rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
                                     : true'
                             required:
                             - action

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclusters.yaml
@@ -897,11 +897,7 @@ spec:
                                   protocol:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
-                                    enum:
-                                    - icmp_tcp_udp
-                                    - icmp
-                                    - tcp
-                                    - udp
+                                    pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                     type: string
                                   remotes:
                                     description: |-
@@ -976,6 +972,9 @@ spec:
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                     : true'
+                                - message: portRange is not valid for protocol
+                                  rule: '(self.protocol != ''tcp'' && self.protocol
+                                    != ''udp'') ? !has(self.portRange) : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                     protocol
                                   rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)
@@ -1034,11 +1033,7 @@ spec:
                                   protocol:
                                     description: protocol defines the traffic protocol
                                       used for the Security Group Rule.
-                                    enum:
-                                    - icmp_tcp_udp
-                                    - icmp
-                                    - tcp
-                                    - udp
+                                    pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                     type: string
                                   remotes:
                                     description: |-
@@ -1113,6 +1108,9 @@ spec:
                                     protocol
                                   rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                     : true'
+                                - message: portRange is not valid for protocol
+                                  rule: '(self.protocol != ''tcp'' && self.protocol
+                                    != ''udp'') ? !has(self.portRange) : true'
                                 - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                     protocol
                                   rule: 'self.protocol == ''icmp_tcp_udp'' ? !has(self.portRange)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
@@ -756,7 +756,7 @@ spec:
                                             description: protocol defines the traffic
                                               protocol used for the Security Group
                                               Rule.
-                                            pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                            pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                             type: string
                                           remotes:
                                             description: |-
@@ -905,7 +905,7 @@ spec:
                                             description: protocol defines the traffic
                                               protocol used for the Security Group
                                               Rule.
-                                            pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
+                                            pattern: ^(any|all|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                             type: string
                                           remotes:
                                             description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
@@ -757,7 +757,7 @@ spec:
                                               protocol used for the Security Group
                                               Rule.
                                             enum:
-                                            - all
+                                            - icmp_tcp_udp
                                             - icmp
                                             - tcp
                                             - udp
@@ -841,14 +841,14 @@ spec:
                                             protocol
                                           rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                             && !has(self.icmpType)) : true'
-                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                            protocol
-                                          rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                            : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                            protocol
+                                          rule: 'self.protocol == ''icmp_tcp_udp''
+                                            ? !has(self.portRange) : true'
                                       direction:
                                         description: direction defines whether the
                                           traffic is inbound or outbound for the Security
@@ -907,7 +907,7 @@ spec:
                                               protocol used for the Security Group
                                               Rule.
                                             enum:
-                                            - all
+                                            - icmp_tcp_udp
                                             - icmp
                                             - tcp
                                             - udp
@@ -991,14 +991,14 @@ spec:
                                             protocol
                                           rule: 'self.protocol != ''icmp'' ? (!has(self.icmpCode)
                                             && !has(self.icmpType)) : true'
-                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolAll
-                                            protocol
-                                          rule: 'self.protocol == ''all'' ? !has(self.portRange)
-                                            : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmp
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
+                                            protocol
+                                          rule: 'self.protocol == ''icmp_tcp_udp''
+                                            ? !has(self.portRange) : true'
                                     required:
                                     - action
                                     - direction

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmvpcclustertemplates.yaml
@@ -756,11 +756,7 @@ spec:
                                             description: protocol defines the traffic
                                               protocol used for the Security Group
                                               Rule.
-                                            enum:
-                                            - icmp_tcp_udp
-                                            - icmp
-                                            - tcp
-                                            - udp
+                                            pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                             type: string
                                           remotes:
                                             description: |-
@@ -845,6 +841,9 @@ spec:
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for protocol
+                                          rule: '(self.protocol != ''tcp'' && self.protocol
+                                            != ''udp'') ? !has(self.portRange) : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                             protocol
                                           rule: 'self.protocol == ''icmp_tcp_udp''
@@ -906,11 +905,7 @@ spec:
                                             description: protocol defines the traffic
                                               protocol used for the Security Group
                                               Rule.
-                                            enum:
-                                            - icmp_tcp_udp
-                                            - icmp
-                                            - tcp
-                                            - udp
+                                            pattern: ^(any|icmp_tcp_udp|icmp|tcp|udp|ah|esp|gre|ip_in_ip|l2tp|rsvp|sctp|vrrp|number_(?:0|2|3|5|[7-9]|1[0-6]|1[8-9]|[2-3][0-9]|4[0-5]|4[89]|5[2-9]|[6-9][0-9]|10[0-9]|11[0-1]|11[3-4]|11[6-9]|12[0-9]|13[0-1]|13[3-9]|1[4-9][0-9]|2[0-4][0-9]|25[0-5]))$
                                             type: string
                                           remotes:
                                             description: |-
@@ -995,6 +990,9 @@ spec:
                                             protocol
                                           rule: 'self.protocol == ''icmp'' ? !has(self.portRange)
                                             : true'
+                                        - message: portRange is not valid for protocol
+                                          rule: '(self.protocol != ''tcp'' && self.protocol
+                                            != ''udp'') ? !has(self.portRange) : true'
                                         - message: portRange is not valid for VPCSecurityGroupRuleProtocolIcmpTCPUDP
                                             protocol
                                           rule: 'self.protocol == ''icmp_tcp_udp''

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.14.1
 	github.com/IBM/networking-go-sdk v0.53.5
 	github.com/IBM/platform-services-go-sdk v0.101.0
-	github.com/IBM/vpc-go-sdk v0.76.2
+	github.com/IBM/vpc-go-sdk v0.78.1
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/ignition/v2 v2.26.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/IBM/networking-go-sdk v0.53.5 h1:zsIngzvWxE5HFhoDJ2Ngb2VOjrT4dW7liXh7
 github.com/IBM/networking-go-sdk v0.53.5/go.mod h1:pscn6ZDzj+jgXzYfyoR8ze471J3G8JydRQfvp13HNsk=
 github.com/IBM/platform-services-go-sdk v0.101.0 h1:g5tRKp2GQCpEeX48obOC/hrMBiCqxw2Y414DylDC5JY=
 github.com/IBM/platform-services-go-sdk v0.101.0/go.mod h1:9FeNezkqhc5RvcvDlvAYaeUjUDz9kZM2EiwZIVLnSjI=
-github.com/IBM/vpc-go-sdk v0.76.2 h1:bZ6aHA1X69Ekn9rxd5XyjxuV9dwEneamEPYojDPHZdA=
-github.com/IBM/vpc-go-sdk v0.76.2/go.mod h1:hhgE1EQZRq1Cngdh4A6+LLUaA0kKWW/rgfHpISM+AKg=
+github.com/IBM/vpc-go-sdk v0.78.1 h1:vzc1GIoTYZsQCoDWpvS5Ah13qfBfN7wWgTGnHhpBg0M=
+github.com/IBM/vpc-go-sdk v0.78.1/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxReDDI5ZdY=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/templates/cluster-template-vpc-with-network-spec.yaml
+++ b/templates/cluster-template-vpc-with-network-spec.yaml
@@ -1,0 +1,550 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    ccm: external
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - ${POD_CIDR:="192.168.0.0/16"}
+    serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
+    services:
+      cidrBlocks:
+      - ${SERVICE_CIDR:="10.128.0.0/12"}
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: IBMVPCCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: IBMVPCCluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}
+spec:
+  region: ${IBMVPC_REGION}
+  resourceGroup: ${IBMVPC_RESOURCEGROUP} # needs to be the resource group name https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2445
+  controlPlaneLoadBalancer:
+    name: ${CLUSTER_NAME}-load-balancer
+  network:
+    vpc:
+      name: ${IBMVPC_NAME}
+    controlPlaneSubnets:
+    - name: ${CLUSTER_NAME}-controlplane-subnet
+      cidr: ${IBMVPC_CONTROLPLANE_SUBNET_CIDR:="10.240.0.0/24"}
+      zone: ${IBMVPC_ZONE}
+    workerSubnets:
+    - name: ${CLUSTER_NAME}-worker-subnet
+      cidr: ${IBMVPC_WORKER_SUBNET_CIDR:="10.240.1.0/24"}
+      zone: ${IBMVPC_ZONE}
+    securityGroups:
+    - name: ${CLUSTER_NAME}-lb-sg
+      rules:
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 6443
+            maximumPort: 6443
+          remotes:
+          - remoteType: any
+      - action: allow
+        direction: outbound
+        destination:
+          protocol: tcp
+          portRange:
+            minimumPort: 6443
+            maximumPort: 6443
+          remotes:
+          - remoteType: sg
+            securityGroupName: ${CLUSTER_NAME}-controlplane-sg
+    - name: ${CLUSTER_NAME}-controlplane-sg
+      rules:
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 6443
+            maximumPort: 6443
+          remotes:
+          - remoteType: sg
+            securityGroupName: ${CLUSTER_NAME}-lb-sg
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 2379
+            maximumPort: 2380
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-controlplane-subnet
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 10250
+            maximumPort: 10252
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-controlplane-subnet
+      # Convenience rule: allow ALL traffic between cluster nodes so any CNI works out of the box.
+      # For a production cluster, drop this rule and add only your CNI's required ports instead
+      # (e.g. Calico VXLAN udp/4789 + Typha tcp/5473). The rules above are the Kubernetes baseline;
+      # this broad rule trades tight security for easy try-outs.
+      - action: allow
+        direction: inbound
+        source:
+          protocol: any
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-controlplane-subnet
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-worker-subnet
+      - action: allow
+        direction: outbound
+        destination:
+          protocol: any
+          remotes:
+          - remoteType: any
+    - name: ${CLUSTER_NAME}-worker-sg
+      rules:
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 10250
+            maximumPort: 10250
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-controlplane-subnet
+      - action: allow
+        direction: inbound
+        source:
+          protocol: tcp
+          portRange:
+            minimumPort: 30000
+            maximumPort: 32767
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-worker-subnet
+      # Convenience rule: allow ALL traffic between cluster nodes (see the note on the control-plane SG).
+      # For a production cluster, drop this rule and use your CNI's specific ports instead.
+      - action: allow
+        direction: inbound
+        source:
+          protocol: any
+          remotes:
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-controlplane-subnet
+          - remoteType: cidr
+            cidrSubnetName: ${CLUSTER_NAME}-worker-subnet
+      - action: allow
+        direction: outbound
+        destination:
+          protocol: any
+          remotes:
+          - remoteType: any
+    loadBalancers:
+    - name: ${CLUSTER_NAME}-load-balancer
+      public: true
+      subnets:
+      - name: ${CLUSTER_NAME}-controlplane-subnet
+      securityGroups:
+      - name: ${CLUSTER_NAME}-lb-sg
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+      controllerManager:
+        extraArgs:
+        - name: cloud-provider
+          value: external
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+        - name: cloud-provider
+          value: external
+        - name: eviction-hard
+          value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+        - name: cloud-provider
+          value: external
+        - name: eviction-hard
+          value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: IBMVPCMachineTemplate
+        name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: IBMVPCMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      bootVolume:
+        sizeGiB: ${IBMVPC_CONTROLPLANE_BOOT_VOLUME_SIZEGIB:=20}
+        profile: ${IBMVPC_CONTROLPLANE_BOOT_VOLUME_PROFILE:="general-purpose"}
+      image:
+        name: ${IBMVPC_IMAGE_NAME}
+      profile: ${IBMVPC_PROFILE}
+      primaryNetworkInterface:
+        subnet: ${CLUSTER_NAME}-controlplane-subnet
+        securityGroups:
+        - name: ${CLUSTER_NAME}-controlplane-sg
+      sshKeys:
+      - name: ${IBMVPC_SSHKEY_NAME}
+      zone: ${IBMVPC_ZONE}
+      loadBalancerPoolMembers:
+      - loadBalancer:
+          name: ${CLUSTER_NAME}-load-balancer
+        pool:
+          name: ${CLUSTER_NAME}-lbpool
+        port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: IBMVPCMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: IBMVPCMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      bootVolume:
+        sizeGiB: ${IBMVPC_WORKER_BOOT_VOLUME_SIZEGIB:=20}
+        profile: ${IBMVPC_WORKER_BOOT_VOLUME_PROFILE:="general-purpose"}
+      image:
+        name: ${IBMVPC_IMAGE_NAME}
+      profile: ${IBMVPC_PROFILE}
+      primaryNetworkInterface:
+        subnet: ${CLUSTER_NAME}-worker-subnet
+        securityGroups:
+        - name: ${CLUSTER_NAME}-worker-sg
+      sshKeys:
+      - name: ${IBMVPC_SSHKEY_NAME}
+      zone: ${IBMVPC_ZONE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+          - name: cloud-provider
+            value: external
+          - name: eviction-hard
+            value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: crs-cloud-conf
+spec:
+  clusterSelector:
+    matchLabels:
+      ccm: external
+  resources:
+  - kind: Secret
+    name: ibm-credential
+  - kind: ConfigMap
+    name: ibm-cfg
+  - kind: ConfigMap
+    name: cloud-controller-manager-addon
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  ibm-cloud-conf.yaml: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ibm-cloud-config
+      namespace: kube-system
+    data:
+      ibm.conf: |
+        [global]
+        version = 1.1.0
+        [kubernetes]
+        config-file = ""
+        [provider]
+        cluster-default-provider = g2
+        accountID = ${IBMACCOUNT_ID}
+        clusterID = ${CLUSTER_NAME}
+        g2workerServiceAccountID = ${IBMACCOUNT_ID}
+        g2Credentials = /etc/ibm-secret/ibmcloud_api_key
+        g2ResourceGroupName = ${IBMVPC_RESOURCEGROUP_NAME:=""}
+        g2VpcSubnetNames = "${CLUSTER_NAME}-controlplane-subnet,${CLUSTER_NAME}-worker-subnet"
+        g2VpcName = ${IBMVPC_NAME:=""}
+        region =  ${IBMVPC_REGION:=""}
+kind: ConfigMap
+metadata:
+  name: ibm-cfg
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ibm-credential
+stringData:
+  ibm-credential.yaml: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ibm-cloud-credential
+      namespace: kube-system
+    data:
+      ibmcloud_api_key: ${BASE64_API_KEY}
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  ibm-ccm-external.yaml: |-
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: cloud-controller-manager:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+      - apiGroup: ""
+        kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+      - kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - services/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - "coordination.k8s.io"
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resourceNames:
+          - node-controller
+          - service-controller
+        resources:
+          - serviceaccounts/token
+        verbs:
+          - create
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: ibm-cloud-controller-manager
+      namespace: kube-system
+      labels:
+        k8s-app: ibm-cloud-controller-manager
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: ibm-cloud-controller-manager
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            k8s-app: ibm-cloud-controller-manager
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+              operator: Exists
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
+              operator: Exists
+            - key: node.kubernetes.io/not-ready
+              effect: NoSchedule
+              operator: Exists
+          serviceAccountName: cloud-controller-manager
+          containers:
+            - name: ibm-cloud-controller-manager
+              image: registry.k8s.io/capi-ibmcloud/powervs-cloud-controller-manager:ef83f3f
+              args:
+                - --v=2
+                - --cloud-provider=ibm
+                - --cloud-config=/etc/cloud/ibm.conf
+                - --use-service-account-credentials=true
+              resources:
+                requests:
+                  cpu: 200m
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /etc/cloud
+                  name: ibm-config-volume
+                  readOnly: true
+                - mountPath: /etc/ibm-secret
+                  name: ibm-secret
+          hostNetwork: true
+          volumes:
+            - name: ibm-config-volume
+              configMap:
+                name: ibm-cloud-config
+            - name: ibm-secret
+              secret:
+                secretName: ibm-cloud-credential
+kind: ConfigMap
+metadata:
+  name: cloud-controller-manager-addon


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the vpc-go-sdk version

The latest release of vpc-go-sdk contains some breaking changes for SecurityGroupRuleProtocol, Its changed from all to icmp_tcp_udp and we are no more able to use 'all' protocol. Besides that it introduced two new protocol types Any and Individual. 

This PR changes the protocol usage from 'all' to 'icmp_tcp_udp' and add support for the new protocol types 'any' and 'individual'.

The release notes: https://cloud.ibm.com/docs/vpc?topic=vpc-api-change-log#9-december-2025

**Which issue(s) this PR fixes**:
Fixes #2579

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The VPC Security Group Rule protocol value 'all' has been replaced with 'icmp_tcp_udp', action required. Added support for the 'any' protocol and all individual protocols currently supported by IBM Cloud VPC Security Group Rules.
```
