### PR TITLE
Dynamic sysType support for power VS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # binaries
 bin/
+*.test
 cmd/clusterctl/clusterctl
 cmd/manager/manager
 IBM_Cloud_CLI*

--- a/api/powervs/v1beta3/conditions_consts.go
+++ b/api/powervs/v1beta3/conditions_consts.go
@@ -94,6 +94,9 @@ const (
 	// InstanceWaitingForImageReason surfaces when the instance that is controlled
 	// by the IBMPowerVSMachine waiting for the Power VS image to be available in workspace.
 	InstanceWaitingForImageReason = "WaitingForIBMImage"
+
+	// InvalidMachineConfigurationReason used when the machine configuration is invalid.
+	InvalidMachineConfigurationReason = "InvalidMachineConfiguration"
 )
 
 // IBMPowerVSImage's Ready condition and corresponding reasons.

--- a/api/powervs/v1beta3/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta3/ibmpowervsmachine_types.go
@@ -72,11 +72,15 @@ type IBMPowerVSMachineSpec struct {
 
 	// systemType is the System type used to host the instance.
 	// systemType determines the number of cores and memory that is available.
-	// Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+	// Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
 	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
-	// +kubebuilder:validation:Enum:="s922";"e980";"s1022";"e1050";"e1080";""
+	// + The pattern validation allows any systemType matching PowerVS naming convention (lowercase letter + numbers).
+	// + Dynamic validation against PowerVS API is performed by the controller during reconciliation.
+	// + The controller validates the systemType against current PowerVS datacenter capabilities.
+	// + If the systemType is not supported, the machine will be marked with InvalidMachineConfiguration condition.
+	// +kubebuilder:validation:Pattern=`^[a-z][0-9]+$|^$`
 	// +optional
 	SystemType string `json:"systemType,omitempty"`
 

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -600,13 +600,16 @@ func (s *ClusterScope) ValidateZoneSupportsPER() error {
 		return fmt.Errorf("PowerVS zone is required but not set in the spec")
 	}
 
-	// fetch the datacenter capabilities for zone.
-	datacenterCapabilities, err := s.IBMPowerVSClient.GetDatacenterCapabilities(zone)
+	// Fetch the datacenter details for the specified zone.
+	datacenterDetails, err := s.IBMPowerVSClient.GetDatatcenterDetails(zone)
 	if err != nil {
-		return fmt.Errorf("failed to get datacenter capabilities for zone %q: %w", zone, err)
+		return fmt.Errorf("failed to get datacenter details: %w", err)
+	}
+	if datacenterDetails == nil || datacenterDetails.Capabilities == nil {
+		return fmt.Errorf("failed to get datacenter details for zone: %s", zone)
 	}
 	// check for the PER support in datacenter capabilities.
-	perAvailable, ok := datacenterCapabilities[powerEdgeRouter]
+	perAvailable, ok := datacenterDetails.Capabilities[powerEdgeRouter]
 	if !ok {
 		return fmt.Errorf("%s capability unknown for zone %q", powerEdgeRouter, zone)
 	}

--- a/cloud/scope/powervs/powervs_machine.go
+++ b/cloud/scope/powervs/powervs_machine.go
@@ -25,8 +25,12 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/blang/semver/v4"
 	ignV3Types "github.com/coreos/ignition/v2/config/v3_4/types"
@@ -70,6 +74,20 @@ import (
 )
 
 const cosURLDomain = "cloud-object-storage.appdomain.cloud"
+
+// ConfigurationError represents an error due to invalid machine configuration.
+type ConfigurationError struct {
+	message string
+}
+
+func (e *ConfigurationError) Error() string {
+	return e.message
+}
+
+// NewConfigurationError creates a new ConfigurationError.
+func NewConfigurationError(message string) *ConfigurationError {
+	return &ConfigurationError{message: message}
+}
 
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
 type MachineScopeParams struct {
@@ -250,6 +268,8 @@ func (m *MachineScope) ensureInstanceUnique(instanceName string) (*models.PVMIns
 }
 
 // CreateMachine creates a PowerVS machine.
+//
+//nolint:gocyclo
 func (m *MachineScope) CreateMachine(ctx context.Context) (*models.PVMInstanceReference, error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -269,6 +289,18 @@ func (m *MachineScope) CreateMachine(ctx context.Context) (*models.PVMInstanceRe
 		if con.Type == infrav1.InstanceReadyCondition && con.Status == metav1.ConditionUnknown {
 			return nil, nil
 		}
+	}
+
+	// Validate systemType before creating the machine
+	if machineSpec.SystemType != "" {
+		valid, supportedTypes, err := m.validateSystemType()
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate systemType: %w", err)
+		}
+		if !valid {
+			return nil, NewConfigurationError(fmt.Sprintf("systemType '%s' is not supported. Supported types: %v", machineSpec.SystemType, supportedTypes))
+		}
+		log.Info("SystemType validation passed", "systemType", machineSpec.SystemType, "machine", m.IBMPowerVSMachine.Name, "namespace", m.IBMPowerVSMachine.Namespace)
 	}
 
 	// TODO(karthik-k-n): Fix this
@@ -1164,4 +1196,82 @@ func (m *MachineScope) bucketName() string {
 // bucketRegion returns the region of the COS bucket for the MachineScope.
 func (m *MachineScope) bucketRegion() string {
 	return fetchBucketRegion(m.IBMPowerVSCluster.Spec.CosInstance, m.IBMPowerVSCluster.Spec.VPC)
+}
+
+// zoneCacheEntry holds the supported system types and the exact time they were fetched for a specific zone.
+type zoneCacheEntry struct {
+	supportedTypes []string
+	lastFetch      time.Time
+}
+
+// SystemTypeCache stores supported system types per datacenter to avoid frequent API calls.
+type SystemTypeCache struct {
+	mu       sync.RWMutex
+	zonesMap map[string]zoneCacheEntry
+	ttl      time.Duration
+}
+
+// Global instance of the cache (TTL set to 6 hours).
+var sysCache = &SystemTypeCache{
+	zonesMap: make(map[string]zoneCacheEntry),
+	ttl:      6 * time.Hour,
+}
+
+func (m *MachineScope) validateSystemType() (bool, []string, error) {
+	systemType := m.IBMPowerVSMachine.Spec.SystemType
+
+	if systemType == "" {
+		return false, nil, fmt.Errorf("systemType is not set")
+	}
+
+	zone := m.GetZone()
+
+	// Read from Cache
+	sysCache.mu.RLock()
+	entry, exists := sysCache.zonesMap[zone]
+	isFresh := time.Since(entry.lastFetch) < sysCache.ttl
+	sysCache.mu.RUnlock()
+
+	if exists && isFresh {
+		return slices.Contains(entry.supportedTypes, systemType), entry.supportedTypes, nil
+	}
+
+	// Cache is expired or empty. Fetch from IBM Cloud.
+	sysCache.mu.Lock()
+	defer sysCache.mu.Unlock()
+
+	// Double check inside the lock
+	entry, exists = sysCache.zonesMap[zone]
+	if exists && time.Since(entry.lastFetch) < sysCache.ttl {
+		return slices.Contains(entry.supportedTypes, systemType), entry.supportedTypes, nil
+	}
+
+	// Fetch the specific datacenter capabilities.
+	datacenter, err := m.IBMPowerVSClient.GetDatatcenterDetails(zone)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get datacenter details for zone %s: %w", zone, err)
+	}
+
+	if datacenter == nil || datacenter.CapabilitiesDetails == nil || datacenter.CapabilitiesDetails.SupportedSystems == nil {
+		return false, nil, fmt.Errorf("system capabilities details are missing for zone %s", zone)
+	}
+
+	// Extract the General list.
+	systemTypes := datacenter.CapabilitiesDetails.SupportedSystems.General
+
+	if len(systemTypes) == 0 {
+		return false, nil, fmt.Errorf("no general system types available in zone %s", zone)
+	}
+
+	// Sort once so error messages are always in alphabetical order.
+	sort.Strings(systemTypes)
+
+	// Update the cache for the zone
+	sysCache.zonesMap[zone] = zoneCacheEntry{
+		supportedTypes: systemTypes,
+		lastFetch:      time.Now(),
+	}
+
+	// Validate against the newly refreshed data.
+	return slices.Contains(systemTypes, systemType), systemTypes, nil
 }

--- a/cloud/scope/powervs/powervs_machine_test.go
+++ b/cloud/scope/powervs/powervs_machine_test.go
@@ -1093,7 +1093,7 @@ func TestSetInstanceID(t *testing.T) {
 }
 
 func TestSetFailureReason(t *testing.T) {
-	t.Run("Set failure reason to InvalidConfiguration", func(t *testing.T) {
+	t.Run("Set failure reason to InvalidMachineConfiguration", func(t *testing.T) {
 		g := NewWithT(t)
 		scope := MachineScope{
 			IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{
@@ -2438,6 +2438,251 @@ func TestSetAddresses(t *testing.T) {
 			scope.DHCPIPCacheStore = tc.dhcpCacheStoreFunc()
 			scope.SetAddresses(ctx, tc.pvmInstance)
 			g.Expect(scope.IBMPowerVSMachine.Status.Addresses).To(Equal(tc.expectedNodeAddress))
+		})
+	}
+}
+
+func TestValidateSystemType(t *testing.T) {
+	testCases := []struct {
+		name              string
+		systemType        string
+		zone              string
+		mockSetup         func(*mock.MockPowerVS)
+		setupCache        func()
+		expectedValid     bool
+		expectedSupported []string
+		expectError       bool
+		errorContains     string
+	}{
+		{
+			name:       "Valid system type with fresh cache",
+			systemType: "s922",
+			zone:       "us-south",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				sysCache.zonesMap["us-south"] = zoneCacheEntry{
+					supportedTypes: []string{"e980", "s1022", "s922"},
+					lastFetch:      time.Now(),
+				}
+			},
+			expectedValid:     true,
+			expectedSupported: []string{"e980", "s1022", "s922"},
+			expectError:       false,
+		},
+		{
+			name:       "Invalid system type with fresh cache",
+			systemType: "invalid-type",
+			zone:       "us-south",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				sysCache.zonesMap["us-south"] = zoneCacheEntry{
+					supportedTypes: []string{"e980", "s1022", "s922"},
+					lastFetch:      time.Now(),
+				}
+			},
+			expectedValid:     false,
+			expectedSupported: []string{"e980", "s1022", "s922"},
+			expectError:       false,
+		},
+		{
+			name:       "Empty system type",
+			systemType: "",
+			zone:       "us-south",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "us-south")
+			},
+			expectError:   true,
+			errorContains: "systemType is not set",
+		},
+		{
+			name:       "Valid system type with expired cache - fetches from API",
+			systemType: "s1022",
+			zone:       "us-east",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				// Set expired cache entry
+				sysCache.zonesMap["us-east"] = zoneCacheEntry{
+					supportedTypes: []string{"old-type"},
+					lastFetch:      time.Now().Add(-7 * time.Hour), // Expired (TTL is 6 hours)
+				}
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("us-east").Return(&models.Datacenter{
+					CapabilitiesDetails: &models.CapabilitiesDetails{
+						SupportedSystems: &models.SupportedSystems{
+							General: []string{"e1080", "s1022", "s922"},
+						},
+					},
+				}, nil)
+			},
+			expectedValid:     true,
+			expectedSupported: []string{"e1080", "s1022", "s922"},
+			expectError:       false,
+		},
+		{
+			name:       "Cache miss - fetches from API successfully",
+			systemType: "e1080",
+			zone:       "eu-de",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "eu-de")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("eu-de").Return(&models.Datacenter{
+					CapabilitiesDetails: &models.CapabilitiesDetails{
+						SupportedSystems: &models.SupportedSystems{
+							General: []string{"e1050", "e1080", "s922"},
+						},
+					},
+				}, nil)
+			},
+			expectedValid:     true,
+			expectedSupported: []string{"e1050", "e1080", "s922"},
+			expectError:       false,
+		},
+		{
+			name:       "API returns error",
+			systemType: "s922",
+			zone:       "jp-tok",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "jp-tok")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("jp-tok").Return(nil, errors.New("API error"))
+			},
+			expectError:   true,
+			errorContains: "failed to get datacenter details",
+		},
+		{
+			name:       "API returns nil datacenter",
+			systemType: "s922",
+			zone:       "ca-tor",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "ca-tor")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("ca-tor").Return(nil, nil)
+			},
+			expectError:   true,
+			errorContains: "system capabilities details are missing",
+		},
+		{
+			name:       "API returns datacenter with nil capabilities",
+			systemType: "s922",
+			zone:       "br-sao",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "br-sao")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("br-sao").Return(&models.Datacenter{
+					CapabilitiesDetails: nil,
+				}, nil)
+			},
+			expectError:   true,
+			errorContains: "system capabilities details are missing",
+		},
+		{
+			name:       "API returns empty system types list",
+			systemType: "s922",
+			zone:       "au-syd",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "au-syd")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("au-syd").Return(&models.Datacenter{
+					CapabilitiesDetails: &models.CapabilitiesDetails{
+						SupportedSystems: &models.SupportedSystems{
+							General: []string{},
+						},
+					},
+				}, nil)
+			},
+			expectError:   true,
+			errorContains: "no general system types available",
+		},
+		{
+			name:       "System types are sorted in cache",
+			systemType: "s922",
+			zone:       "test-zone",
+			setupCache: func() {
+				sysCache.mu.Lock()
+				defer sysCache.mu.Unlock()
+				delete(sysCache.zonesMap, "test-zone")
+			},
+			mockSetup: func(m *mock.MockPowerVS) {
+				m.EXPECT().GetDatatcenterDetails("test-zone").Return(&models.Datacenter{
+					CapabilitiesDetails: &models.CapabilitiesDetails{
+						SupportedSystems: &models.SupportedSystems{
+							General: []string{"s922", "e980", "s1022", "e1050"}, // Unsorted
+						},
+					},
+				}, nil)
+			},
+			expectedValid:     true,
+			expectedSupported: []string{"e1050", "e980", "s1022", "s922"}, // Should be sorted
+			expectError:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Setup cache
+			if tc.setupCache != nil {
+				tc.setupCache()
+			}
+
+			// Setup mock
+			mockPowerVSClient := mock.NewMockPowerVS(ctrl)
+			if tc.mockSetup != nil {
+				tc.mockSetup(mockPowerVSClient)
+			}
+
+			// Create machine scope
+			scope := setupPowerVSMachineScope("test-cluster", "test-machine", ptr.To("test-image"), ptr.To("test-network"), true, mockPowerVSClient)
+			scope.IBMPowerVSMachine.Spec.SystemType = tc.systemType
+			scope.SetZone(tc.zone)
+
+			// Execute validation
+			valid, supportedTypes, err := scope.validateSystemType()
+
+			// Assertions
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(valid).To(Equal(tc.expectedValid))
+				g.Expect(supportedTypes).To(Equal(tc.expectedSupported))
+
+				// Verify cache was updated correctly (if not error case)
+				if !tc.expectError && tc.mockSetup != nil {
+					sysCache.mu.RLock()
+					entry, exists := sysCache.zonesMap[tc.zone]
+					sysCache.mu.RUnlock()
+					g.Expect(exists).To(BeTrue())
+					g.Expect(entry.supportedTypes).To(Equal(tc.expectedSupported))
+				}
+			}
 		})
 	}
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -608,16 +608,10 @@ spec:
                 description: |-
                   systemType is the System type used to host the instance.
                   systemType determines the number of cores and memory that is available.
