### PR TITLE
:sparkles: Enable KAL linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,45 @@
+version: "2"
+run:
+  go: "1.25"
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - kubeapilinter # linter for Kube API conventions
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+              - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+
+            # Linters below this line are disabled, pending conversation on how and when to enable them.
+            disable:
+            - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
+  exclusions:
+    generated: strict
+    paths:
+      - zz_generated.*\.go$
+      - ".*_test.go"  # Exclude test files.
+    rules:
+    ## KAL should only run on API folders.
+    - path-except: "^api//*"
+      linters:
+        - kubeapilinter
+
+    ## Excludes for old apiVersions that can be removed once the apiVersions are dropped (we don't want to make any changes to these APIs).
+    - path: "api/powervs/v1beta2"
+      linters:
+        - kubeapilinter
+
+    ## Excludes for VPC API's.
+    - path: "api/vpc"
+      linters:
+        - kubeapilinter
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,0 +1,6 @@
+version: v2.5.0
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  version: v0.0.0-20260206102632-39e3d06a2850 #To fetch the latest version: https://github.com/kubernetes-sigs/kube-api-linter?tab=readme-ov-file#golangci-lint-module


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR enables KAL linter for API's, More info about KAL can be found here: https://github.com/kubernetes-sigs/kube-api-linter

Eventually we want to enable most of the KAL linting rules like https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci-kal.yml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable Kube API Linter
```
