### PR TITLE
Stop using v1beta2 conditions for PowerVS resources

### DIFF
--- a/internal/controllers/powervs/ibmpowervscluster_controller.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller.go
@@ -221,7 +221,7 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 	log.Info("Reconciling transit gateway")
 	if requeue, err := clusterScope.ReconcileTransitGateway(ctx); err != nil {
 		deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition, infrav1.TransitGatewayReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.TransitGatewayReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.TransitGatewayNotReadyReason,
@@ -233,7 +233,7 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 	deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition)
-	conditions.Set(powerVSCluster.cluster, metav1.Condition{
+	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.TransitGatewayReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.TransitGatewayReadyReason,
@@ -244,7 +244,7 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 		log.Info("Reconciling COS service instance")
 		if err := clusterScope.ReconcileCOSInstance(ctx); err != nil {
 			deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition, infrav1.COSInstanceReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
-			conditions.Set(powerVSCluster.cluster, metav1.Condition{
+			powerVSCluster.updateCondition(metav1.Condition{
 				Type:    infrav1.COSInstanceReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  infrav1.COSInstanceNotReadyReason,
@@ -253,7 +253,7 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 			return reconcile.Result{}, fmt.Errorf("failed to reconcile COS instance: %w", err)
 		}
 		deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition)
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:   infrav1.COSInstanceReadyCondition,
 			Status: metav1.ConditionTrue,
 			Reason: infrav1.COSInstanceReadyReason,
@@ -304,15 +304,14 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 	// reconcile PowerVS service instance
 	log.Info("Reconciling PowerVS service instance")
 	if requeue, err := clusterScope.ReconcilePowerVSServiceInstance(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.ServiceInstanceReadyV1Beta2Condition,
 			Reason:   infrav1.ServiceInstanceReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		//TODO: When we completely transition into v1beta2 api's update the conditions with lock
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.WorkspaceReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.WorkspaceNotReadyReason,
@@ -325,11 +324,11 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(clusterv1.Condition{
+	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.ServiceInstanceReadyV1Beta2Condition,
 	})
-	conditions.Set(powerVSCluster.cluster, metav1.Condition{
+	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.WorkspaceReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.WorkspaceReadyReason,
@@ -340,14 +339,14 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 	// reconcile network
 	log.Info("Reconciling network")
 	if networkActive, err := clusterScope.ReconcileNetwork(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.NetworkReadyV1Beta2Condition,
 			Reason:   infrav1.NetworkReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.NetworkReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.NetworkNotReadyReason,
@@ -356,11 +355,11 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile network: %w", err)}
 		return
 	} else if networkActive {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status: corev1.ConditionTrue,
 			Type:   infrav1.NetworkReadyV1Beta2Condition,
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:   infrav1.NetworkReadyCondition,
 			Status: metav1.ConditionTrue,
 			Reason: infrav1.NetworkReadyReason,
@@ -381,14 +380,14 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	defer log.Info("Finished VPC reconciliation")
 
 	if requeue, err := clusterScope.ReconcileVPC(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCReadyV1Beta2Condition,
 			Reason:   infrav1.VPCReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.VPCReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.VPCNotReadyReason,
@@ -401,11 +400,11 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(clusterv1.Condition{
+	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCReadyV1Beta2Condition,
 	})
-	conditions.Set(powerVSCluster.cluster, metav1.Condition{
+	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.VPCReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.VPCReadyReason,
@@ -414,14 +413,14 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile VPC Subnet
 	log.Info("Reconciling VPC subnets")
 	if requeue, err := clusterScope.ReconcileVPCSubnets(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCSubnetReadyV1Beta2Condition,
 			Reason:   infrav1.VPCSubnetReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.VPCSubnetReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.VPCSubnetNotReadyReason,
@@ -434,11 +433,11 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	powerVSCluster.updateCondition(clusterv1.Condition{
+	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCSubnetReadyV1Beta2Condition,
 	})
-	conditions.Set(powerVSCluster.cluster, metav1.Condition{
+	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.VPCSubnetReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.VPCSubnetReadyReason,
@@ -447,14 +446,14 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile VPC security group
 	log.Info("Reconciling VPC security group")
 	if err := clusterScope.ReconcileVPCSecurityGroups(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCSecurityGroupReadyV1Beta2Condition,
 			Reason:   infrav1.VPCSecurityGroupReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.VPCSecurityGroupReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.VPCSecurityGroupReconciliationFailedReason,
@@ -463,11 +462,11 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC security groups: %w", err)}
 		return
 	}
-	powerVSCluster.updateCondition(clusterv1.Condition{
+	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCSecurityGroupReadyV1Beta2Condition,
 	})
-	conditions.Set(powerVSCluster.cluster, metav1.Condition{
+	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.VPCSecurityGroupReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.VPCSecurityGroupReadyCondition,
@@ -476,14 +475,14 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile LoadBalancer
 	log.Info("Reconciling VPC load balancers")
 	if loadBalancerReady, err := clusterScope.ReconcileLoadBalancers(ctx); err != nil {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.LoadBalancerReadyV1Beta2Condition,
 			Reason:   infrav1.LoadBalancerReconciliationFailedV1Beta2Reason,
 			Severity: clusterv1.ConditionSeverityError,
 			Message:  err.Error(),
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.VPCLoadBalancerReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav1.VPCLoadBalancerNotReadyReason,
@@ -492,11 +491,11 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC load balancers: %w", err)}
 		return
 	} else if loadBalancerReady {
-		powerVSCluster.updateCondition(clusterv1.Condition{
+		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
 			Status: corev1.ConditionTrue,
 			Type:   infrav1.LoadBalancerReadyV1Beta2Condition,
 		})
-		conditions.Set(powerVSCluster.cluster, metav1.Condition{
+		powerVSCluster.updateCondition(metav1.Condition{
 			Type:   infrav1.VPCLoadBalancerReadyCondition,
 			Status: metav1.ConditionTrue,
 			Reason: infrav1.VPCLoadBalancerReadyReason,
@@ -635,10 +634,10 @@ func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clust
 	return ctrl.Result{}, nil
 }
 
-func (update *powerVSCluster) updateCondition(condition clusterv1.Condition) {
+func (update *powerVSCluster) updateCondition(condition metav1.Condition) {
 	update.mu.Lock()
 	defer update.mu.Unlock()
-	deprecatedv1beta1conditions.Set(update.cluster, &condition)
+	conditions.Set(update.cluster, condition)
 }
 
 func (r *IBMPowerVSClusterReconciler) deleteIBMPowerVSImage(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This ensures that we set and work with metav1.Conditions for PowerVS resources adhering to the CAPI v1beta2 contract

Also ensured that v1beta2 API package only imports core v1beta1 packages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2650

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop using v1beta2 status for PowerVS resources
```
