### PR TITLE
Fix panic in IBMPowerVSCluster webhook

### DIFF
--- a/internal/webhooks/powervs/ibmpowervscluster.go
+++ b/internal/webhooks/powervs/ibmpowervscluster.go
@@ -251,13 +251,29 @@ func validateAdditionalListenerSelector(newCluster, oldCluster *infrav1.IBMPower
 	newLoadBalancerListeners := map[string]metav1.LabelSelector{}
 	for _, loadbalancer := range newCluster.Spec.LoadBalancers {
 		for _, additionalListener := range loadbalancer.AdditionalListeners {
-			newLoadBalancerListeners[fmt.Sprintf("%d-%s", additionalListener.Port, *additionalListener.Protocol)] = additionalListener.Selector
+			var key string
+			if additionalListener.Protocol != nil {
+				key = fmt.Sprintf("%d-%s", additionalListener.Port, *additionalListener.Protocol)
+			} else {
+				// Use default protocol marker when protocol is not specified
+				key = fmt.Sprintf("%d-<default>", additionalListener.Port)
+			}
+			newLoadBalancerListeners[key] = additionalListener.Selector
 		}
 	}
 	for _, loadbalancer := range oldCluster.Spec.LoadBalancers {
 		for _, additionalListener := range loadbalancer.AdditionalListeners {
-			if selector, ok := newLoadBalancerListeners[fmt.Sprintf("%d-%s", additionalListener.Port, *additionalListener.Protocol)]; ok && !reflect.DeepEqual(selector, additionalListener.Selector) {
-				allErrs = append(allErrs, field.Forbidden(field.NewPath("selector"), "Selector is immutable"))
+			var key string
+			if additionalListener.Protocol != nil {
+				key = fmt.Sprintf("%d-%s", additionalListener.Port, *additionalListener.Protocol)
+			} else {
+				// Use default protocol marker when protocol is not specified
+				key = fmt.Sprintf("%d-<default>", additionalListener.Port)
+			}
+			if selector, ok := newLoadBalancerListeners[key]; ok && !reflect.DeepEqual(selector, additionalListener.Selector) {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "loadBalancers", "additionalListeners", "selector"),
+					fmt.Sprintf("Selector is immutable for port %d", additionalListener.Port)))
 			}
 		}
 	}

--- a/internal/webhooks/powervs/ibmpowervscluster_test.go
+++ b/internal/webhooks/powervs/ibmpowervscluster_test.go
@@ -402,6 +402,58 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Should not panic with nil protocol in additionalListener",
+			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1.IBMPowerVSResourceReference{
+						ID: ptr.To("capi-net-id"),
+					},
+					LoadBalancers: []infrav1.VPCLoadBalancerSpec{
+						{
+							Name: "load-balancer-1",
+							AdditionalListeners: []infrav1.AdditionalListenerSpec{
+								{
+									Port:     23,
+									Protocol: nil,
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"listener-selector": "port-23",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newPowervsCluster: &infrav1.IBMPowerVSCluster{
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					ServiceInstanceID: "capi-si-id",
+					Network: infrav1.IBMPowerVSResourceReference{
+						ID: ptr.To("capi-net-id"),
+					},
+					LoadBalancers: []infrav1.VPCLoadBalancerSpec{
+						{
+							Name: "load-balancer-1",
+							AdditionalListeners: []infrav1.AdditionalListenerSpec{
+								{
+									Port:     23,
+									Protocol: nil,
+									Selector: metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"listener-selector": "port-23",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes panic in PowerVSCluster webhook while validating the loadbalancers when the protocol is nil

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix panic in IBMPowerVSCluster webhook validation
```
