### PR TITLE
:warning: Remove deprecated ServiceInstanceID from PowerVSCluster, PowerVSMachine and PowerVSImage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -202,18 +202,6 @@ linters:
         text: 'deferInLoop: Possible resource leak, ''defer'' is called in the ''for'' loop'
       - linters:
           - staticcheck
-        text: 'SA1019: .*(i|s|m)\.IBMPowerVSCluster.Spec.ServiceInstanceID is deprecated: use ServiceInstance instead'
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*(i|s|m)\.IBMPowerVSImage.Spec.ServiceInstanceID is deprecated: use ServiceInstance instead'
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*(i|s|m|params)\.IBMPowerVSMachine.Spec.ServiceInstanceID is deprecated: use ServiceInstance instead'
-      - linters:
-          - staticcheck
-        text: 'SA1019: spec.ServiceInstanceID is deprecated: use ServiceInstance instead'
-      - linters:
-          - staticcheck
         text: 'SA1019: endpoints.(FetchRCEndpoint|FetchPVSEndpoint) is deprecated: Use FetchEndpoints instead.'
       # v1Beta2 deprecated fields
       - linters:

--- a/api/powervs/v1beta2/conversion.go
+++ b/api/powervs/v1beta2/conversion.go
@@ -382,6 +382,18 @@ func Convert_v1beta2_IBMPowerVSMachineSpec_To_v1beta3_IBMPowerVSMachineSpec(in *
 		}
 	}
 
+	// Manual conversion for ServiceInstanceID to ServiceInstance
+	// Only set ServiceInstance if ServiceInstanceID was explicitly set in v1beta2
+	if in.ServiceInstanceID != "" {
+		if out.ServiceInstance == nil {
+			out.ServiceInstance = &infrav1.IBMPowerVSResourceReference{}
+		}
+		out.ServiceInstance.ID = ptr.To(in.ServiceInstanceID)
+	} else if in.ServiceInstance == nil {
+		// If ServiceInstanceID is empty and ServiceInstance is nil in v1beta2, keep it nil in v1beta3
+		out.ServiceInstance = nil
+	}
+
 	return nil
 }
 
@@ -399,6 +411,81 @@ func Convert_v1beta3_IBMPowerVSMachineSpec_To_v1beta2_IBMPowerVSMachineSpec(in *
 		}
 	} else {
 		out.ImageRef = nil
+	}
+
+	// Manual conversion for ServiceInstance to ServiceInstanceID (deprecated field)
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil {
+		out.ServiceInstanceID = *in.ServiceInstance.ID
+	}
+
+	return nil
+}
+
+// Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec converts v1beta2 IBMPowerVSClusterSpec to v1beta3.
+func Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(in *IBMPowerVSClusterSpec, out *infrav1.IBMPowerVSClusterSpec, s apimachineryconversion.Scope) error {
+	if err := autoConvert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(in, out, s); err != nil {
+		return err
+	}
+
+	// Manual conversion for ServiceInstanceID to ServiceInstance
+	// Only set ServiceInstance if ServiceInstanceID was explicitly set in v1beta2
+	if in.ServiceInstanceID != "" {
+		if out.ServiceInstance == nil {
+			out.ServiceInstance = &infrav1.IBMPowerVSResourceReference{}
+		}
+		out.ServiceInstance.ID = ptr.To(in.ServiceInstanceID)
+	} else if in.ServiceInstance == nil {
+		// If ServiceInstanceID is empty and ServiceInstance is nil in v1beta2, keep it nil in v1beta3
+		out.ServiceInstance = nil
+	}
+
+	return nil
+}
+
+// Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec converts v1beta2 IBMPowerVSImageSpec to v1beta3.
+func Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in *IBMPowerVSImageSpec, out *infrav1.IBMPowerVSImageSpec, s apimachineryconversion.Scope) error {
+	if err := autoConvert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in, out, s); err != nil {
+		return err
+	}
+
+	// Manual conversion for ServiceInstanceID to ServiceInstance
+	// Only set ServiceInstance if ServiceInstanceID was explicitly set in v1beta2
+	if in.ServiceInstanceID != "" {
+		if out.ServiceInstance == nil {
+			out.ServiceInstance = &infrav1.IBMPowerVSResourceReference{}
+		}
+		out.ServiceInstance.ID = ptr.To(in.ServiceInstanceID)
+	} else if in.ServiceInstance == nil {
+		// If ServiceInstanceID is empty and ServiceInstance is nil in v1beta2, keep it nil in v1beta3
+		out.ServiceInstance = nil
+	}
+
+	return nil
+}
+
+// Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec converts v1beta3 IBMPowerVSClusterSpec to v1beta2.
+func Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(in *infrav1.IBMPowerVSClusterSpec, out *IBMPowerVSClusterSpec, s apimachineryconversion.Scope) error {
+	if err := autoConvert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(in, out, s); err != nil {
+		return err
+	}
+
+	// Manual conversion for ServiceInstance to ServiceInstanceID (deprecated field)
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil {
+		out.ServiceInstanceID = *in.ServiceInstance.ID
+	}
+
+	return nil
+}
+
+// Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec converts v1beta3 IBMPowerVSImageSpec to v1beta2.
+func Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in *infrav1.IBMPowerVSImageSpec, out *IBMPowerVSImageSpec, s apimachineryconversion.Scope) error {
+	if err := autoConvert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in, out, s); err != nil {
+		return err
+	}
+
+	// Manual conversion for ServiceInstance to ServiceInstanceID (deprecated field)
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil {
+		out.ServiceInstanceID = *in.ServiceInstance.ID
 	}
 
 	return nil

--- a/api/powervs/v1beta2/conversion_test.go
+++ b/api/powervs/v1beta2/conversion_test.go
@@ -49,7 +49,7 @@ func TestFuzzyConversion(t *testing.T) {
 		Scheme:      scheme,
 		Hub:         &infrav1.IBMPowerVSClusterTemplate{},
 		Spoke:       &IBMPowerVSClusterTemplate{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{IBMPowerVSClusterTemplateFuzzFuncs},
 	}))
 	t.Run("for IBMPowerVSMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Scheme:      scheme,
@@ -75,6 +75,7 @@ func IBMPowerVSClusterFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} 
 	return []interface{}{
 		hubIBMPowerVSClusterStatus,
 		spokeIBMPowerVSClusterStatus,
+		spokeIBMPowerVSClusterSpec,
 	}
 }
 
@@ -98,6 +99,24 @@ func spokeIBMPowerVSClusterStatus(in *IBMPowerVSClusterStatus, c randfill.Contin
 	}
 }
 
