### PR TITLE
[WIP] Enable support for configuring Security Group for Loadbalancer

### DIFF
--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -2224,6 +2224,28 @@ func (s *ClusterScope) createLoadBalancer(ctx context.Context, lb infrav1.VPCLoa
 		}
 		options.Subnets = append(options.Subnets, subnet)
 	}
+
+	// Use security groups from spec if provided
+	if len(lb.SecurityGroups) > 0 {
+		for _, sg := range lb.SecurityGroups {
+			sgIdentity := &vpcv1.SecurityGroupIdentity{}
+			if sg.ID != nil {
+				sgIdentity.ID = sg.ID
+			} else if sg.Name != nil {
+				// If name is provided, look up the security group ID
+				sgDetails, err := s.IBMVPCClient.GetSecurityGroupByName(*sg.Name)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get security group by name %s: %w", *sg.Name, err)
+				}
+				if sgDetails == nil {
+					return nil, fmt.Errorf("security group with name %s not found", *sg.Name)
+				}
+				sgIdentity.ID = sgDetails.ID
+			}
+			options.SecurityGroups = append(options.SecurityGroups, sgIdentity)
+		}
+	}
+
 	options.SetPools([]vpcv1.LoadBalancerPoolPrototypeLoadBalancerContext{
 		{
 			Algorithm:     core.StringPtr("round_robin"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2537

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