-                  Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+                  Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
                   reasonable default, which is subject to change over time. The current default is s922 which is generally available.
-                enum:
-                - s922
-                - e980
-                - s1022
-                - e1050
-                - e1080
-                - ""
+                pattern: ^[a-z][0-9]+$|^$
                 type: string
               workspace:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
@@ -396,16 +396,10 @@ spec:
                         description: |-
                           systemType is the System type used to host the instance.
                           systemType determines the number of cores and memory that is available.
-                          Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+                          Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
                           reasonable default, which is subject to change over time. The current default is s922 which is generally available.
-                        enum:
-                        - s922
-                        - e980
-                        - s1022
-                        - e1050
-                        - e1080
-                        - ""
+                        pattern: ^[a-z][0-9]+$|^$
                         type: string
                       workspace:
                         description: |-

--- a/internal/controllers/powervs/ibmpowervscluster_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller_test.go
@@ -479,7 +479,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					},
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": false}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": false},
+				}, nil)
 				clusterScope.IBMPowerVSClient = mockPowerVS
 				return clusterScope
 			},
@@ -501,7 +503,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					},
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": true},
+				}, nil)
 				clusterScope.IBMPowerVSClient = mockPowerVS
 				return clusterScope
 			},
@@ -529,7 +533,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					},
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": true},
+				}, nil)
 				clusterScope.IBMPowerVSClient = mockPowerVS
 
 				mockResourceClient := resourceclientmock.NewMockResourceController(gomock.NewController(t))
