### PR TITLE
🐛VPC: fix break logic in findOrCreateSecurityGroupRule

### DIFF
--- a/cloud/scope/vpc/cluster_v2.go
+++ b/cloud/scope/vpc/cluster_v2.go
@@ -1452,6 +1452,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 	// Each defined SecurityGroupRule can have multiple Remotes specified, each signifying a separate Security Group Rule (with the same Action, Direction, etc.)
 	for _, remote := range securityGroupRulePrototype.Remotes {
 		remoteMatch := false
+	loop:
 		for _, existingRuleIntf := range existingSecurityGroupRules.Rules {
 			// Perform analysis of the existingRuleIntf, based on its Protocol type, further analysis is performed based on remaining attributes to find if the specific Rule and Remote match
 			switch reflect.TypeOf(existingRuleIntf).String() {
@@ -1472,7 +1473,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
 					log.V(3).Info("security group rule all protocol match found")
 					remoteMatch = true
-					break
+					break loop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 				// If our Remote doesn't define ICMP Protocol, we don't need further checks, move on to next Rule
@@ -1490,7 +1491,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule icmp match found")
 					remoteMatch = true
-					break
+					break loop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 				// If our Remote doesn't define TCP/UDP Protocol, we don't need further checks, move on to next Rule
@@ -1508,7 +1509,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule tcp/udp match found")
 					remoteMatch = true
-					break
+					break loop
 				}
 			default:
 				// This is an unexpected IBM Cloud Security Group Rule Prototype, log it and move on

--- a/pkg/cloud/scope/vpc/cluster_v2.go
+++ b/pkg/cloud/scope/vpc/cluster_v2.go
@@ -1473,6 +1473,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 	// Each defined SecurityGroupRule can have multiple Remotes specified, each signifying a separate Security Group Rule (with the same Action, Direction, etc.)
 	for _, remote := range securityGroupRulePrototype.Remotes {
 		remoteMatch := false
+	existingRuleLoop:
 		for _, existingRuleIntf := range existingSecurityGroupRules.Rules {
 			// Perform analysis of the existingRuleIntf, based on its Protocol type, further analysis is performed based on remaining attributes to find if the specific Rule and Remote match
 			switch reflect.TypeOf(existingRuleIntf).String() {
@@ -1493,7 +1494,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// The expectation is that only one IBM Cloud Security Group Rule will match, but if at least one matches the defined SecurityGroupRule, that is sufficient.
 					log.V(3).Info("security group rule any protocol match found")
 					remoteMatch = true
-					break
+					break existingRuleLoop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolIcmptcpudpType:
 				// If our Remote doesn't define icmp_tcp_udp Protocols, we don't need further checks, move on to next Rule
@@ -1511,7 +1512,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule icmp_tcp_udp protocol match found")
 					remoteMatch = true
-					break
+					break existingRuleLoop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolIcmpType:
 				// If our Remote doesn't define ICMP Protocol, we don't need further checks, move on to next Rule
@@ -1529,7 +1530,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule icmp match found")
 					remoteMatch = true
-					break
+					break existingRuleLoop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolTcpudpType:
 				// If our Remote doesn't define TCP/UDP Protocol, we don't need further checks, move on to next Rule
@@ -1547,7 +1548,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule tcp/udp match found")
 					remoteMatch = true
-					break
+					break existingRuleLoop
 				}
 			case infrav1.VPCSecurityGroupRuleProtocolIndividualType:
 				matched := individualSgrRegexp.MatchString(string(securityGroupRulePrototype.Protocol))
@@ -1567,7 +1568,7 @@ func (s *ClusterScopeV2) findOrCreateSecurityGroupRule(ctx context.Context, secu
 					// If we found the matching IBM Cloud Security Group Rule for the defined SecurityGroupRule and Remote, we can stop checking IBM Cloud Security Group Rules for this remote and move onto the next remote.
 					log.V(3).Info("security group rule individual protocol match found", "protocol", string(securityGroupRulePrototype.Protocol))
 					remoteMatch = true
-					break
+					break existingRuleLoop
 				}
 			default:
 				// This is an unexpected IBM Cloud Security Group Rule Prototype, log it and move on


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The break statements inside the switch cases of the findOrCreateSecurityGroupRule method were intended to exit the inner loop. However, they only exited the switch block, causing the loop to continue unexpectedly.

A loop label has been introduced so the break statements correctly exit the intended loop.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix break logic in findOrCreateSecurityGroupRule
```