+func spokeIBMPowerVSClusterSpec(in *IBMPowerVSClusterSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Ensure ServiceInstance and ServiceInstanceID are in sync for round-trip conversion
+	// This handles the deprecated field migration
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil && *in.ServiceInstance.ID != "" {
+		// If ServiceInstance.ID is set, ensure ServiceInstanceID matches
+		in.ServiceInstanceID = *in.ServiceInstance.ID
+	} else if in.ServiceInstanceID != "" {
+		// If ServiceInstanceID is set, ensure ServiceInstance matches
+		if in.ServiceInstance == nil {
+			in.ServiceInstance = &IBMPowerVSResourceReference{}
+		}
+		id := in.ServiceInstanceID
+		in.ServiceInstance.ID = &id
+	}
+}
+
 func IBMPowerVSMachineFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubIBMPowerVSMachineStatus,
@@ -116,6 +135,19 @@ func hubIBMPowerVSMachineStatus(in *infrav1.IBMPowerVSMachineStatus, c randfill.
 	}
 }
 
+func IBMPowerVSClusterTemplateFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		spokeIBMPowerVSClusterTemplateResource,
+	}
+}
+
+func spokeIBMPowerVSClusterTemplateResource(in *IBMPowerVSClusterTemplateResource, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Handle the nested spec
+	spokeIBMPowerVSClusterSpec(&in.Spec, c)
+}
+
 func spokeIBMPowerVSMachineSpec(in *IBMPowerVSMachineSpec, c randfill.Continue) {
 	c.FillNoCustom(in)
 
@@ -126,6 +158,20 @@ func spokeIBMPowerVSMachineSpec(in *IBMPowerVSMachineSpec, c randfill.Continue) 
 	// Set ImageRef to nil if it has an empty name
 	if in.ImageRef != nil && in.ImageRef.Name == "" {
 		in.ImageRef = nil
+	}
+
+	// Ensure ServiceInstance and ServiceInstanceID are in sync for round-trip conversion
+	// This handles the deprecated field migration
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil && *in.ServiceInstance.ID != "" {
+		// If ServiceInstance.ID is set, ensure ServiceInstanceID matches
+		in.ServiceInstanceID = *in.ServiceInstance.ID
+	} else if in.ServiceInstanceID != "" {
+		// If ServiceInstanceID is set, ensure ServiceInstance matches
+		if in.ServiceInstance == nil {
+			in.ServiceInstance = &IBMPowerVSResourceReference{}
+		}
+		id := in.ServiceInstanceID
+		in.ServiceInstance.ID = &id
 	}
 }
 
@@ -142,8 +188,15 @@ func spokeIBMPowerVSMachineStatus(in *IBMPowerVSMachineStatus, c randfill.Contin
 func IBMPowerVSMachineTemplateFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubIBMPowerVSMachineTemplateResource,
-		spokeIBMPowerVSMachineSpec,
+		spokeIBMPowerVSMachineTemplateResource,
 	}
+}
+
+func spokeIBMPowerVSMachineTemplateResource(in *IBMPowerVSMachineTemplateResource, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Handle the nested spec
+	spokeIBMPowerVSMachineSpec(&in.Spec, c)
 }
 
 func hubIBMPowerVSMachineTemplateResource(in *infrav1.IBMPowerVSMachineTemplateResource, c randfill.Continue) {
@@ -156,6 +209,25 @@ func IBMPowerVSImageFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubIBMPowerVSImageStatus,
 		spokeIBMPowerVSImageStatus,
+		spokeIBMPowerVSImageSpec,
+	}
+}
+
+func spokeIBMPowerVSImageSpec(in *IBMPowerVSImageSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Ensure ServiceInstance and ServiceInstanceID are in sync for round-trip conversion
+	// This handles the deprecated field migration
+	if in.ServiceInstance != nil && in.ServiceInstance.ID != nil && *in.ServiceInstance.ID != "" {
+		// If ServiceInstance.ID is set, ensure ServiceInstanceID matches
+		in.ServiceInstanceID = *in.ServiceInstance.ID
+	} else if in.ServiceInstanceID != "" {
+		// If ServiceInstanceID is set, ensure ServiceInstance matches
+		if in.ServiceInstance == nil {
+			in.ServiceInstance = &IBMPowerVSResourceReference{}
+		}
+		id := in.ServiceInstanceID
+		in.ServiceInstance.ID = &id
 	}
 }
 