@@ -575,7 +581,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					},
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": true},
+				}, nil)
 				clusterScope.IBMPowerVSClient = mockPowerVS
 
 				mockResourceClient := resourceclientmock.NewMockResourceController(gomock.NewController(t))
@@ -618,7 +626,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					},
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": true},
+				}, nil)
 				clusterScope.IBMPowerVSClient = mockPowerVS
 
 				mockResourceClient := resourceclientmock.NewMockResourceController(gomock.NewController(t))
@@ -773,7 +783,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					IBMPowerVSCluster: getPowerVSClusterWithSpecAndStatus(),
 				}
 				mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-				mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+				mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+					Capabilities: map[string]bool{"power-edge-router": true},
+				}, nil)
 				mockPowerVS.EXPECT().GetNetworkByID(gomock.Any()).Return(nil, errors.New("error get networkByID"))
 				mockPowerVS.EXPECT().WithClients(gomock.Any())
 				clusterScope.IBMPowerVSClient = mockPowerVS
@@ -2090,7 +2102,9 @@ func getPowerVSClusterWithSpecAndStatus() *infrav1.IBMPowerVSCluster {
 func getMockPowerVS(t *testing.T) *powervsmock.MockPowerVS {
 	t.Helper()
 	mockPowerVS := powervsmock.NewMockPowerVS(gomock.NewController(t))
-	mockPowerVS.EXPECT().GetDatacenterCapabilities(gomock.Any()).Return(map[string]bool{"power-edge-router": true}, nil)
+	mockPowerVS.EXPECT().GetDatatcenterDetails(gomock.Any()).Return(&models.Datacenter{
+		Capabilities: map[string]bool{"power-edge-router": true},
+	}, nil)
 	network := &models.Network{NetworkID: ptr.To("netID")}
 	mockPowerVS.EXPECT().GetNetworkByID(gomock.Any()).Return(network, nil)
 	mockPowerVS.EXPECT().WithClients(gomock.Any())

--- a/internal/controllers/powervs/ibmpowervsmachine_controller.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller.go
@@ -18,6 +18,7 @@ package powervs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -314,11 +315,22 @@ func (r *IBMPowerVSMachineReconciler) reconcileNormal(ctx context.Context, machi
 	machine, err := machineScope.CreateMachine(ctx)
 	if err != nil {
 		log.Error(err, "Unable to create PowerVS machine")
+
+		// Check if this is a configuration error
+		var configErr *powervsscope.ConfigurationError
+		var reason string
+		if errors.As(err, &configErr) {
+			// Use InvalidMachineConfigurationReason for configuration validation errors (v1beta3)
+			reason = infrav1.InvalidMachineConfigurationReason
+		} else {
+			reason = infrav1.InstanceProvisionFailedReason
+		}
+		// For v1beta2, still use InstanceProvisionFailedReason as it doesn't have a specific config error reason
 		deprecatedv1beta1conditions.MarkFalse(machineScope.IBMPowerVSMachine, infrav1.InstanceReadyV1Beta2Condition, infrav1.InstanceProvisionFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
 		conditions.Set(machineScope.IBMPowerVSMachine, metav1.Condition{
 			Type:    infrav1.InstanceReadyCondition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.InstanceProvisionFailedReason,
+			Reason:  reason,
 			Message: err.Error(),
 		})
 		return ctrl.Result{}, fmt.Errorf("failed to create IBMPowerVSMachine: %w", err)

--- a/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
@@ -489,6 +489,55 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 			expectConditions(g, machineScope.IBMPowerVSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceProvisionFailedReason}})
 		})
 
+		t.Run("Should fail reconcile with InvalidMachineConfiguration when systemType is not supported", func(t *testing.T) {
+			g := NewWithT(t)
+			setup(t)
+			t.Cleanup(teardown)
+			var instances = &models.PVMInstances{}
+			secret := newSecret()
+			machine := newMachine()
+			pvsMachine := newIBMPowerVSMachineWithInvalidConfiguration()
+			mockClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(secret).Build()
+			machineScope = &powervsscope.MachineScope{
+				Client: mockClient,
+				Cluster: &clusterv1.Cluster{
+					Status: clusterv1.ClusterStatus{
+						Initialization: clusterv1.ClusterInitializationStatus{
+							InfrastructureProvisioned: ptr.To(true),
+						},
+					},
+				},
+				Machine:           machine,
+				IBMPowerVSMachine: pvsMachine,
+				IBMPowerVSImage: &infrav1.IBMPowerVSImage{
+					Status: infrav1.IBMPowerVSImageStatus{
+						Ready: true,
+					},
+				},
+				IBMPowerVSClient: mockpowervs,
+			}
+			machineScope.SetZone("us-south")
+
+			// Mock GetAllInstance to return no existing instances
+			mockpowervs.EXPECT().GetAllInstance().Return(instances, nil)
+
+			// Mock GetDatatcenterDetails to return valid system types (but not "Invalid")
+			mockpowervs.EXPECT().GetDatatcenterDetails("us-south").Return(&models.Datacenter{
+				CapabilitiesDetails: &models.CapabilitiesDetails{
+					SupportedSystems: &models.SupportedSystems{
+						General: []string{"e980", "s1022", "s922"},
+					},
+				},
+			}, nil)
+
+			result, err := reconciler.reconcileNormal(ctx, machineScope)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(result.RequeueAfter).To(BeZero())
+			g.Expect(machineScope.IBMPowerVSMachine.Finalizers).To(ContainElement(infrav1.IBMPowerVSMachineFinalizer))
+			// Check v1beta3 condition for InvalidMachineConfiguration
+			expectV1Beta3Conditions(g, machineScope.IBMPowerVSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InvalidMachineConfigurationReason}})
+		})
+
 		t.Run("Should fail reconcile if creation of the load balancer pool member is unsuccessful", func(t *testing.T) {
 			g := NewWithT(t)
 			setup(t)
@@ -936,6 +985,23 @@ func expectConditions(g *WithT, m *infrav1.IBMPowerVSMachine, expected []conditi
 	}
 }
 
+func expectV1Beta3Conditions(g *WithT, m *infrav1.IBMPowerVSMachine, expected []conditionAssertion) {
+	g.Expect(len(m.Status.Conditions)).To(BeNumerically(">=", len(expected)))
+	for _, c := range expected {
+		var actual *metav1.Condition
+		for i := range m.Status.Conditions {
+			if m.Status.Conditions[i].Type == string(c.conditionType) {
+				actual = &m.Status.Conditions[i]
+				break
+			}
+		}
+		g.Expect(actual).To(Not(BeNil()), "condition %s not found", c.conditionType)
+		g.Expect(actual.Type).To(Equal(string(c.conditionType)))
+		g.Expect(actual.Status).To(Equal(metav1.ConditionStatus(c.status)))
+		g.Expect(actual.Reason).To(Equal(c.reason))
+	}
+}
+
 func createObject(g *WithT, obj client.Object, namespace string) {
 	if obj.DeepCopyObject() != nil {
 		obj.SetNamespace(namespace)
@@ -980,6 +1046,26 @@ func newIBMPowerVSMachine() *infrav1.IBMPowerVSMachine {
 				ID: "capi-net-id",
 			},
 			Workspace: infrav1.ResourceIdentifier{ID: "service-instance-1"},
+		},
+	}
+}
+
+func newIBMPowerVSMachineWithInvalidConfiguration() *infrav1.IBMPowerVSMachine {
+	return &infrav1.IBMPowerVSMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       *ptr.To("capi-test-machine-invalid-systype"),
+			Finalizers: []string{infrav1.IBMPowerVSMachineFinalizer},
+		},
+		Spec: infrav1.IBMPowerVSMachineSpec{
+			MemoryGiB:  8,
+			Processors: intstr.FromString("0.5"),
+			Image: &infrav1.IBMPowerVSResourceReference{
+				ID: ptr.To("capi-image-id-invalid-systype"),
+			},
+			SystemType: "Invalid",
+			Network: infrav1.ResourceIdentifier{
+				ID: "capi-net-id-invalid-systype",
+			},
 		},
 	}
 }

