### PR TITLE
Backport: Update capi powervs-utils version to include all region/systems types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.25.1
 	github.com/onsi/gomega v1.38.0
-	github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20260417184652-84e90bc52f3d
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db h1:Fy2pmDLfLq2H0N77KD2LpNoCWbDGP0BknZU/odPx2+c=
-github.com/ppc64le-cloud/powervs-utils v0.0.0-20250403153021-219b161805db/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20260417184652-84e90bc52f3d h1:9Nm8jNlxZRsS0rzslr43Tzn6jbRI2YxtYunlIvpLYgI=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20260417184652-84e90bc52f3d/go.mod h1:APQVGiVIdJ3HuzYdQS0319Xsk08Y8S/bbbJYLoDwYvw=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR backports the updated github.com/ppc64le-cloud/powervs-utils module version to the release-0.12 branch.

The previous version bundled in this branch did not include the latest PowerVS region and system‑type mapping logic, which  when using the installer to ctreate clusters in newer IBM Cloud PowerVS regions (e.g., dal14) prevented CAPI recognition of newer system types such as S1122.

By updating to v0.0.0-20260417184652-84e90bc52f3d, this backport ensures that:

- Region lookup logic matches current IBM Cloud PowerVS API behavior
- Newer system types (including S1122) are correctly detected
- Behavior is consistent with the fix already merged in upstream branches
- PowerVS cluster creation works reliably across all supported regions
- This aligns the release-0.12 branch with the fixes applied in MULTIARCH‑5824.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Relates to [MULTIARCH-5824](https://github.com/openshift/installer/pull/10268/changes)
**Special notes for your reviewer**:

- This PR only updates the powervs-utils module version in `go.mod` and `go.sum`.
- This backport is required to ensure PowerVS support parity with newer branches and to prevent failures in regions such as dal14, where sysType s1122 is available. 

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update powervs-utils to v0.0.0-20260417184652-84e90bc52f3d in release-0.12 to include updated PowerVS region mapping and support for newer system types such as S1122.
```