--- a/api/powervs/v1beta2/zz_generated.conversion.go
+++ b/api/powervs/v1beta2/zz_generated.conversion.go
@@ -90,16 +90,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*IBMPowerVSClusterSpec)(nil), (*v1beta3.IBMPowerVSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(a.(*IBMPowerVSClusterSpec), b.(*v1beta3.IBMPowerVSClusterSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta3.IBMPowerVSClusterSpec)(nil), (*IBMPowerVSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(a.(*v1beta3.IBMPowerVSClusterSpec), b.(*IBMPowerVSClusterSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*IBMPowerVSClusterTemplate)(nil), (*v1beta3.IBMPowerVSClusterTemplate)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_IBMPowerVSClusterTemplate_To_v1beta3_IBMPowerVSClusterTemplate(a.(*IBMPowerVSClusterTemplate), b.(*v1beta3.IBMPowerVSClusterTemplate), scope)
 	}); err != nil {
@@ -157,16 +147,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1beta3.IBMPowerVSImageList)(nil), (*IBMPowerVSImageList)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta3_IBMPowerVSImageList_To_v1beta2_IBMPowerVSImageList(a.(*v1beta3.IBMPowerVSImageList), b.(*IBMPowerVSImageList), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*IBMPowerVSImageSpec)(nil), (*v1beta3.IBMPowerVSImageSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(a.(*IBMPowerVSImageSpec), b.(*v1beta3.IBMPowerVSImageSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta3.IBMPowerVSImageSpec)(nil), (*IBMPowerVSImageSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(a.(*v1beta3.IBMPowerVSImageSpec), b.(*IBMPowerVSImageSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -455,8 +435,18 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*IBMPowerVSClusterSpec)(nil), (*v1beta3.IBMPowerVSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(a.(*IBMPowerVSClusterSpec), b.(*v1beta3.IBMPowerVSClusterSpec), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*IBMPowerVSClusterStatus)(nil), (*v1beta3.IBMPowerVSClusterStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_IBMPowerVSClusterStatus_To_v1beta3_IBMPowerVSClusterStatus(a.(*IBMPowerVSClusterStatus), b.(*v1beta3.IBMPowerVSClusterStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*IBMPowerVSImageSpec)(nil), (*v1beta3.IBMPowerVSImageSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(a.(*IBMPowerVSImageSpec), b.(*v1beta3.IBMPowerVSImageSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -485,8 +475,18 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*v1beta3.IBMPowerVSClusterSpec)(nil), (*IBMPowerVSClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(a.(*v1beta3.IBMPowerVSClusterSpec), b.(*IBMPowerVSClusterSpec), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta3.IBMPowerVSClusterStatus)(nil), (*IBMPowerVSClusterStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta3_IBMPowerVSClusterStatus_To_v1beta2_IBMPowerVSClusterStatus(a.(*v1beta3.IBMPowerVSClusterStatus), b.(*IBMPowerVSClusterStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta3.IBMPowerVSImageSpec)(nil), (*IBMPowerVSImageSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(a.(*v1beta3.IBMPowerVSImageSpec), b.(*IBMPowerVSImageSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -666,7 +666,7 @@ func Convert_v1beta3_IBMPowerVSClusterList_To_v1beta2_IBMPowerVSClusterList(in *
 }
 
 func autoConvert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(in *IBMPowerVSClusterSpec, out *v1beta3.IBMPowerVSClusterSpec, s conversion.Scope) error {
-	out.ServiceInstanceID = in.ServiceInstanceID
+	// WARNING: in.ServiceInstanceID requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta2_IBMPowerVSResourceReference_To_v1beta3_IBMPowerVSResourceReference(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
@@ -687,13 +687,7 @@ func autoConvert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(
 	return nil
 }
 
-// Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec is an autogenerated conversion function.
-func Convert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(in *IBMPowerVSClusterSpec, out *v1beta3.IBMPowerVSClusterSpec, s conversion.Scope) error {
-	return autoConvert_v1beta2_IBMPowerVSClusterSpec_To_v1beta3_IBMPowerVSClusterSpec(in, out, s)
-}
-
 func autoConvert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(in *v1beta3.IBMPowerVSClusterSpec, out *IBMPowerVSClusterSpec, s conversion.Scope) error {
-	out.ServiceInstanceID = in.ServiceInstanceID
 	if err := Convert_v1beta3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
@@ -712,11 +706,6 @@ func autoConvert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(
 	out.CosInstance = (*CosInstance)(unsafe.Pointer(in.CosInstance))
 	out.Ignition = (*Ignition)(unsafe.Pointer(in.Ignition))
 	return nil
-}
-
-// Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec is an autogenerated conversion function.
-func Convert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(in *v1beta3.IBMPowerVSClusterSpec, out *IBMPowerVSClusterSpec, s conversion.Scope) error {
-	return autoConvert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(in, out, s)
 }
 
 func autoConvert_v1beta2_IBMPowerVSClusterStatus_To_v1beta3_IBMPowerVSClusterStatus(in *IBMPowerVSClusterStatus, out *v1beta3.IBMPowerVSClusterStatus, s conversion.Scope) error {
@@ -971,7 +960,7 @@ func Convert_v1beta3_IBMPowerVSImageList_To_v1beta2_IBMPowerVSImageList(in *v1be
 
 func autoConvert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in *IBMPowerVSImageSpec, out *v1beta3.IBMPowerVSImageSpec, s conversion.Scope) error {
 	out.ClusterName = in.ClusterName
-	out.ServiceInstanceID = in.ServiceInstanceID
+	// WARNING: in.ServiceInstanceID requires manual conversion: does not exist in peer-type
 	out.ServiceInstance = (*v1beta3.IBMPowerVSResourceReference)(unsafe.Pointer(in.ServiceInstance))
 	out.Bucket = (*string)(unsafe.Pointer(in.Bucket))
 	out.Object = (*string)(unsafe.Pointer(in.Object))
@@ -981,14 +970,8 @@ func autoConvert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in *
 	return nil
 }
 
-// Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec is an autogenerated conversion function.
-func Convert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in *IBMPowerVSImageSpec, out *v1beta3.IBMPowerVSImageSpec, s conversion.Scope) error {
-	return autoConvert_v1beta2_IBMPowerVSImageSpec_To_v1beta3_IBMPowerVSImageSpec(in, out, s)
-}
-
 func autoConvert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in *v1beta3.IBMPowerVSImageSpec, out *IBMPowerVSImageSpec, s conversion.Scope) error {
 	out.ClusterName = in.ClusterName
-	out.ServiceInstanceID = in.ServiceInstanceID
 	out.ServiceInstance = (*IBMPowerVSResourceReference)(unsafe.Pointer(in.ServiceInstance))
 	out.Bucket = (*string)(unsafe.Pointer(in.Bucket))
 	out.Object = (*string)(unsafe.Pointer(in.Object))
@@ -996,11 +979,6 @@ func autoConvert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in *
 	out.StorageType = in.StorageType
 	out.DeletePolicy = in.DeletePolicy
 	return nil
-}
-
-// Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec is an autogenerated conversion function.
-func Convert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in *v1beta3.IBMPowerVSImageSpec, out *IBMPowerVSImageSpec, s conversion.Scope) error {
-	return autoConvert_v1beta3_IBMPowerVSImageSpec_To_v1beta2_IBMPowerVSImageSpec(in, out, s)
 }
 
 func autoConvert_v1beta2_IBMPowerVSImageStatus_To_v1beta3_IBMPowerVSImageStatus(in *IBMPowerVSImageStatus, out *v1beta3.IBMPowerVSImageStatus, s conversion.Scope) error {
@@ -1118,7 +1096,7 @@ func Convert_v1beta3_IBMPowerVSMachineList_To_v1beta2_IBMPowerVSMachineList(in *
 }
 
 func autoConvert_v1beta2_IBMPowerVSMachineSpec_To_v1beta3_IBMPowerVSMachineSpec(in *IBMPowerVSMachineSpec, out *v1beta3.IBMPowerVSMachineSpec, s conversion.Scope) error {
-	out.ServiceInstanceID = in.ServiceInstanceID
+	// WARNING: in.ServiceInstanceID requires manual conversion: does not exist in peer-type
 	out.ServiceInstance = (*v1beta3.IBMPowerVSResourceReference)(unsafe.Pointer(in.ServiceInstance))
 	out.SSHKey = in.SSHKey
 	out.Image = (*v1beta3.IBMPowerVSResourceReference)(unsafe.Pointer(in.Image))
@@ -1137,7 +1115,6 @@ func autoConvert_v1beta2_IBMPowerVSMachineSpec_To_v1beta3_IBMPowerVSMachineSpec(
 }
 
 func autoConvert_v1beta3_IBMPowerVSMachineSpec_To_v1beta2_IBMPowerVSMachineSpec(in *v1beta3.IBMPowerVSMachineSpec, out *IBMPowerVSMachineSpec, s conversion.Scope) error {
-	out.ServiceInstanceID = in.ServiceInstanceID
 	out.ServiceInstance = (*IBMPowerVSResourceReference)(unsafe.Pointer(in.ServiceInstance))
 	out.SSHKey = in.SSHKey
 	out.Image = (*IBMPowerVSResourceReference)(unsafe.Pointer(in.Image))

--- a/api/powervs/v1beta3/ibmpowervscluster_types.go
+++ b/api/powervs/v1beta3/ibmpowervscluster_types.go
@@ -34,11 +34,6 @@ func init() {
 
 // IBMPowerVSClusterSpec defines the desired state of IBMPowerVSCluster.
 type IBMPowerVSClusterSpec struct {
-	// serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-	//
-	// Deprecated: use ServiceInstance instead
-	ServiceInstanceID string `json:"serviceInstanceID"`
-
 	// controlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty,omitzero"`
@@ -200,7 +195,6 @@ type IBMPowerVSClusterStatus struct {
 // +kubebuilder:resource:path=ibmpowervsclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this IBMPowerVSCluster belongs"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IBMPowerVSCluster"
-// +kubebuilder:printcolumn:name="PowerVS Cloud Instance ID",type="string",priority=1,JSONPath=".spec.serviceInstanceID"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",priority=1,JSONPath=".spec.controlPlaneEndpoint.host",description="Control Plane Endpoint"
 // +kubebuilder:printcolumn:name="Port",type="string",priority=1,JSONPath=".spec.controlPlaneEndpoint.port",description="Control Plane Port"
 

--- a/api/powervs/v1beta3/ibmpowervsimage_types.go
+++ b/api/powervs/v1beta3/ibmpowervsimage_types.go
@@ -38,11 +38,6 @@ type IBMPowerVSImageSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ClusterName string `json:"clusterName"`
 
-	// serviceInstanceID is the id of the power cloud instance where the image will get imported.
-	//
-	// Deprecated: use ServiceInstance instead
-	ServiceInstanceID string `json:"serviceInstanceID"`
-
 	// serviceInstance is the reference to the Power VS workspace on which the server instance(VM) will be created.
 	// Power VS workspace is a container for all Power VS instances at a specific geographic region.
 	// serviceInstance can be created via IBM Cloud catalog or CLI.

--- a/api/powervs/v1beta3/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta3/ibmpowervsmachine_types.go
@@ -46,11 +46,6 @@ func init() {
 
 // IBMPowerVSMachineSpec defines the desired state of IBMPowerVSMachine.
 type IBMPowerVSMachineSpec struct {
-	// serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-	//
-	// Deprecated: use ServiceInstance instead
-	ServiceInstanceID string `json:"serviceInstanceID"`
-
 	// serviceInstance is the reference to the Power VS workspace on which the server instance(VM) will be created.
 	// Power VS workspace is a container for all Power VS instances at a specific geographic region.
 	// serviceInstance can be created via IBM Cloud catalog or CLI.

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -174,41 +174,8 @@ func NewPowerVSClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		},
 	}
 
-	// if Spec.ServiceInstanceID is set fetch zone associated with it or else use Spec.Zone.
-	if params.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-		// Create Resource Controller client.
-		var serviceOption resourcecontroller.ServiceOptions
-		// Fetch the resource controller endpoint.
-		rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
-		if rcEndpoint != "" {
-			serviceOption.URL = rcEndpoint
-			params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
-		}
-		rc, err := resourcecontroller.NewService(serviceOption)
-		if err != nil {
-			return nil, err
-		}
-
-		// Fetch the resource controller endpoint.
-		if rcEndpoint := endpoints.FetchRCEndpoint(params.ServiceEndpoint); rcEndpoint != "" {
-			params.Logger.V(3).Info("Overriding the default resource controller endpoint", "ResourceControllerEndpoint", rcEndpoint)
-			if err := rc.SetServiceURL(rcEndpoint); err != nil {
-				return nil, fmt.Errorf("failed to set resource controller endpoint: %w", err)
-			}
-		}
-
-		res, _, err := rc.GetResourceInstance(
-			&resourcecontrollerv2.GetResourceInstanceOptions{
-				ID: core.StringPtr(params.IBMPowerVSCluster.Spec.ServiceInstanceID),
-			})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get resource instance: %w", err)
-		}
-		piOptions.Zone = *res.RegionID
-		piOptions.CloudInstanceID = params.IBMPowerVSCluster.Spec.ServiceInstanceID
-	} else {
-		piOptions.Zone = *params.IBMPowerVSCluster.Spec.Zone
-	}
+	// Use Spec.Zone for the PowerVS zone.
+	piOptions.Zone = *params.IBMPowerVSCluster.Spec.Zone
 
 	// Get the authenticator.
 	auth, err := params.getAuthenticator()
@@ -808,9 +775,7 @@ func (s *ClusterScope) isServiceInstanceExists(ctx context.Context) (string, boo
 		serviceInstance *resourcecontrollerv2.ResourceInstance
 	)
 
-	if s.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-		id = s.IBMPowerVSCluster.Spec.ServiceInstanceID
-	} else if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+	if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
 		id = *s.IBMPowerVSCluster.Spec.ServiceInstance.ID
 	}
 
@@ -2482,9 +2447,7 @@ func (s *ClusterScope) fetchVPCCRN() (*string, error) {
 func (s *ClusterScope) fetchPowerVSServiceInstanceCRN() (*string, error) {
 	serviceInstanceID := s.GetServiceInstanceID()
 	if serviceInstanceID == "" {
-		if s.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-			serviceInstanceID = s.IBMPowerVSCluster.Spec.ServiceInstanceID
-		} else if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+		if s.IBMPowerVSCluster.Spec.ServiceInstance != nil && s.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
 			serviceInstanceID = *s.IBMPowerVSCluster.Spec.ServiceInstance.ID
 		}
 	}

--- a/cloud/scope/powervs/powervs_cluster_test.go
+++ b/cloud/scope/powervs/powervs_cluster_test.go
@@ -2298,7 +2298,9 @@ func TestIsServiceInstanceExists(t *testing.T) {
 			ResourceClient: mockResourceController,
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "instance-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{
+						ID: ptr.To("instance-id"),
+					},
 				},
 			},
 		}

--- a/cloud/scope/powervs/powervs_image.go
+++ b/cloud/scope/powervs/powervs_image.go
@@ -54,10 +54,11 @@ type ImageScopeParams struct {
 
 // ImageScope defines a scope defined around a Power VS Cluster.
 type ImageScope struct {
-	Client           client.Client
-	IBMPowerVSClient powervs.PowerVS
-	IBMPowerVSImage  *infrav1.IBMPowerVSImage
-	ServiceEndpoint  []endpoints.ServiceEndpoint
+	Client            client.Client
+	IBMPowerVSClient  powervs.PowerVS
+	IBMPowerVSImage   *infrav1.IBMPowerVSImage
+	ServiceEndpoint   []endpoints.ServiceEndpoint
+	serviceInstanceID string
 }
 
 // NewPowerVSImageScope creates a new ImageScope from the supplied parameters.
@@ -92,10 +93,7 @@ func NewPowerVSImageScope(ctx context.Context, params ImageScopeParams) (scope *
 	}
 
 	var serviceInstanceID string
-	spec := params.IBMPowerVSImage.Spec
-	if spec.ServiceInstanceID != "" {
-		serviceInstanceID = spec.ServiceInstanceID
-	} else if params.IBMPowerVSImage.Spec.ServiceInstance != nil && params.IBMPowerVSImage.Spec.ServiceInstance.ID != nil {
+	if params.IBMPowerVSImage.Spec.ServiceInstance != nil && params.IBMPowerVSImage.Spec.ServiceInstance.ID != nil {
 		serviceInstanceID = *params.IBMPowerVSImage.Spec.ServiceInstance.ID
 	} else {
 		name := fmt.Sprintf("%s-%s", params.IBMPowerVSImage.Spec.ClusterName, "serviceInstance")
@@ -154,6 +152,7 @@ func NewPowerVSImageScope(ctx context.Context, params ImageScopeParams) (scope *
 	options.CloudInstanceID = serviceInstanceID
 	c.WithClients(options)
 	scope.IBMPowerVSClient = c
+	scope.serviceInstanceID = serviceInstanceID
 	return scope, nil
 }
 
@@ -224,7 +223,7 @@ func (i *ImageScope) DeleteImage() error {
 
 // GetImportJob will get the image import job.
 func (i *ImageScope) GetImportJob() (*models.Job, error) {
-	return i.IBMPowerVSClient.GetCosImages(i.IBMPowerVSImage.Spec.ServiceInstanceID)
+	return i.IBMPowerVSClient.GetCosImages(i.serviceInstanceID)
 }
 
 // DeleteImportJob will delete the image import job.

--- a/cloud/scope/powervs/powervs_image_test.go
+++ b/cloud/scope/powervs/powervs_image_test.go
@@ -27,6 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -45,12 +46,12 @@ func newPowervsImage(imageName string) *infrav1.IBMPowerVSImage {
 			Namespace: "default",
 		},
 		Spec: infrav1.IBMPowerVSImageSpec{
-			ClusterName:       "test-cluster",
-			ServiceInstanceID: "test-service-ID",
-			StorageType:       "foo-tier",
-			Object:            core.StringPtr("foo-obj"),
-			Bucket:            core.StringPtr("foo-bucket"),
-			Region:            core.StringPtr("foo-zone"),
+			ClusterName:     "test-cluster",
+			ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test-service-ID")},
+			StorageType:     "foo-tier",
+			Object:          core.StringPtr("foo-obj"),
+			Bucket:          core.StringPtr("foo-bucket"),
+			Region:          core.StringPtr("foo-zone"),
 		},
 	}
 }

--- a/cloud/scope/powervs/powervs_machine.go
+++ b/cloud/scope/powervs/powervs_machine.go
@@ -155,9 +155,7 @@ func NewMachineScope(params MachineScopeParams) (scope *MachineScope, err error)
 	scope.ResourceClient = rc
 
 	var serviceInstanceID, serviceInstanceName string
-	if params.IBMPowerVSMachine.Spec.ServiceInstanceID != "" {
-		serviceInstanceID = params.IBMPowerVSMachine.Spec.ServiceInstanceID
-	} else if params.IBMPowerVSMachine.Spec.ServiceInstance != nil && params.IBMPowerVSMachine.Spec.ServiceInstance.ID != nil {
+	if params.IBMPowerVSMachine.Spec.ServiceInstance != nil && params.IBMPowerVSMachine.Spec.ServiceInstance.ID != nil {
 		serviceInstanceID = *params.IBMPowerVSMachine.Spec.ServiceInstance.ID
 	} else {
 		serviceInstanceName = fmt.Sprintf("%s-%s", params.IBMPowerVSCluster.GetName(), "serviceInstance")
@@ -915,9 +913,6 @@ func (m *MachineScope) GetZone() string {
 func (m *MachineScope) GetServiceInstanceID() (string, error) {
 	if m.IBMPowerVSCluster.Status.ServiceInstance != nil && m.IBMPowerVSCluster.Status.ServiceInstance.ID != nil {
 		return *m.IBMPowerVSCluster.Status.ServiceInstance.ID, nil
-	}
-	if m.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
-		return m.IBMPowerVSCluster.Spec.ServiceInstanceID, nil
 	}
 	if m.IBMPowerVSCluster.Spec.ServiceInstance != nil && m.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
 		return *m.IBMPowerVSCluster.Spec.ServiceInstance.ID, nil

--- a/cloud/scope/powervs/powervs_machine_test.go
+++ b/cloud/scope/powervs/powervs_machine_test.go
@@ -393,7 +393,7 @@ func TestGetServiceInstanceIDForMachineScope(t *testing.T) {
 			machineScope: MachineScope{
 				IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 					Spec: infrav1.IBMPowerVSClusterSpec{
-						ServiceInstanceID: "service-instance-1",
+						ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 					},
 				},
 			},
@@ -420,7 +420,7 @@ func TestGetServiceInstanceIDForMachineScope(t *testing.T) {
 						},
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
-						ServiceInstanceID: "service-instance-in-spec",
+						ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-in-spec")},
 					},
 				},
 			},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -1210,10 +1210,6 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.serviceInstanceID
-      name: PowerVS Cloud Instance ID
-      priority: 1
-      type: string
     - description: Control Plane Endpoint
       jsonPath: .spec.controlPlaneEndpoint.host
       name: Endpoint
@@ -1658,12 +1654,6 @@ spec:
                     minLength: 1
                     type: string
                 type: object
-              serviceInstanceID:
-                description: |-
-                  serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-
-                  Deprecated: use ServiceInstance instead
-                type: string
               transitGateway:
                 description: |-
                   transitGateway contains information about IBM Cloud TransitGateway
@@ -2083,7 +2073,6 @@ spec:
                 type: string
             required:
             - network
-            - serviceInstanceID
             type: object
           status:
             description: status defines the observed state of IBMPowerVSCluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -1413,12 +1413,6 @@ spec:
                             minLength: 1
                             type: string
                         type: object
-                      serviceInstanceID:
-                        description: |-
-                          serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-
-                          Deprecated: use ServiceInstance instead
-                        type: string
                       transitGateway:
                         description: |-
                           transitGateway contains information about IBM Cloud TransitGateway
@@ -1845,7 +1839,6 @@ spec:
                         type: string
                     required:
                     - network
-                    - serviceInstanceID
                     type: object
                 required:
                 - spec

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsimages.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsimages.yaml
@@ -342,12 +342,6 @@ spec:
                     minLength: 1
                     type: string
                 type: object
-              serviceInstanceID:
-                description: |-
-                  serviceInstanceID is the id of the power cloud instance where the image will get imported.
-
-                  Deprecated: use ServiceInstance instead
-                type: string
               storageType:
                 default: tier1
                 description: storageType is the type of storage, storage pool with
@@ -362,7 +356,6 @@ spec:
             - clusterName
             - object
             - region
-            - serviceInstanceID
             type: object
           status:
             description: status defines the observed state of IBMPowerVSImage

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -628,12 +628,6 @@ spec:
                     minLength: 1
                     type: string
                 type: object
-              serviceInstanceID:
-                description: |-
-                  serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-
-                  Deprecated: use ServiceInstance instead
-                type: string
               sshKey:
                 description: sshKey is the name of the SSH key pair provided to the
                   vsi for authenticating users.
@@ -655,7 +649,6 @@ spec:
                 type: string
             required:
             - network
-            - serviceInstanceID
             type: object
           status:
             description: status defines the observed state of IBMPowerVSMachine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
@@ -415,12 +415,6 @@ spec:
                             minLength: 1
                             type: string
                         type: object
-                      serviceInstanceID:
-                        description: |-
-                          serviceInstanceID is the id of the power cloud instance where the vsi instance will get deployed.
-
-                          Deprecated: use ServiceInstance instead
-                        type: string
                       sshKey:
                         description: sshKey is the name of the SSH key pair provided
                           to the vsi for authenticating users.
@@ -442,7 +436,6 @@ spec:
                         type: string
                     required:
                     - network
-                    - serviceInstanceID
                     type: object
                 required:
                 - spec

--- a/internal/controllers/powervs/ibmpowervscluster_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller_test.go
@@ -69,7 +69,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "powervs-test-",
 			},
-			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstanceID: "foo"},
+			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("foo")}},
 		}
 
 		createCluster(g, powerVSCluster, ns.Name)
@@ -111,7 +111,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						Name:       "capi-test",
 						UID:        "1",
 					}}},
-			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstanceID: "foo"},
+			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("foo")}},
 		}
 
 		createCluster(g, powerVSCluster, ns.Name)
@@ -141,7 +141,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 				GenerateName: "powervs-test-",
 				Finalizers:   []string{infrav1.IBMPowerVSClusterFinalizer},
 			},
-			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstanceID: "foo"},
+			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("foo")}},
 		}
 
 		createCluster(g, powerVSCluster, ns.Name)
@@ -196,7 +196,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						Name:       "capi-test",
 						UID:        "1",
 					}}},