--- a/pkg/cloud/services/powervs/mock/powervs_generated.go
+++ b/pkg/cloud/services/powervs/mock/powervs_generated.go
@@ -247,19 +247,19 @@ func (mr *MockPowerVSMockRecorder) GetDHCPServer(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPServer", reflect.TypeOf((*MockPowerVS)(nil).GetDHCPServer), id)
 }
 
-// GetDatacenterCapabilities mocks base method.
-func (m *MockPowerVS) GetDatacenterCapabilities(zone string) (map[string]bool, error) {
+// GetDatatcenterDetails mocks base method.
+func (m *MockPowerVS) GetDatatcenterDetails(zone string) (*models.Datacenter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDatacenterCapabilities", zone)
-	ret0, _ := ret[0].(map[string]bool)
+	ret := m.ctrl.Call(m, "GetDatatcenterDetails", zone)
+	ret0, _ := ret[0].(*models.Datacenter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDatacenterCapabilities indicates an expected call of GetDatacenterCapabilities.
-func (mr *MockPowerVSMockRecorder) GetDatacenterCapabilities(zone any) *gomock.Call {
+// GetDatatcenterDetails indicates an expected call of GetDatatcenterDetails.
+func (mr *MockPowerVSMockRecorder) GetDatatcenterDetails(zone any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenterCapabilities", reflect.TypeOf((*MockPowerVS)(nil).GetDatacenterCapabilities), zone)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatatcenterDetails", reflect.TypeOf((*MockPowerVS)(nil).GetDatatcenterDetails), zone)
 }
 
 // GetImage mocks base method.

--- a/pkg/cloud/services/powervs/powervs.go
+++ b/pkg/cloud/services/powervs/powervs.go
@@ -44,5 +44,5 @@ type PowerVS interface {
 	DeleteDHCPServer(id string) error
 	WithClients(options ServiceOptions) *Service
 	GetNetworkByName(networkName string) (*models.NetworkReference, error)
-	GetDatacenterCapabilities(zone string) (map[string]bool, error)
+	GetDatatcenterDetails(zone string) (*models.Datacenter, error)
 }

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -18,11 +18,9 @@ package powervs
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/datacenters"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 
@@ -34,12 +32,13 @@ var _ PowerVS = &Service{}
 
 // Service holds the PowerVS Service specific information.
 type Service struct {
-	session        *ibmpisession.IBMPISession
-	instanceClient *instance.IBMPIInstanceClient
-	networkClient  *instance.IBMPINetworkClient
-	imageClient    *instance.IBMPIImageClient
-	jobClient      *instance.IBMPIJobClient
-	dhcpClient     *instance.IBMPIDhcpClient
+	session          *ibmpisession.IBMPISession
+	instanceClient   *instance.IBMPIInstanceClient
+	networkClient    *instance.IBMPINetworkClient
+	imageClient      *instance.IBMPIImageClient
+	jobClient        *instance.IBMPIJobClient
+	dhcpClient       *instance.IBMPIDhcpClient
+	dataCenterClient *instance.IBMPIDatacentersClient
 }
 
 // ServiceOptions holds the PowerVS Service Options specific information.
@@ -84,6 +83,7 @@ func (s *Service) WithClients(options ServiceOptions) *Service {
 	s.imageClient = instance.NewIBMPIImageClient(ctx, s.session, options.CloudInstanceID)
 	s.jobClient = instance.NewIBMPIJobClient(ctx, s.session, options.CloudInstanceID)
 	s.dhcpClient = instance.NewIBMPIDhcpClient(ctx, s.session, options.CloudInstanceID)
+	s.dataCenterClient = instance.NewIBMPIDatacenterClient(ctx, s.session, options.CloudInstanceID)
 	return s
 }
 
@@ -193,16 +193,7 @@ func (s *Service) GetNetworkByName(networkName string) (*models.NetworkReference
 	return network, nil
 }
 
-// GetDatacenterCapabilities fetches the datacenter capabilities for the given zone.
-func (s *Service) GetDatacenterCapabilities(zone string) (map[string]bool, error) {
-	// though the function name is WithDatacenterRegion it takes zone as parameter
-	params := datacenters.NewV1DatacentersGetParamsWithContext(context.TODO()).WithDatacenterRegion(zone)
-	datacenter, err := s.session.Power.Datacenters.V1DatacentersGet(params)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get datacenter details for zone: %s err:%w", zone, err)
-	}
-	if datacenter == nil || datacenter.Payload == nil || datacenter.Payload.Capabilities == nil {
-		return nil, fmt.Errorf("failed to get datacenter capabilities for zone: %s", zone)
-	}
-	return datacenter.Payload.Capabilities, nil
+// GetDatatcenterDetails fetches the datacenter capabilities for the given zone.
+func (s *Service) GetDatatcenterDetails(zone string) (*models.Datacenter, error) {
+	return s.dataCenterClient.Get(zone)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Implements dynamic validation for PowerVS systemType field following CAPI architectural patterns. This replaces the previous webhook-based hardcoded validation with runtime validation against the PowerVS API, enabling automatic support for new systemTypes without code changes. Before these additions the design of CAPI required continuous maintenance when a new sysType is made available (i.e s1122).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Key Changes:

- Moved systemType validation from webhook (hardcoded list) to controller (dynamic API validation)
- Added validateSystemType() function in [controllers/validation.go](vscode-webview://0ir53id75arbuqj7kd4tipg5tdu9iaq6hhjuhvgs5kridndk0hdj/controllers/validation.go) that queries PowerVS API for supported types
- Updated webhook to only validate format pattern (^[a-z][0-9]+$), delegating reality checks to controller
- Added InvalidConfigurationReason condition for clear error reporting
- Exposed GetPISession() method in PowerVS service interface for API access

Benefits:

- Automatically supports new systemTypes added by PowerVS without requiring code updates
- Follows CAPI best practices: CRDs define shape, webhooks protect invariants, controllers enforce reality
- Provides clear error messages listing all supported systemTypes when validation fails
- Prevents VM creation with invalid configurations

Note: A separate PR is also open for these changes to backport into v0.12.0

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
- no change to image version

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
PowerVS systemType validation is now dynamic, automatically supporting new system types added by IBM Cloud PowerVS without requiring provider updates. Validation moved from webhook (hardcoded list) to controller (API-based), following CAPI architectural patterns.
```
