### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.25"
   allow-parallel-runners: true
 linters:
   default: none

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.25"
   build-tags:
     - tools
     - e2e

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b' # v20251211-4c812d4cd8
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- bump golang to v1.25.9
- Fix security vulnerabilities

- [Go JOSE Panics in JWE decryption](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/security/dependabot/117)
- [Go JOSE Panics in JWE decryption](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/security/dependabot/116)
- [opentelemetry-go: BSD kenv command not using absolute path enables PATH hijacking](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/security/dependabot/119)
- [opentelemetry-go: BSD kenv command not using absolute path enables PATH hijacking](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/security/dependabot/118)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix security vulnerabilities
```