-			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstanceID: "foo"},
+			Spec: infrav1.IBMPowerVSClusterSpec{ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("foo")}},
 		}
 
 		createCluster(g, powerVSCluster, ns.Name)
@@ -842,7 +842,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 						Name: "capi-powervs-cluster",
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
-						ServiceInstanceID: "service-instance-1",
+						ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 					},
 				},
 				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build(),
@@ -864,7 +864,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 						Name: "capi-powervs-cluster",
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
-						ServiceInstanceID: "service-instance-1",
+						ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 					},
 				},
 				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build(),
@@ -1268,8 +1268,8 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 			ControllerCreated: ptr.To(true),
 		}
 		clusterScope.IBMPowerVSCluster.Spec = infrav1.IBMPowerVSClusterSpec{
-			ServiceInstanceID: "service-instance-1",
-			Ignition:          &infrav1.Ignition{Version: "3.4"},
+			ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+			Ignition:        &infrav1.Ignition{Version: "3.4"},
 		}
 		mockPowerVS = powervsmock.NewMockPowerVS(gomock.NewController(t))
 		mockPowerVS.EXPECT().WithClients(gomock.Any())
@@ -1300,8 +1300,8 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 			},
 		}
 		clusterScope.IBMPowerVSCluster.Spec = infrav1.IBMPowerVSClusterSpec{
-			ServiceInstanceID: "service-instance-1",
-			Ignition:          &infrav1.Ignition{Version: "3.4"},
+			ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+			Ignition:        &infrav1.Ignition{Version: "3.4"},
 		}
 		mockPowerVS = powervsmock.NewMockPowerVS(gomock.NewController(t))
 		mockPowerVS.EXPECT().WithClients(gomock.Any())
