### PR TITLE
Fix e2e test scaling worker nodes

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -111,25 +111,13 @@ var _ = Describe("Workload cluster creation", func() {
 			}, result)
 
 			By("Scaling worker node to 3")
-			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-				ClusterProxy: bootstrapClusterProxy,
-				ConfigCluster: clusterctl.ConfigClusterInput{
-					LogFolder:                clusterctlLogFolder,
-					ClusterctlConfigPath:     clusterctlConfigPath,
-					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
-					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-					Flavor:                   flavor,
-					Namespace:                namespace.Name,
-					ClusterName:              clusterName,
-					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
-					ControlPlaneMachineCount: ptr.To(int64(1)),
-					WorkerMachineCount:       ptr.To(int64(3)),
-				},
-				CNIManifestPath:              cniPath,
-				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
-				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
-				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
-			}, result)
+			framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+				ClusterProxy:              bootstrapClusterProxy,
+				Cluster:                   result.Cluster,
+				Replicas:                  3,
+				MachineDeployment:         result.MachineDeployments[0],
+				WaitForMachineDeployments: e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			})
 		})
 	})
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
```
capibm-e2e: [It] Workload cluster creation Creating a single control-plane cluster Should create a cluster with 1 worker node and can be scaled expand_less16m4s{Failed to apply the cluster template Expected success, but got an error:     <errors.aggregate \| len:11, cap:16>:      [create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps "cloud-controller-manager-addon" already exists, create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps "ibmpowervs-cfg" already exists, create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets "ibmpowervs-credential" already exists, create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io "crs-cloud-conf" already exists, create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists]     [         <*errors.errorString \| 0xc0002aab50>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps \"cloud-controller-manager-addon\" already exists",         },         <*errors.errorString \| 0xc000fb1970>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps \"ibmpowervs-cfg\" already exists",         },         <*errors.errorString \| 0xc0027a61e0>{             s: "create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets \"ibmpowervs-credential\" already exists",         },         <*errors.errorString \| 0xc001664960>{             s: "create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io \"crs-cloud-conf\" already exists",         },         <*errors.errorString \| 0xc00132aab0>{             s: "create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc001964fe0>{             s: "create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc001a58d00>{             s: "create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc000820a20>{             s: "create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc000fe61b0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc0024e62a0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc00158d3f0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists", | capibm-e2e: [It] Workload cluster creation Creating a single control-plane cluster Should create a cluster with 1 worker node and can be scaled expand_less | 16m4s | {Failed to apply the cluster template Expected success, but got an error:     <errors.aggregate \| len:11, cap:16>:      [create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps "cloud-controller-manager-addon" already exists, create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps "ibmpowervs-cfg" already exists, create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets "ibmpowervs-credential" already exists, create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io "crs-cloud-conf" already exists, create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists]     [         <*errors.errorString \| 0xc0002aab50>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps \"cloud-controller-manager-addon\" already exists",         },         <*errors.errorString \| 0xc000fb1970>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps \"ibmpowervs-cfg\" already exists",         },         <*errors.errorString \| 0xc0027a61e0>{             s: "create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets \"ibmpowervs-credential\" already exists",         },         <*errors.errorString \| 0xc001664960>{             s: "create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io \"crs-cloud-conf\" already exists",         },         <*errors.errorString \| 0xc00132aab0>{             s: "create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc001964fe0>{             s: "create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc001a58d00>{             s: "create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc000820a20>{             s: "create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc000fe61b0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc0024e62a0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc00158d3f0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",
capibm-e2e: [It] Workload cluster creation Creating a single control-plane cluster Should create a cluster with 1 worker node and can be scaled expand_less | 16m4s
{Failed to apply the cluster template Expected success, but got an error:     <errors.aggregate \| len:11, cap:16>:      [create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps "cloud-controller-manager-addon" already exists, create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps "ibmpowervs-cfg" already exists, create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets "ibmpowervs-credential" already exists, create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io "crs-cloud-conf" already exists, create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists, create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-control-plane" already exists, create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io "capibm-e2e-odj93c-md-0" already exists]     [         <*errors.errorString \| 0xc0002aab50>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/cloud-controller-manager-addon: configmaps \"cloud-controller-manager-addon\" already exists",         },         <*errors.errorString \| 0xc000fb1970>{             s: "create v1 ConfigMap create-workload-cluster-9wm46p/ibmpowervs-cfg: configmaps \"ibmpowervs-cfg\" already exists",         },         <*errors.errorString \| 0xc0027a61e0>{             s: "create v1 Secret create-workload-cluster-9wm46p/ibmpowervs-credential: secrets \"ibmpowervs-credential\" already exists",         },         <*errors.errorString \| 0xc001664960>{             s: "create addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet create-workload-cluster-9wm46p/crs-cloud-conf: clusterresourcesets.addons.cluster.x-k8s.io \"crs-cloud-conf\" already exists",         },         <*errors.errorString \| 0xc00132aab0>{             s: "create bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc001964fe0>{             s: "create cluster.x-k8s.io/v1beta2 Cluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: clusters.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc001a58d00>{             s: "create cluster.x-k8s.io/v1beta2 MachineDeployment create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: machinedeployments.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",         },         <*errors.errorString \| 0xc000820a20>{             s: "create controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlane create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc000fe61b0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSCluster create-workload-cluster-9wm46p/capibm-e2e-odj93c: ibmpowervsclusters.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c\" already exists",         },         <*errors.errorString \| 0xc0024e62a0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-control-plane: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-control-plane\" already exists",         },         <*errors.errorString \| 0xc00158d3f0>{             s: "create infrastructure.cluster.x-k8s.io/v1beta3 IBMPowerVSMachineTemplate create-workload-cluster-9wm46p/capibm-e2e-odj93c-md-0: ibmpowervsmachinetemplates.infrastructure.cluster.x-k8s.io \"capibm-e2e-odj93c-md-0\" already exists",
```
Test failure is caused by breaking change in Cluster API v1.12.4 where ApplyClusterTemplateAndWait changed from CreateOrUpdate to Create.

Use ScaleAndWaitMachineDeployment to properly scale MachineDeployment instead of re-applying the entire cluster template.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix e2e test scaling worker nodes

```
