### PR TITLE
Move GetResourceID method to clusterScope struct

### DIFF
--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -122,6 +122,7 @@ type ClusterScope struct {
 	Cluster           *clusterv1.Cluster
 	IBMPowerVSCluster *infrav1.IBMPowerVSCluster
 	ServiceEndpoint   []endpoints.ServiceEndpoint
+	ResourceGroupID   string
 }
 
 func getTGPowerVSConnectionName(tgName string) string { return fmt.Sprintf("%s-pvs-con", tgName) }
@@ -156,6 +157,12 @@ func NewPowerVSClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		return nil, err
 	}
 
+	// fetch resource group id
+	rsID := GetResourceGroupIDV1(params.IBMPowerVSCluster)
+	if rsID == "" {
+		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", params.IBMPowerVSCluster.Spec.ResourceGroup)
+	}
+
 	// if powervs.cluster.x-k8s.io/create-infra=true annotation is not set, create only powerVSClient.
 	if !CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
 		return &ClusterScope{
@@ -164,6 +171,7 @@ func NewPowerVSClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 			Cluster:           params.Cluster,
 			IBMPowerVSCluster: params.IBMPowerVSCluster,
 			ServiceEndpoint:   params.ServiceEndpoint,
+			ResourceGroupID:   rsID,
 		}, nil
 	}
 
@@ -272,6 +280,7 @@ func NewPowerVSClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		TransitGatewayClient:  tgClient,
 		ResourceClient:        resourceClient,
 		ResourceManagerClient: rmClient,
+		ResourceGroupID:       rsID,
 	}
 	return clusterScope, nil
 }
@@ -686,6 +695,18 @@ func (s *ClusterScope) GetResourceGroupID() string {
 	return ""
 }
 