@@ -1697,7 +1697,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "serviceInstanceID",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("serviceInstanceID")},
 						},
 						Status: infrav1.IBMPowerVSClusterStatus{
 							Network:         &infrav1.ResourceReference{ID: ptr.To("NetworkID")},
@@ -1735,7 +1735,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "serviceInstanceID",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("serviceInstanceID")},
 						},
 						Status: infrav1.IBMPowerVSClusterStatus{
 							Network:         &infrav1.ResourceReference{ID: ptr.To("netID")},

--- a/internal/controllers/powervs/ibmpowervsimage_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsimage_controller_test.go
@@ -180,7 +180,7 @@ func TestIBMPowerVSImageReconciler_reconcile(t *testing.T) {
 					UID:  "1",
 				},
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "service-instance-1",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 				},
 			}
 			powervsImage := &infrav1.IBMPowerVSImage{

--- a/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
@@ -73,8 +73,8 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "powervs-test-1"},
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "service-instance-1",
-					Image:             &infrav1.IBMPowerVSResourceReference{}}},
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+					Image:           &infrav1.IBMPowerVSResourceReference{}}},
 			expectError: false,
 		},
 		{
@@ -93,8 +93,8 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 					Finalizers: []string{infrav1.IBMPowerVSMachineFinalizer},
 				},
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "service-instance-1",
-					Image:             &infrav1.IBMPowerVSResourceReference{}},
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+					Image:           &infrav1.IBMPowerVSResourceReference{}},
 			},
 			expectError: true,
 		},
