### PR TITLE
Bump PowerVS image to CentOS Stream 10 with Kubernetes v1.34.7

### DIFF
--- a/docs/book/src/machine-images/powervs.md
+++ b/docs/book/src/machine-images/powervs.md
@@ -3,6 +3,7 @@
 
 | Region   | Bucket           | Object                                                          | Kubernetes Version |
 |----------|------------------|-----------------------------------------------------------------|--------------------|
+| us-south | power-oss-bucket | [capibm-powervs-centos-streams10-1-34-7.ova.gz][streams10-1-34-7] | 1.34.7             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-33-1.ova.gz][streams9-1-33-1] | 1.33.1             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-32-3.ova.gz][streams9-1-32-3] | 1.32.3             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-31-0.ova.gz][streams9-1-31-0] | 1.31.0             |
@@ -17,6 +18,7 @@
 
 > **Note:** These images are built using the [image-builder][image-builder] tool and more information can be found [here](../developer/build-images.md#powervs)
 
+[streams10-1-34-7]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams10-1-34-7-150500-1-1-1778144615.ova.gz
 [streams9-1-33-1]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-33-1-1751454774.ova.gz
 [streams9-1-32-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-32-3-1747820578.ova.gz
 [streams9-1-31-0]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-31-0-1737533452.ova.gz

--- a/docs/book/src/topics/powervs/creating-a-cluster.md
+++ b/docs/book/src/topics/powervs/creating-a-cluster.md
@@ -47,14 +47,14 @@ following the steps below.
     IBMPOWERVS_VIP="192.168.167.6" \
     IBMPOWERVS_VIP_EXTERNAL="163.68.65.6" \
     IBMPOWERVS_VIP_CIDR="29" \
-    IBMPOWERVS_IMAGE_NAME="capibm-powervs-centos-streams8-1-26-2" \
+    IBMPOWERVS_IMAGE_NAME="capibm-powervs-centos-streams10-1-34-7" \
     IBMPOWERVS_SERVICE_INSTANCE_ID="3229a94c-af54-4212-bf60-6202b6fd0a07" \
     IBMPOWERVS_NETWORK_NAME="capi-test" \
     IBMACCOUNT_ID="ibm-accountid" \
     IBMPOWERVS_REGION="osa" \
     IBMPOWERVS_ZONE="osa21" \
     BASE64_API_KEY=$(echo -n $IBMCLOUD_API_KEY | base64) \
-    clusterctl generate cluster ibm-powervs-1 --kubernetes-version v1.26.2 \
+    clusterctl generate cluster ibm-powervs-1 --kubernetes-version v1.34.7 \
     --target-namespace default \
     --control-plane-machine-count=3 \
     --worker-machine-count=1 \
@@ -106,15 +106,15 @@ following the steps below.
     ```console
     ~ kubectl get kubeadmcontrolplane
     NAME                       INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-    ibm-powervs-1-control-plane    true          true                   v1.26.2   1          1       1
+    ibm-powervs-1-control-plane    true          true                   v1.34.7   1          1       1
     ```
 
     Machines
     ```console
     ~ kubectl get machines
-    ibm-powervs-1-control-plane-vzz47     ibmpowervs://ibm-powervs-1/ibm-powervs-1-control-plane-rg6xv   Running        v1.26.2
-    ibm-powervs-1-md-0-5444cfcbcd-6gg5z   ibmpowervs://ibm-powervs-1/ibm-powervs-1-md-0-dbxb7            Running        v1.26.2
-    ibm-powervs-1-md-0-5444cfcbcd-7kr9x   ibmpowervs://ibm-powervs-1/ibm-powervs-1-md-0-k7blr            Running        v1.26.2
+    ibm-powervs-1-control-plane-vzz47     ibmpowervs://ibm-powervs-1/ibm-powervs-1-control-plane-rg6xv   Running        v1.34.7
+    ibm-powervs-1-md-0-5444cfcbcd-6gg5z   ibmpowervs://ibm-powervs-1/ibm-powervs-1-md-0-dbxb7            Running        v1.34.7
+    ibm-powervs-1-md-0-5444cfcbcd-7kr9x   ibmpowervs://ibm-powervs-1/ibm-powervs-1-md-0-k7blr            Running        v1.34.7
     ```
 
 4. Deploy Container Network Interface (CNI)
@@ -131,9 +131,9 @@ following the steps below.
     ```console
     ~ kubectl get nodes
     NAME                             STATUS   ROLES    AGE   VERSION
-    ibm-powervs-1-control-plane-rg6xv    Ready    master   41h   v1.26.2
-    ibm-powervs-1-md-0-4dc5c             Ready    <none>   41h   v1.26.2
-    ibm-powervs-1-md-0-dbxb7             Ready    <none>   20h   v1.26.2
+    ibm-powervs-1-control-plane-rg6xv    Ready    master   41h   v1.34.7
+    ibm-powervs-1-md-0-4dc5c             Ready    <none>   41h   v1.34.7
+    ibm-powervs-1-md-0-dbxb7             Ready    <none>   20h   v1.34.7
 
 ### Deploy a PowerVS cluster with infrastructure creation
 
@@ -174,14 +174,14 @@ following the steps below.
   IBMPOWERVS_VIP="192.168.167.6" \
   IBMPOWERVS_VIP_EXTERNAL="163.68.65.6" \
   IBMPOWERVS_VIP_CIDR="29" \
-  IBMPOWERVS_IMAGE_NAME="capibm-powervs-centos-streams8-1-26-2" \
+  IBMPOWERVS_IMAGE_NAME="capibm-powervs-centos-streams10-1-34-7" \
   IBMPOWERVS_SERVICE_INSTANCE_ID="3229a94c-af54-4212-bf60-6202b6fd0a07" \
   IBMPOWERVS_NETWORK_NAME="capi-test" \
   IBMACCOUNT_ID="ibm-accountid" \
   IBMPOWERVS_REGION="osa" \
   IBMPOWERVS_ZONE="osa21" \
   BASE64_API_KEY=$(echo -n $IBMCLOUD_API_KEY | base64) \
-  clusterctl generate cluster ibm-powervs-1 --kubernetes-version v1.26.2 \
+  clusterctl generate cluster ibm-powervs-1 --kubernetes-version v1.34.7 \
   --target-namespace default \
   --control-plane-machine-count=3 \
   --worker-machine-count=1 \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -124,7 +124,7 @@ init_network_powervs(){
 prerequisites_powervs(){
     # Assigning PowerVS variables
     export IBMPOWERVS_SSHKEY_NAME=${IBMPOWERVS_SSHKEY_NAME:-"powercloud-bot-key"}
-    export IBMPOWERVS_IMAGE_NAME=${IBMPOWERVS_IMAGE_NAME:-"capibm-powervs-centos-streams9-1-33-1"}
+    export IBMPOWERVS_IMAGE_NAME=${IBMPOWERVS_IMAGE_NAME:-"capibm-powervs-centos-streams10-1-34-7"}
     export IBMPOWERVS_SERVICE_INSTANCE_ID=${BOSKOS_SERVICE_INSTANCE_ID:-"d53da3bf-1f4a-42fa-9735-acf16b1a05cd"}
     export IBMPOWERVS_NETWORK_NAME="capi-net-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head --bytes 5)"
     export IBMPOWERVS_REGION=${BOSKOS_REGION:-"osa"}

--- a/test/e2e/config/ibmcloud-e2e-powervs.yaml
+++ b/test/e2e/config/ibmcloud-e2e-powervs.yaml
@@ -42,7 +42,7 @@ providers:
         targetName: "cluster-template-powervs-md-remediation.yaml"
 
 variables:
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.33.1}"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.34.7}"
   # Below variable should be set based on the targeted environment
   SERVICE_ENDPOINT: "${SERVICE_ENDPOINT:-}"
   CUSTOM_KIND_NODE_IMAGE: ${CUSTOM_KIND_NODE_IMAGE:-}""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Updates the default PowerVS machine image from CentOS Stream 9 + Kubernetes v1.33.1
to CentOS Stream 10 + Kubernetes v1.34.7.

The new image was built using image-builder with the following changes:
- Added CentOS Stream 10 support to image-builder (centos-10.json + Makefile)
- Fixed lsvpd dependency conflict on CentOS 10
- Fixed sysprep ifcfg compatibility for CentOS 10 (network-scripts removed)
- Kubernetes RPM version updated to OBS-style versioning (1.34.7-150500.1.1)

Image validated on PowerVS osa21 - node reached Ready state running v1.34.7
on CentOS Stream 10 (ppc64le) with containerd 2.2.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
part of https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2567

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
PR to add Add [CentOS Stream 10 support for PowerVS image builds](https://github.com/kubernetes-sigs/image-builder/pull/2006/)