+// GetResourceGroupIDV1 returns the resource group id if it present under spec or status filed of IBMPowerVSCluster object
+// or returns empty string.
+func GetResourceGroupIDV1(s *infrav1.IBMPowerVSCluster) string {
+	if s.Spec.ResourceGroup != nil && s.Spec.ResourceGroup.ID != nil {
+		return *s.Spec.ResourceGroup.ID
+	}
+	if s.Status.ResourceGroup != nil && s.Status.ResourceGroup.ID != nil {
+		return *s.Status.ResourceGroup.ID
+	}
+	return ""
+}
+
 // IsPowerVSZoneSupportsPER checks whether PowerVS zone supports PER capabilities.
 func (s *ClusterScope) IsPowerVSZoneSupportsPER() error {
 	zone := s.Zone()
@@ -856,11 +877,6 @@ func (s *ClusterScope) getServiceInstance() (*resourcecontrollerv2.ResourceInsta
 // createServiceInstance creates the service instance.
 func (s *ClusterScope) createServiceInstance(ctx context.Context) (*resourcecontrollerv2.ResourceInstance, error) {
 	log := ctrl.LoggerFrom(ctx)
-	// fetch resource group id.
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
 
 	// create service instance.
 	log.V(3).Info("Creating new PowerVS service instance", "serviceInstanceName", s.GetServiceName(infrav1.ResourceTypeServiceInstance))
@@ -871,7 +887,7 @@ func (s *ClusterScope) createServiceInstance(ctx context.Context) (*resourcecont
 	serviceInstance, _, err := s.ResourceClient.CreateResourceInstance(&resourcecontrollerv2.CreateResourceInstanceOptions{
 		Name:           s.GetServiceName(infrav1.ResourceTypeServiceInstance),
 		Target:         zone,
-		ResourceGroup:  &resourceGroupID,
+		ResourceGroup:  &s.ResourceGroupID,
 		ResourcePlanID: ptr.To(resourcecontroller.PowerVSResourcePlanID),
 	})
 	if err != nil {
@@ -1174,13 +1190,9 @@ func (s *ClusterScope) getVPCByName() (*vpcv1.VPC, error) {
 
 // createVPC creates VPC.
 func (s *ClusterScope) createVPC() (*string, error) {
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
 	addressPrefixManagement := "auto"
 	vpcOption := &vpcv1.CreateVPCOptions{
-		ResourceGroup:           &vpcv1.ResourceGroupIdentity{ID: &resourceGroupID},
+		ResourceGroup:           &vpcv1.ResourceGroupIdentity{ID: &s.ResourceGroupID},
 		Name:                    s.GetServiceName(infrav1.ResourceTypeVPC),
 		AddressPrefixManagement: &addressPrefixManagement,
 	}
@@ -1305,13 +1317,6 @@ func (s *ClusterScope) checkVPCSubnet(ctx context.Context, subnetName string) (s
 
 // createVPCSubnet creates a VPC subnet.
 func (s *ClusterScope) createVPCSubnet(subnet infrav1.Subnet) (*string, error) {
-	// TODO(karthik-k-n): consider moving to clusterscope
-	// fetch resource group id
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
-
 	// create subnet
 	vpcID := s.GetVPCID()
 	if vpcID == nil {
@@ -1332,7 +1337,7 @@ func (s *ClusterScope) createVPCSubnet(subnet infrav1.Subnet) (*string, error) {
 			Name: subnet.Zone,
 		},
 		ResourceGroup: &vpcv1.ResourceGroupIdentity{
-			ID: &resourceGroupID,
+			ID: &s.ResourceGroupID,
 		},
 	})
 
@@ -1557,7 +1562,7 @@ func (s *ClusterScope) createVPCSecurityGroup(ctx context.Context, spec infrav1.
 		},
 		Name: spec.Name,
 		ResourceGroup: &vpcv1.ResourceGroupIdentity{
-			ID: ptr.To(s.GetResourceGroupID()),
+			ID: ptr.To(s.ResourceGroupID),
 		},
 	}
 
@@ -1992,12 +1997,6 @@ func (s *ClusterScope) createTransitGatewayConnections(ctx context.Context, tg *
 
 // createTransitGateway creates transit gateway and sets the transit gateway status.
 func (s *ClusterScope) createTransitGateway(ctx context.Context) error {
-	// fetch resource group id
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
-
 	if s.IBMPowerVSCluster.Status.ServiceInstance == nil || s.IBMPowerVSCluster.Status.VPC == nil {
 		return fmt.Errorf("failed to proeceed with transit gateway creation as either one of VPC or PowerVS service instance reconciliation is not successful")
 	}
@@ -2022,7 +2021,7 @@ func (s *ClusterScope) createTransitGateway(ctx context.Context) error {
 		Location:      location,
 		Name:          tgName,
 		Global:        globalRouting,
-		ResourceGroup: &tgapiv1.ResourceGroupIdentity{ID: ptr.To(resourceGroupID)},
+		ResourceGroup: &tgapiv1.ResourceGroupIdentity{ID: ptr.To(s.ResourceGroupID)},
 	})
 	if err != nil {
 		return err
@@ -2176,12 +2175,6 @@ func (s *ClusterScope) checkLoadBalancer(ctx context.Context, lb infrav1.VPCLoad
 func (s *ClusterScope) createLoadBalancer(ctx context.Context, lb infrav1.VPCLoadBalancerSpec) (*infrav1.VPCLoadBalancerStatus, error) {
 	log := ctrl.LoggerFrom(ctx)
 	options := &vpcv1.CreateLoadBalancerOptions{}
-	// TODO(karthik-k-n): consider moving resource group id to clusterscope
-	// fetch resource group id
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
 
 	var isPublic bool
 	if lb.Public != nil && *lb.Public {
@@ -2190,7 +2183,7 @@ func (s *ClusterScope) createLoadBalancer(ctx context.Context, lb infrav1.VPCLoa
 	options.SetIsPublic(isPublic)
 	options.SetName(lb.Name)
 	options.SetResourceGroup(&vpcv1.ResourceGroupIdentity{
-		ID: &resourceGroupID,
+		ID: &s.ResourceGroupID,
 	})
 
 	subnetIDs := s.GetVPCSubnetIDs()
@@ -2404,18 +2397,12 @@ func (s *ClusterScope) checkCOSServiceInstance(ctx context.Context) (*resourceco
 }
 
 func (s *ClusterScope) createCOSServiceInstance() (*resourcecontrollerv2.ResourceInstance, error) {
-	// fetch resource group id.
-	resourceGroupID := s.GetResourceGroupID()
-	if resourceGroupID == "" {
-		return nil, fmt.Errorf("failed to fetch resource group ID for resource group %v, ID is empty", s.ResourceGroup())
-	}
-
 	target := "Global"
 	// create service instance
 	serviceInstance, _, err := s.ResourceClient.CreateResourceInstance(&resourcecontrollerv2.CreateResourceInstanceOptions{
 		Name:           s.GetServiceName(infrav1.ResourceTypeCOSInstance),
 		Target:         &target,
-		ResourceGroup:  &resourceGroupID,
+		ResourceGroup:  &s.ResourceGroupID,
 		ResourcePlanID: ptr.To(resourcecontroller.CosResourcePlanID),
 	})
 	if err != nil {

--- a/cloud/scope/powervs/powervs_cluster_test.go
+++ b/cloud/scope/powervs/powervs_cluster_test.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/ibm-cos-sdk-go/aws/awserr"
@@ -32,6 +30,7 @@ import (
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	regionUtil "github.com/ppc64le-cloud/powervs-utils"
+	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -86,7 +85,7 @@ func TestNewPowerVSClusterScope(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Successfully create cluster scope when create infra annotation is not set",
+			name: "Error when ResourceGroup ID is not set",
 			params: ClusterScopeParams{
 				Client:  testEnv.Client,
 				Cluster: newCluster(clusterName),
@@ -101,6 +100,31 @@ func TestNewPowerVSClusterScope(t *testing.T) {
 								UID:        "1",
 							}}},
 					Spec: infrav1.IBMPowerVSClusterSpec{Zone: ptr.To("zone")},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Successfully create cluster scope when create infra annotation is not set",
+			params: ClusterScopeParams{
+				Client:  testEnv.Client,
+				Cluster: newCluster(clusterName),
+				IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "powervs-test-",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: clusterv1.GroupVersion.String(),
+								Kind:       "Cluster",
+								Name:       "capi-test",
+								UID:        "1",
+							}}},
+					Spec: infrav1.IBMPowerVSClusterSpec{
+						Zone: ptr.To("zone"),
+						ResourceGroup: &infrav1.IBMPowerVSResourceReference{
+							ID: ptr.To("resource-group-id"),
+						},
+					},
 				},
 				ClientFactory: ClientFactory{
 					AuthenticatorFactory: func() (core.Authenticator, error) {
@@ -132,6 +156,9 @@ func TestNewPowerVSClusterScope(t *testing.T) {
 					Spec: infrav1.IBMPowerVSClusterSpec{
 						Zone: ptr.To("zone"),
 						VPC:  &infrav1.VPCResourceReference{Region: ptr.To("eu-gb")},
+						ResourceGroup: &infrav1.IBMPowerVSResourceReference{
+							ID: ptr.To("resource-group-id"),
+						},
 					},
 				},
 				ClientFactory: ClientFactory{
@@ -2693,15 +2720,23 @@ func TestPowerVSScopeCreateVPC(t *testing.T) {
 	teardown := func() {
 		mockCtrl.Finish()
 	}
-	t.Run("When resourceGroupID is not set", func(t *testing.T) {
+	t.Run("When CreateVPC returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 
 		clusterScope := ClusterScope{
-			IBMVPCClient:      mockVPC,
+			IBMVPCClient: mockVPC,
+			Cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					ClusterNetwork: clusterv1.ClusterNetwork{},
+				},
+			},
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
+			ResourceGroupID:   "resourceGroupID",
 		}
+
+		mockVPC.EXPECT().CreateVPC(gomock.Any()).Return(nil, nil, fmt.Errorf("failed to create VPC"))
 
 		vpcID, err := clusterScope.createVPC()
 		g.Expect(err).ToNot(BeNil())
@@ -2714,9 +2749,14 @@ func TestPowerVSScopeCreateVPC(t *testing.T) {
 
 		clusterScope := ClusterScope{
 			IBMVPCClient: mockVPC,
-			Cluster:      &clusterv1.Cluster{},
+			Cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					ClusterNetwork: clusterv1.ClusterNetwork{},
+				},
+			},
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{Spec: infrav1.IBMPowerVSClusterSpec{
 				ResourceGroup: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")}}},
+			ResourceGroupID: "resourceGroupID",
 		}
 		vpcOutput := &vpcv1.VPC{Name: ptr.To("VPCName"), ID: ptr.To("vpcID"), DefaultSecurityGroup: &vpcv1.SecurityGroupReference{ID: ptr.To("DefaultSecurityGroupID")}}
 		mockVPC.EXPECT().CreateVPC(gomock.Any()).Return(vpcOutput, nil, nil)
@@ -2727,16 +2767,21 @@ func TestPowerVSScopeCreateVPC(t *testing.T) {
 		g.Expect(vpcID).To(Equal(vpcOutput.ID))
 	})
 
-	t.Run("When resourceGroupID is not nil and CreateSecurityGroupRule returns error", func(t *testing.T) {
+	t.Run("When CreateSecurityGroupRule returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 
 		clusterScope := ClusterScope{
 			IBMVPCClient: mockVPC,
-			Cluster:      &clusterv1.Cluster{},
+			Cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					ClusterNetwork: clusterv1.ClusterNetwork{},
+				},
+			},
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{Spec: infrav1.IBMPowerVSClusterSpec{
 				ResourceGroup: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")}}},
+			ResourceGroupID: "resourceGroupID",
 		}
 		vpcOutput := &vpcv1.VPC{Name: ptr.To("VPCName"), ID: ptr.To("vpcID"), DefaultSecurityGroup: &vpcv1.SecurityGroupReference{ID: ptr.To("DefaultSecurityGroupID")}}
 		mockVPC.EXPECT().CreateVPC(gomock.Any()).Return(vpcOutput, nil, nil)
@@ -3596,6 +3641,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 						{Name: ptr.To("subnet5Name")},
 					}},
 			},
+			ResourceGroupID: "resourceGroupID",
 		}
 
 		vpcZones, err := regionUtil.VPCZonesForVPCRegion(*clusterScope.IBMPowerVSCluster.Spec.VPC.Region)
@@ -3655,6 +3701,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 						{Name: ptr.To("subnet3Name"), Zone: ptr.To("eu-de-3")},
 					}},
 			},
+			ResourceGroupID: "resourceGroupID",
 		}
 
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(len(clusterScope.IBMPowerVSCluster.Spec.VPCSubnets))
@@ -3701,6 +3748,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 					ResourceGroup: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("resourceGroupID")},
 					VPC:           &infrav1.VPCResourceReference{Region: ptr.To("eu-de")}},
 			},
+			ResourceGroupID: "resourceGroupID",
 		}
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("ClusterName-vpcsubnet-eu-de-1")}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil).Times(3)
@@ -3730,6 +3778,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 					VPC:           &infrav1.VPCResourceReference{Region: ptr.To("eu-de")},
 					VPCSubnets:    []infrav1.Subnet{{Name: ptr.To("subnet1Name")}}},
 			},
+			ResourceGroupID: "resourceGroupID",
 		}
 		subnet1Details := &vpcv1.Subnet{ID: ptr.To("subnet1ID"), Name: ptr.To("subnet1Name")}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
@@ -3875,7 +3924,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 		g.Expect(err).ToNot(BeNil())
 	})
 
-	t.Run("When createVPCSubnet returns error as Resourcegroup is not set", func(t *testing.T) {
+	t.Run("When createVPCSubnet returns error as VPC ID is not set", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -3888,6 +3937,7 @@ func TestReconcileVPCSubnets(t *testing.T) {
 					VPC: &infrav1.VPCResourceReference{Region: ptr.To("eu-de")},
 				},
 			},
+			ResourceGroupID: "resourceGroupID",
 		}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
 		requeue, err := clusterScope.ReconcileVPCSubnets(ctx)
@@ -6443,34 +6493,14 @@ func TestCreateCOSServiceInstance(t *testing.T) {
 		mockCtrl.Finish()
 	}
 
-	t.Run("When creating COS resource instance fails due to missing resource group id", func(t *testing.T) {
-		g := NewWithT(t)
-		setup(t)
-		t.Cleanup(teardown)
-
-		clusterScope := ClusterScope{
-			ResourceClient: mockResourceController,
-			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
-				Status: infrav1.IBMPowerVSClusterStatus{
-					ServiceInstance: &infrav1.ResourceReference{
-						ID: ptr.To("test-serviceinstance-id"),
-					},
-				},
-			},
-		}
-
-		cosResourceInstance, err := clusterScope.createCOSServiceInstance()
-		g.Expect(cosResourceInstance).To(BeNil())
-		g.Expect(err).ToNot(BeNil())
-	})
-
 	t.Run("When creating COS resource instance fails", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 
 		clusterScope := ClusterScope{
-			ResourceClient: mockResourceController,
+			ResourceClient:  mockResourceController,
+			ResourceGroupID: "test-resourcegroup-id",
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
 					ResourceGroup: &infrav1.IBMPowerVSResourceReference{
@@ -6498,7 +6528,8 @@ func TestCreateCOSServiceInstance(t *testing.T) {
 		t.Cleanup(teardown)
 
 		clusterScope := ClusterScope{
-			ResourceClient: mockResourceController,
+			ResourceClient:  mockResourceController,
+			ResourceGroupID: "test-resourcegroup-id",
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
 					ResourceGroup: &infrav1.IBMPowerVSResourceReference{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: GetResourceID method is getting invoked as part of multiple methods in powervs_cluster file.  Refactored the code to move a commonly used GetResourceID method into a shared struct. Moving this common method to clusterscope shared struct improves reusability and reduces duplication.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
GetResourceID method into a shared struct
```