@@ -112,8 +112,8 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 						},
 					},
 				}, Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "service-instance-1",
-					Image:             &infrav1.IBMPowerVSResourceReference{}},
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+					Image:           &infrav1.IBMPowerVSResourceReference{}},
 			},
 			ownerMachine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{Name: "capi-test-machine"}},
@@ -142,8 +142,8 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 						},
 					},
 				}, Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "service-instance-1",
-					Image:             &infrav1.IBMPowerVSResourceReference{}},
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
+					Image:           &infrav1.IBMPowerVSResourceReference{}},
 			},
 			ownerMachine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{Name: "capi-test-machine"}},
@@ -177,7 +177,7 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 					},
 					Finalizers: []string{infrav1.IBMPowerVSMachineFinalizer},
 				}, Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "service-instance-1",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 					ImageRef: infrav1.ImageReference{
 						Name: "capi-image",
 					}},
@@ -192,7 +192,7 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "powervs-cluster"},
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "service-instance-1"}},
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")}}},
 			expectError: false,
 		},
 	}
@@ -951,7 +951,7 @@ func newIBMPowerVSMachine() *infrav1.IBMPowerVSMachine {
 			Network: infrav1.IBMPowerVSResourceReference{
 				ID: ptr.To("capi-net-id"),
 			},
-			ServiceInstanceID: *ptr.To("service-instance-1"),
+			ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("service-instance-1")},
 		},
 	}
 }

