### PR TITLE
[release-0.10] Cherry-pick: Infra: Fix Machine GT endpoint management (#2232)

### DIFF
--- a/.github/workflows/validate-yaml-lint.yaml
+++ b/.github/workflows/validate-yaml-lint.yaml
@@ -4,6 +4,6 @@ jobs:
   yamllint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run yamllint make target
         run: make yamllint

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/globaltagging"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/utils"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
@@ -104,8 +105,17 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		core.SetLoggingLevel(core.LevelDebug)
 	}
 
+	auth, err := authenticator.GetAuthenticator()
+	if err != nil {
+		return nil, fmt.Errorf("error failed to create authenticator: %w", err)
+	}
+
 	// Create Global Tagging client.
-	gtOptions := globaltagging.ServiceOptions{}
+	gtOptions := globaltagging.ServiceOptions{
+		GlobalTaggingV1Options: &globaltaggingv1.GlobalTaggingV1Options{
+			Authenticator: auth,
+		},
+	}
 	// Override the Global Tagging endpoint if provided.
 	if gtEndpoint := endpoints.FetchEndpoints(string(endpoints.GlobalTagging), params.ServiceEndpoint); gtEndpoint != "" {
 		gtOptions.URL = gtEndpoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Cherry-picked #2232 (16563093) to the release-0.10 branch.
Similarly to #2704 this fix is required for the [OpenShift Installer](https://github.com/openshift/installer). Some versions depend on cluster-api-provider-ibmcloud v0.10. OpenShift versions are locked to specific go versions and specific cluster-api versions and cannot upgrade the cluster-api-provider-ibmcloud dependency to v0.12 or v0.13 due to this constraint, but IBM Cloud support must be maintained for the installer.
In some OpenShift versions the installer referenced a commit on main instead of the 0.10 release but the cherry-picked 16563093 is the only significant difference between the referenced commit and the 0.10 release branch. In order to be able to reference the 0.10 release branch instead of the random commit the fix needs to be cherry-picked, otherwise the change can introduce a bug in the installer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2231


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cherry-pick fix globaltagging endpoint override for infrastructure machines
```
