### PR TITLE
:sparkles: Implement CRD migration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,28 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - ibmpowervsclusters.infrastructure.cluster.x-k8s.io
+  - ibmpowervsclustertemplates.infrastructure.cluster.x-k8s.io
+  - ibmpowervsimages.infrastructure.cluster.x-k8s.io
+  - ibmpowervsmachines.infrastructure.cluster.x-k8s.io
+  - ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -76,6 +98,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ibmpowervsclustertemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Recently we have added v1beta3 apiVersion for PowerVS resources and eventually we need to remove v1beta2 apiVersion as documented here https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2611.

There are few important things to consider while removing apiVersion for a CRD, On a high level
1. Ensure all custom resources can still be read from etcd after the apiVersion is removed ("Storage version migration")
2. Remove the old apiVersion from managedFields of all custom resources ("ManagedField cleanup")

More info about it can be found here
1. https://github.com/kubernetes-sigs/cluster-api/issues/11894

CAPI already has a controller to handle these scenarios, In this PR we are configuring that controller to use it for IBMPowerVS resources.

More info can be found here: https://github.com/kubernetes-sigs/cluster-api/pull/11889


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement CRD migration
```