--- a/internal/controllers/powervs/ibmpowervsmachinetemplate_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachinetemplate_controller_test.go
@@ -190,7 +190,7 @@ func stubPowerVSMachineTemplate(processor intstr.IntOrString, memory int32) *inf
 		Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 			Template: infrav1.IBMPowerVSMachineTemplateResource{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "test_service_instance_id_27",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test_service_instance_id_27")},
 					Image: &infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-image"),
 					},

--- a/internal/webhooks/powervs/ibmpowervscluster_test.go
+++ b/internal/webhooks/powervs/ibmpowervscluster_test.go
@@ -35,7 +35,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should allow if either Network ID or name is set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -47,7 +47,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network ID and name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net"),
@@ -60,7 +60,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if all Network ID, name and regex are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID:    ptr.To("capi-net-id"),
 						Name:  ptr.To("capi-net"),
@@ -74,7 +74,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network name and DHCP name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -89,7 +89,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network id and DHCP name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -104,7 +104,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network name and DHCP id are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -119,7 +119,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network id and DHCP id are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -158,7 +158,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should allow if either Network ID or name is set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -166,7 +166,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -178,7 +178,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if both Network ID and name are set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -186,7 +186,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net-name"),
@@ -199,7 +199,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should allow if Network ID is set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						RegEx: ptr.To("^capi-net-id$"),
 					},
@@ -207,7 +207,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						RegEx: ptr.To("^capi-net-id$"),
 					},
@@ -219,7 +219,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if all Network ID, name and regex are set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -227,7 +227,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID:    ptr.To("capi-net-id"),
 						Name:  ptr.To("capi-net-name"),
@@ -241,7 +241,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if the additionalListener selector is changed for same port and protocol",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -265,7 +265,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -293,7 +293,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should work if there is an additional listener added",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -317,7 +317,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -354,7 +354,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should work if the additionalListener selector is updated with new port and protocol",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -378,7 +378,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -406,7 +406,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should not panic with nil protocol in additionalListener",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},
@@ -430,7 +430,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
-					ServiceInstanceID: "capi-si-id",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID: ptr.To("capi-net-id"),
 					},

--- a/internal/webhooks/powervs/ibmpowervsclustertemplate_test.go
+++ b/internal/webhooks/powervs/ibmpowervsclustertemplate_test.go
@@ -19,6 +19,8 @@ package powervs
 import (
 	"testing"
 
+	"k8s.io/utils/ptr"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/powervs/v1beta3"
 
 	. "github.com/onsi/gomega"
@@ -39,7 +41,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "test-instance1",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test-instance1")},
 						},
 					},
 				},
@@ -48,7 +50,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "test-instance1",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test-instance1")},
 						},
 					},
 				},
@@ -61,7 +63,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "test-instance1",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test-instance1")},
 						},
 					},
 				},
@@ -70,7 +72,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							ServiceInstanceID: "test-instance2",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("test-instance2")},
 						},
 					},
 				},

--- a/internal/webhooks/powervs/ibmpowervsmachine_test.go
+++ b/internal/webhooks/powervs/ibmpowervsmachine_test.go
@@ -59,9 +59,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should fail to validate IBMPowerVSMachine - incorrect spec values",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "a890",
-					ProcessorType:     "unknown",
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "a890",
+					ProcessorType:   "unknown",
 					Network: infrav1.IBMPowerVSResourceReference{
 						ID:   ptr.To("capi-net-id"),
 						Name: ptr.To("capi-net"),
@@ -74,9 +74,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should fail to validate IBMPowerVSMachine - no Image or Imagref in Spec",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -88,9 +88,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should fail to validate IBMPowerVSMachine - both Image and Imagref specified in Spec",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -106,9 +106,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should fail to validate IBMPowerVSMachine - Both Id and Name specified in Spec",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -124,9 +124,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should fail to validate IBMPowerVSMachine - invalid memory and processor values",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -143,9 +143,9 @@ func TestIBMPowerVSMachine_create(t *testing.T) {
 			name: "Should successfully validate IBMPowerVSMachine - valid spec",
 			powerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -185,11 +185,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should fail to update IBMPowerVSMachine with invalid ProcessorType",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -200,11 +200,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "e980",
-					ProcessorType:     "invalid",
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "e980",
+					ProcessorType:   "invalid",
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -219,11 +219,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should fail to update IBMPowerVSMachine with invalid Network",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -234,11 +234,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 						ID:   ptr.To("capi-net-ID"),
@@ -254,11 +254,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should fail to update IBMPowerVSMachine with invalid Image",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -269,11 +269,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -289,11 +289,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should fail to update IBMPowerVSMachine with invalid memory",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -304,11 +304,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         int32(-8),
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       int32(-8),
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -323,11 +323,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should fail to update IBMPowerVSMachine with invalid processors",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -338,11 +338,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("two"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("two"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -357,11 +357,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			name: "Should successfully update IBMPowerVSMachine",
 			oldPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         4,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       4,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},
@@ -372,11 +372,11 @@ func TestIBMPowerVSMachine_update(t *testing.T) {
 			},
 			newPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{
-					ServiceInstanceID: "capi-si-id",
-					SystemType:        "s922",
-					ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-					MemoryGiB:         8,
-					Processors:        intstr.FromString("0.25"),
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+					SystemType:      "s922",
+					ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+					MemoryGiB:       8,
+					Processors:      intstr.FromString("0.25"),
 					Network: infrav1.IBMPowerVSResourceReference{
 						Name: ptr.To("capi-net"),
 					},

--- a/internal/webhooks/powervs/ibmpowervsmachinetemplate_test.go
+++ b/internal/webhooks/powervs/ibmpowervsmachinetemplate_test.go
@@ -65,9 +65,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "a890",
-							ProcessorType:     "unknown",
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "a890",
+							ProcessorType:   "unknown",
 							Network: infrav1.IBMPowerVSResourceReference{
 								ID:   ptr.To("capi-net-id"),
 								Name: ptr.To("capi-net"),
@@ -84,9 +84,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -102,9 +102,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -124,9 +124,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -146,9 +146,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -169,9 +169,9 @@ func TestIBMPowerVSMachineTemplate_create(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -216,11 +216,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -235,11 +235,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "e980",
-							ProcessorType:     "invalid",
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "e980",
+							ProcessorType:   "invalid",
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -258,11 +258,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -277,11 +277,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 								ID:   ptr.To("capi-net-ID"),
@@ -301,11 +301,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -320,11 +320,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -344,11 +344,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -363,11 +363,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         int32(-8),
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       int32(-8),
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -386,11 +386,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -405,11 +405,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("two"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("two"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -428,11 +428,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         4,
-							Processors:        intstr.FromString("0.25"),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       4,
+							Processors:      intstr.FromString("0.25"),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},
@@ -447,11 +447,11 @@ func TestIBMPowerVSMachineTemplate_update(t *testing.T) {
 				Spec: infrav1.IBMPowerVSMachineTemplateSpec{
 					Template: infrav1.IBMPowerVSMachineTemplateResource{
 						Spec: infrav1.IBMPowerVSMachineSpec{
-							ServiceInstanceID: "capi-si-id",
-							SystemType:        "s922",
-							ProcessorType:     infrav1.PowerVSProcessorTypeShared,
-							MemoryGiB:         8,
-							Processors:        intstr.FromInt(2),
+							ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("capi-si-id")},
+							SystemType:      "s922",
+							ProcessorType:   infrav1.PowerVSProcessorTypeShared,
+							MemoryGiB:       8,
+							Processors:      intstr.FromInt(2),
 							Network: infrav1.IBMPowerVSResourceReference{
 								Name: ptr.To("capi-net"),
 							},

--- a/templates/bases/powervs/cluster.yaml
+++ b/templates/bases/powervs/cluster.yaml
@@ -29,7 +29,8 @@ metadata:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
 spec:
-  serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+  serviceInstance:
+    id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
   network:
     name: "${IBMPOWERVS_NETWORK_NAME}"
   controlPlaneEndpoint:

--- a/templates/bases/powervs/kcp.yaml
+++ b/templates/bases/powervs/kcp.yaml
@@ -178,7 +178,8 @@ metadata:
 spec:
   template:
     spec:
-      serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+      serviceInstance:
+        id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
       sshKey: "${IBMPOWERVS_SSHKEY_NAME}"
       image:
         name: "${IBMPOWERVS_IMAGE_NAME}"

--- a/templates/bases/powervs/md.yaml
+++ b/templates/bases/powervs/md.yaml
@@ -26,7 +26,8 @@ metadata:
 spec:
   template:
     spec:
-      serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+      serviceInstance:
+        id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
       sshKey: "${IBMPOWERVS_SSHKEY_NAME}"
       image:
         name: "${IBMPOWERVS_IMAGE_NAME}"

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -72,7 +72,8 @@ spec:
         port: ${API_SERVER_PORT:=6443}
       network:
         name: ${IBMPOWERVS_NETWORK_NAME}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
@@ -286,7 +287,8 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
 ---
@@ -304,7 +306,8 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
 ---

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -72,7 +72,8 @@ spec:
         port: ${API_SERVER_PORT:=6443}
       network:
         name: "${IBMPOWERVS_NETWORK_NAME}"
-      serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+      serviceInstance:
+        id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate

--- a/templates/cluster-template-powervs-clusterclass/md.yaml
+++ b/templates/cluster-template-powervs-clusterclass/md.yaml
@@ -35,7 +35,8 @@ metadata:
 spec:
   template:
     spec:
-      serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+      serviceInstance:
+        id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
       sshKey: "${IBMPOWERVS_SSHKEY_NAME}"
       image:
         name: "${IBMPOWERVS_IMAGE_NAME}"
@@ -53,7 +54,8 @@ metadata:
 spec:
   template:
     spec:
-      serviceInstanceID: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
+      serviceInstance:
+        id: "${IBMPOWERVS_SERVICE_INSTANCE_ID}"
       sshKey: "${IBMPOWERVS_SSHKEY_NAME}"
       image:
         name: "${IBMPOWERVS_IMAGE_NAME}"

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -35,7 +35,8 @@ spec:
     port: ${API_SERVER_PORT:=6443}
   network:
     name: ${IBMPOWERVS_NETWORK_NAME}
-  serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+  serviceInstance:
+    id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlane
@@ -224,7 +225,8 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
 ---
@@ -263,7 +265,8 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
 ---

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -527,7 +527,8 @@ spec:
     port: ${API_SERVER_PORT:=6443}
   network:
     name: ${IBMPOWERVS_NETWORK_NAME}
-  serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+  serviceInstance:
+    id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
 kind: IBMPowerVSMachineTemplate
@@ -543,7 +544,8 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
 ---
@@ -561,6 +563,7 @@ spec:
         name: ${IBMPOWERVS_NETWORK_NAME}
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
-      serviceInstanceID: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
+      serviceInstance:
+        id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
       systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR removes the deprecated ServiceInstanceID field from PowerVSCluster, PowerVSMachine and PoweVSImage , Its recomended to use Resource.ServiceInstance.ID field from now on.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated ServiceInstanceID from IBMPowerVSCluster, IBMPowerVSMachine and IBMPowerVSImage
```
