### PR TITLE
✨ Add Topology field into IBMPowerVSCluster

### DIFF
--- a/api/powervs/v1beta2/conversion.go
+++ b/api/powervs/v1beta2/conversion.go
@@ -213,6 +213,22 @@ func (src *IBMPowerVSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	if !reflect.DeepEqual(initialization, infrav1.IBMPowerVSClusterInitializationStatus{}) {
 		dst.Status.Initialization = initialization
 	}
+
+	// If the old v1beta2 annotation is true, map it to LoadBalancer. Otherwise, VirtualIP.
+	if val, exists := src.Annotations["powervs.cluster.x-k8s.io/create-infra"]; exists && val == "true" {
+		dst.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
+	} else {
+		dst.Spec.Topology = infrav1.PowerVSVirtualIPTopology
+	}
+
+	// Clean up the annotation in v1beta3 so we don't have duplicated sources of truth
+	if dst.Annotations != nil {
+		delete(dst.Annotations, "powervs.cluster.x-k8s.io/create-infra")
+		if len(dst.Annotations) == 0 {
+			dst.Annotations = nil
+		}
+	}
+
 	return nil
 }
 
@@ -221,6 +237,18 @@ func (dst *IBMPowerVSCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1beta3_IBMPowerVSCluster_To_v1beta2_IBMPowerVSCluster(src, dst, nil); err != nil {
 		return err
 	}
+
+	// Map the v1beta3 Topology explicit enum back to the v1beta2 annotation
+	if src.Spec.Topology == infrav1.PowerVSLoadBalancerTopology {
+		if dst.Annotations == nil {
+			dst.Annotations = make(map[string]string)
+		}
+		dst.Annotations["powervs.cluster.x-k8s.io/create-infra"] = "true"
+	} else if dst.Annotations != nil {
+		// For VirtualIP, we ensure the annotation is removed
+		delete(dst.Annotations, "powervs.cluster.x-k8s.io/create-infra")
+	}
+
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}

--- a/api/powervs/v1beta2/conversion_test.go
+++ b/api/powervs/v1beta2/conversion_test.go
@@ -94,6 +94,12 @@ func hubIBMPowerVSClusterStatus(in *infrav1.IBMPowerVSClusterStatus, c randfill.
 
 func hubIBMPowerVSClusterSpec(in *infrav1.IBMPowerVSClusterSpec, c randfill.Continue) {
 	c.FillNoCustom(in)
+
+	// Enforce safe Enum values for Topology so round-trips match
+	if in.Topology != infrav1.PowerVSLoadBalancerTopology {
+		in.Topology = infrav1.PowerVSVirtualIPTopology
+	}
+
 	// Enforce the SourceType union constraints for v1beta3 Workspace so round-trip tests pass
 	switch in.Workspace.Type {
 	case infrav1.SourceTypeReference:

--- a/api/powervs/v1beta2/zz_generated.conversion.go
+++ b/api/powervs/v1beta2/zz_generated.conversion.go
@@ -691,6 +691,7 @@ func autoConvert_v1beta3_IBMPowerVSClusterSpec_To_v1beta2_IBMPowerVSClusterSpec(
 	if err := Convert_v1beta3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
+	// WARNING: in.Topology requires manual conversion: does not exist in peer-type
 	// WARNING: in.Workspace requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta3_IBMPowerVSResourceReference_To_v1beta2_IBMPowerVSResourceReference(&in.Network, &out.Network, s); err != nil {
 		return err

--- a/api/powervs/v1beta3/ibmpowervscluster_types.go
+++ b/api/powervs/v1beta3/ibmpowervscluster_types.go
@@ -22,6 +22,17 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
+// ClusterTopology defines the external access architecture of the cluster.
+type ClusterTopology string
+
+const (
+	// PowerVSVirtualIPTopology uses a pure PowerVS network and Virtual IP for access.
+	PowerVSVirtualIPTopology ClusterTopology = "VirtualIP"
+
+	// PowerVSLoadBalancerTopology integrates the PowerVS workspace with an IBM Cloud VPC and LoadBalancer.
+	PowerVSLoadBalancerTopology ClusterTopology = "LoadBalancer"
+)
+
 const (
 	// IBMPowerVSClusterFinalizer allows IBMPowerVSClusterReconciler to clean up resources associated with IBMPowerVSCluster before
 	// removing it from the apiserver.
@@ -48,6 +59,11 @@ type IBMPowerVSClusterSpec struct {
 	// controlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty,omitzero"`
+
+	// Topology defines the architectural mode for external cluster access.
+	// +required
+	// +kubebuilder:validation:Enum=VirtualIP;LoadBalancer
+	Topology ClusterTopology `json:"topology"`
 
 	// workspace specifies how the PowerVS workspace is sourced.
 	// A PowerVS workspace is a container for PowerVS resources in a specific zone.

--- a/cloud/scope/powervs/powervs_cluster.go
+++ b/cloud/scope/powervs/powervs_cluster.go
@@ -156,8 +156,8 @@ func NewPowerVSClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		return nil, err
 	}
 
-	// if powervs.cluster.x-k8s.io/create-infra=true annotation is not set, create only powerVSClient.
-	if !CheckCreateInfraAnnotation(*params.IBMPowerVSCluster) {
+	// If the topology is not explicitly set to LoadBalancer, we only need the PowerVS client
+	if params.IBMPowerVSCluster.Spec.Topology != infrav1.PowerVSLoadBalancerTopology {
 		return &ClusterScope{
 			Client:            params.Client,
 			patchHelper:       helper,

--- a/cloud/scope/powervs/util.go
+++ b/cloud/scope/powervs/util.go
@@ -19,7 +19,6 @@ package powervs
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -39,23 +38,6 @@ func GetClusterByName(ctx context.Context, c client.Client, namespace, name stri
 	}
 
 	return cluster, nil
-}
-
-// CheckCreateInfraAnnotation checks for annotations set on IBMPowerVSCluster object to determine cluster creation workflow.
-func CheckCreateInfraAnnotation(cluster infrav1.IBMPowerVSCluster) bool {
-	annotations := cluster.GetAnnotations()
-	if len(annotations) == 0 {
-		return false
-	}
-	value, found := annotations[infrav1.CreateInfrastructureAnnotation]
-	if !found {
-		return false
-	}
-	createInfra, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-	return createInfra
 }
 
 func fetchBucketRegion(cos *infrav1.CosInstance, vpc *infrav1.VPCResourceReference) string {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -1625,6 +1625,13 @@ spec:
                     minLength: 1
                     type: string
                 type: object
+              topology:
+                description: Topology defines the architectural mode for external
+                  cluster access.
+                enum:
+                - VirtualIP
+                - LoadBalancer
+                type: string
               transitGateway:
                 description: |-
                   transitGateway contains information about IBM Cloud TransitGateway
@@ -2099,6 +2106,7 @@ spec:
                 type: string
             required:
             - network
+            - topology
             type: object
           status:
             description: status defines the observed state of IBMPowerVSCluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -1384,6 +1384,13 @@ spec:
                             minLength: 1
                             type: string
                         type: object
+                      topology:
+                        description: Topology defines the architectural mode for external
+                          cluster access.
+                        enum:
+                        - VirtualIP
+                        - LoadBalancer
+                        type: string
                       transitGateway:
                         description: |-
                           transitGateway contains information about IBM Cloud TransitGateway
@@ -1867,6 +1874,7 @@ spec:
                         type: string
                     required:
                     - network
+                    - topology
                     type: object
                 required:
                 - spec

--- a/docs/proposal/20260421-powervs-v1beta3-api-modernization.md
+++ b/docs/proposal/20260421-powervs-v1beta3-api-modernization.md
@@ -125,7 +125,7 @@ if cluster.Status.VPC.ID != "" {
 **Solution**: We are removing the annotation and "implicit mode switching." We introduce a top-level Topology enum in the Spec to explicitly define the external access architecture. We pair this with CEL cross-field validation to strictly enforce IBM Cloud service boundaries.
 Go
 ```go
-// +kubebuilder:validation:Enum=VIP;LoadBalancer
+// +kubebuilder:validation:Enum=VirtualIP;LoadBalancer
 // Topology defines the architectural mode for external cluster access.
 Topology ClusterTopology `json:"topology"`
 ```

--- a/internal/controllers/powervs/ibmpowervscluster_controller.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller.go
@@ -163,12 +163,17 @@ func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) { //nolint:gocyclo
 	log := ctrl.LoggerFrom(ctx)
-	// check for annotation set for cluster resource and decide on proceeding with infra creation.
-	// do not proceed further if "powervs.cluster.x-k8s.io/create-infra=true" annotation is not set.
-	if !powervsscope.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
-		log.V(3).Info("IBMPowerVSCluster has no create infrastructure annotation, setting cluster status to ready")
+
+	// 1. If it's VirtualIP, do the minimal logic and return early.
+	if clusterScope.IBMPowerVSCluster.Spec.Topology == infrav1.PowerVSVirtualIPTopology {
+		log.Info("Reconciling in VirtualIP topology mode")
 		clusterScope.IBMPowerVSCluster.Status.Initialization.Provisioned = ptr.To(true)
 		return ctrl.Result{}, nil
+	}
+
+	// 2. Otherwise, assume LoadBalancer and proceed with the heavy VPC/TG logic.
+	if clusterScope.IBMPowerVSCluster.Spec.Topology != infrav1.PowerVSLoadBalancerTopology {
+		return ctrl.Result{}, fmt.Errorf("unknown topology: %q", clusterScope.IBMPowerVSCluster.Spec.Topology)
 	}
 
 	// validate PER availability for the PowerVS zone, proceed further only if PowerVS zone support PER.
@@ -525,9 +530,9 @@ func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clust
 		return result, err
 	}
 
-	// check for annotation set for cluster resource and decide on proceeding with infra deletion.
-	if !powervsscope.CheckCreateInfraAnnotation(*clusterScope.IBMPowerVSCluster) {
-		log.Info("IBMPowerVSCluster has no infra annotation, removing finalizer")
+	// Check the cluster topology to decide if we need to proceed with VPC/TransitGateway infra deletion.
+	if clusterScope.IBMPowerVSCluster.Spec.Topology != infrav1.PowerVSLoadBalancerTopology {
+		log.Info("IBMPowerVSCluster is not in LoadBalancer topology mode, skipping advanced infra deletion and removing finalizer")
 		controllerutil.RemoveFinalizer(cluster, infrav1.IBMPowerVSClusterFinalizer)
 		return ctrl.Result{}, nil
 	}
@@ -774,8 +779,9 @@ func (c *clusterDescendants) filterOwnedDescendants(cluster *infrav1.IBMPowerVSC
 
 // patchIBMPowerVSCluster updates the IBMPowerVSCluster and its status on the API server.
 func patchIBMPowerVSCluster(ctx context.Context, patchHelper *patch.Helper, ibmPowerVSCluster *infrav1.IBMPowerVSCluster) error {
-	// we don't need to set any conditions for IBMPowerVSCluster without create infra annotation.
-	if !powervsscope.CheckCreateInfraAnnotation(*ibmPowerVSCluster) {
+	// We don't need to set VPC/LoadBalancer conditions for an IBMPowerVSCluster
+	// unless it is explicitly using the LoadBalancer topology.
+	if ibmPowerVSCluster.Spec.Topology != infrav1.PowerVSLoadBalancerTopology {
 		if err := patchHelper.Patch(ctx, ibmPowerVSCluster); err != nil {
 			return fmt.Errorf("error patching IBMPowerVSCluster: %w", err)
 		}

--- a/internal/controllers/powervs/ibmpowervscluster_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller_test.go
@@ -70,6 +70,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 				GenerateName: "powervs-test-",
 			},
 			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
 				Workspace: infrav1.WorkspaceSource{
 					Type: infrav1.SourceTypeReference,
 					Reference: infrav1.ResourceIdentifier{
@@ -119,6 +120,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						UID:        "1",
 					}}},
 			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
 				Workspace: infrav1.WorkspaceSource{
 					Type: infrav1.SourceTypeReference,
 					Reference: infrav1.ResourceIdentifier{
@@ -156,6 +158,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 				Finalizers:   []string{infrav1.IBMPowerVSClusterFinalizer},
 			},
 			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
 				Workspace: infrav1.WorkspaceSource{
 					Type: infrav1.SourceTypeReference,
 					Reference: infrav1.ResourceIdentifier{
@@ -218,6 +221,7 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						UID:        "1",
 					}}},
 			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
 				Workspace: infrav1.WorkspaceSource{
 					Type: infrav1.SourceTypeReference,
 					Reference: infrav1.ResourceIdentifier{
@@ -259,7 +263,10 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						Name:       "capi-test",
 						UID:        "1",
 					}}},
-			Spec: infrav1.IBMPowerVSClusterSpec{Zone: ptr.To("zone")},
+			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
+				Zone:     ptr.To("zone"),
+			},
 		}
 
 		ownerCluster := &clusterv1.Cluster{
@@ -323,7 +330,10 @@ func TestIBMPowerVSClusterReconciler_Reconcile(t *testing.T) {
 						Name:       "capi-test",
 						UID:        "1",
 					}}},
-			Spec: infrav1.IBMPowerVSClusterSpec{Zone: ptr.To("zone")},
+			Spec: infrav1.IBMPowerVSClusterSpec{
+				Topology: infrav1.PowerVSVirtualIPTopology,
+				Zone:     ptr.To("zone"),
+			},
 		}
 
 		ownerCluster := &clusterv1.Cluster{
@@ -391,6 +401,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Finalizers: []string{infrav1.IBMPowerVSClusterFinalizer},
 						},
+						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
+						},
 					},
 				}
 			},
@@ -403,6 +416,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						ObjectMeta: metav1.ObjectMeta{
 							Finalizers: []string{infrav1.IBMPowerVSClusterFinalizer},
+						},
+						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 						},
 					},
 				}
@@ -419,7 +435,8 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 						},
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							Zone: ptr.To("dal10"),
+							Topology: infrav1.PowerVSLoadBalancerTopology,
+							Zone:     ptr.To("dal10"),
 						},
 					},
 				}
@@ -440,7 +457,8 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 						},
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							Zone: ptr.To("dal10"),
+							Topology: infrav1.PowerVSLoadBalancerTopology,
+							Zone:     ptr.To("dal10"),
 						},
 					},
 				}
@@ -461,7 +479,8 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 						},
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							Zone: ptr.To("dal10"),
+							Topology: infrav1.PowerVSLoadBalancerTopology,
+							Zone:     ptr.To("dal10"),
 							ResourceGroup: &infrav1.IBMPowerVSResourceReference{
 								ID: ptr.To("rg-id"),
 							},
@@ -503,7 +522,8 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 						},
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							Zone: ptr.To("dal10"),
+							Topology: infrav1.PowerVSLoadBalancerTopology,
+							Zone:     ptr.To("dal10"),
 							ResourceGroup: &infrav1.IBMPowerVSResourceReference{
 								ID: ptr.To("rg-id"),
 							},
@@ -548,7 +568,8 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 						},
 						Spec: infrav1.IBMPowerVSClusterSpec{
-							Zone: ptr.To("dal10"),
+							Topology: infrav1.PowerVSLoadBalancerTopology,
+							Zone:     ptr.To("dal10"),
 							ResourceGroup: &infrav1.IBMPowerVSResourceReference{
 								ID: ptr.To("rg-id"),
 							},
@@ -846,7 +867,9 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 							UID:        "1",
 						}},
 				},
-				Spec: infrav1.IBMPowerVSClusterSpec{},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
+				},
 				Status: infrav1.IBMPowerVSClusterStatus{
 					Workspace: infrav1.ResourceReferenceV1Beta3{
 						ID: "serviceInstanceID",
@@ -870,6 +893,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 						Name: "capi-powervs-cluster",
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
+						Topology: infrav1.PowerVSVirtualIPTopology,
 						Workspace: infrav1.WorkspaceSource{
 							Type: infrav1.SourceTypeReference,
 							Reference: infrav1.ResourceIdentifier{
@@ -897,6 +921,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 						Name: "capi-powervs-cluster",
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
+						Topology: infrav1.PowerVSVirtualIPTopology,
 						Workspace: infrav1.WorkspaceSource{
 							Type: infrav1.SourceTypeReference,
 							Reference: infrav1.ResourceIdentifier{
@@ -964,6 +989,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete TransitGateway returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.TransitGateway = &infrav1.TransitGatewayStatus{
 			ID:                ptr.To("transitgatewayID"),
 			ControllerCreated: ptr.To(true),
@@ -1000,6 +1026,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete TransitGateway returns requeue as true", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.TransitGateway = &infrav1.TransitGatewayStatus{
 			ID:                ptr.To("transitgatewayID"),
 			ControllerCreated: ptr.To(true),
@@ -1034,6 +1061,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete LoadBalancer returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.LoadBalancers = map[string]infrav1.VPCLoadBalancerStatus{
 			"lb": {
 				ID:                ptr.To("lb-id"),
@@ -1063,6 +1091,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete LoadBalancer returns requeue as true", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.LoadBalancers = map[string]infrav1.VPCLoadBalancerStatus{
 			"lb": {
 				ID:                ptr.To("lb-id"),
@@ -1091,6 +1120,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete VPC security group returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.VPCSecurityGroups = map[string]infrav1.VPCSecurityGroupStatus{
 			"sc": {
 				ID:                ptr.To("sc-id"),
@@ -1119,6 +1149,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete VPC subnet returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.VPCSubnet = map[string]infrav1.ResourceReference{
 			"subent1": {
 				ID:                ptr.To("subent1"),
@@ -1144,6 +1175,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete VPC subnet returns requeue as true", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.VPCSubnet = map[string]infrav1.ResourceReference{
 			"subent1": {
 				ID:                ptr.To("subent1"),
@@ -1167,6 +1199,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete VPC returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.VPC = &infrav1.ResourceReference{
 			ID:                ptr.To("vpcid"),
 			ControllerCreated: ptr.To(true),
@@ -1190,6 +1223,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete VPC returns requeue as true", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.VPC = &infrav1.ResourceReference{
 			ID:                ptr.To("vpcid"),
 			ControllerCreated: ptr.To(true),
@@ -1211,6 +1245,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete DHCP returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status = infrav1.IBMPowerVSClusterStatus{
 			Workspace: infrav1.ResourceReferenceV1Beta3{
 				ID: "serviceInstanceID",
@@ -1241,6 +1276,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete Workspace returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Spec.Workspace.Type = infrav1.SourceTypeProvision
 		clusterScope.IBMPowerVSCluster.Status = infrav1.IBMPowerVSClusterStatus{
 			Workspace: infrav1.ResourceReferenceV1Beta3{
@@ -1271,6 +1307,7 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete Workspace returns requeue as true", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Spec.Workspace.Type = infrav1.SourceTypeProvision
 		clusterScope.IBMPowerVSCluster.Status = infrav1.IBMPowerVSClusterStatus{
 			Workspace: infrav1.ResourceReferenceV1Beta3{
@@ -1300,11 +1337,13 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When delete COSInstance returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status.COSInstance = &infrav1.ResourceReference{
 			ID:                ptr.To("CosInstanceID"),
 			ControllerCreated: ptr.To(true),
 		}
 		clusterScope.IBMPowerVSCluster.Spec = infrav1.IBMPowerVSClusterSpec{
+			Topology: infrav1.PowerVSLoadBalancerTopology,
 			Workspace: infrav1.WorkspaceSource{
 				Type: infrav1.SourceTypeReference,
 				Reference: infrav1.ResourceIdentifier{
@@ -1336,12 +1375,14 @@ func TestIBMPowerVSClusterReconciler_delete(t *testing.T) {
 	t.Run("When reconcile delete is successful", func(t *testing.T) {
 		g := NewWithT(t)
 		clusterScope = powervsClusterScope()
+		clusterScope.IBMPowerVSCluster.Spec.Topology = infrav1.PowerVSLoadBalancerTopology
 		clusterScope.IBMPowerVSCluster.Status = infrav1.IBMPowerVSClusterStatus{
 			Workspace: infrav1.ResourceReferenceV1Beta3{
 				ID: "serviceInstanceID",
 			},
 		}
 		clusterScope.IBMPowerVSCluster.Spec = infrav1.IBMPowerVSClusterSpec{
+			Topology: infrav1.PowerVSLoadBalancerTopology,
 			Workspace: infrav1.WorkspaceSource{
 				Type: infrav1.SourceTypeReference,
 				Reference: infrav1.ResourceIdentifier{
@@ -1426,6 +1467,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							VPC: &infrav1.VPCResourceReference{
 								Region: ptr.To("us-south"),
 							},
@@ -1465,6 +1507,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							ResourceGroup: &infrav1.IBMPowerVSResourceReference{
 								ID: ptr.To("rg-id"),
 							},
@@ -1502,6 +1545,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							VPC: &infrav1.VPCResourceReference{
 								Region: ptr.To("us-south"),
 							},
@@ -1553,6 +1597,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							VPC: &infrav1.VPCResourceReference{
 								Region: ptr.To("us-south"),
 							},
@@ -1605,6 +1650,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							VPC: &infrav1.VPCResourceReference{
 								Region: ptr.To("us-south"),
 							},
@@ -1744,6 +1790,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{
@@ -1789,6 +1836,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope := &powervsscope.ClusterScope{
 					IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{
@@ -1892,7 +1940,8 @@ func getPowerVSClusterWithSpecAndStatus() *infrav1.IBMPowerVSCluster {
 			Annotations: map[string]string{infrav1.CreateInfrastructureAnnotation: "true"},
 		},
 		Spec: infrav1.IBMPowerVSClusterSpec{
-			Zone: ptr.To("dal10"),
+			Topology: infrav1.PowerVSLoadBalancerTopology,
+			Zone:     ptr.To("dal10"),
 			ResourceGroup: &infrav1.IBMPowerVSResourceReference{
 				ID: ptr.To("rg-id"),
 			},

--- a/internal/controllers/powervs/ibmpowervsimage_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsimage_controller_test.go
@@ -180,6 +180,7 @@ func TestIBMPowerVSImageReconciler_reconcile(t *testing.T) {
 					UID:  "1",
 				},
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -421,6 +422,9 @@ func TestIBMPowerVSImageReconciler_Reconcile_Conditions(t *testing.T) {
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "capi-powervs-cluster"},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
+				},
 			},
 			powervsImage: &infrav1.IBMPowerVSImage{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
@@ -192,6 +192,7 @@ func TestIBMPowerVSMachineReconciler_Reconcile(t *testing.T) {
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "powervs-cluster"},
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -522,6 +523,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
+						Topology: infrav1.PowerVSVirtualIPTopology,
 						Workspace: infrav1.WorkspaceSource{
 							Type: infrav1.SourceTypeReference,
 							Reference: infrav1.ResourceIdentifier{
@@ -621,6 +623,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 						},
 					},
 					Spec: infrav1.IBMPowerVSClusterSpec{
+						Topology: infrav1.PowerVSVirtualIPTopology,
 						Workspace: infrav1.WorkspaceSource{
 							Type: infrav1.SourceTypeReference,
 							Reference: infrav1.ResourceIdentifier{
@@ -734,6 +737,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 				DHCPIPCacheStore: cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
 				IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 					Spec: infrav1.IBMPowerVSClusterSpec{
+						Topology: infrav1.PowerVSVirtualIPTopology,
 						Workspace: infrav1.WorkspaceSource{
 							Type: infrav1.SourceTypeReference,
 							Reference: infrav1.ResourceIdentifier{
@@ -854,6 +858,7 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 					},
 				},
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{

--- a/internal/webhooks/powervs/ibmpowervscluster_test.go
+++ b/internal/webhooks/powervs/ibmpowervscluster_test.go
@@ -35,6 +35,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should allow if either Network ID or name is set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -52,6 +53,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network ID and name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -70,6 +72,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if all Network ID, name and regex are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -89,6 +92,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network name and DHCP name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -109,6 +113,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network id and DHCP name are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -129,6 +134,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network name and DHCP id are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -149,6 +155,7 @@ func TestIBMPowerVSCluster_create(t *testing.T) {
 			name: "Should error if both Network id and DHCP id are set",
 			powervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -193,6 +200,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should allow if either Network ID or name is set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -206,6 +214,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -223,6 +232,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if both Network ID and name are set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -236,6 +246,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -254,6 +265,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should allow if Network ID is set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -267,6 +279,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -284,6 +297,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if all Network ID, name and regex are set",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -297,6 +311,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -316,6 +331,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should error if the additionalListener selector is changed for same port and protocol",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -345,6 +361,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -378,6 +395,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should work if there is an additional listener added",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -407,6 +425,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -449,6 +468,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should work if the additionalListener selector is updated with new port and protocol",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -478,6 +498,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -511,6 +532,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			name: "Should not panic with nil protocol in additionalListener",
 			oldPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{
@@ -540,6 +562,7 @@ func TestIBMPowerVSCluster_update(t *testing.T) {
 			},
 			newPowervsCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSLoadBalancerTopology,
 					Workspace: infrav1.WorkspaceSource{
 						Type: infrav1.SourceTypeReference,
 						Reference: infrav1.ResourceIdentifier{

--- a/internal/webhooks/powervs/ibmpowervsclustertemplate_test.go
+++ b/internal/webhooks/powervs/ibmpowervsclustertemplate_test.go
@@ -39,6 +39,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{
@@ -53,6 +54,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{
@@ -71,6 +73,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSVirtualIPTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{
@@ -85,6 +88,7 @@ func TestIBMPowerVSClusterTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.IBMPowerVSClusterTemplateSpec{
 					Template: infrav1.IBMPowerVSClusterTemplateResource{
 						Spec: infrav1.IBMPowerVSClusterSpec{
+							Topology: infrav1.PowerVSLoadBalancerTopology,
 							Workspace: infrav1.WorkspaceSource{
 								Type: infrav1.SourceTypeReference,
 								Reference: infrav1.ResourceIdentifier{

--- a/templates/bases/powervs/cluster.yaml
+++ b/templates/bases/powervs/cluster.yaml
@@ -29,12 +29,13 @@ metadata:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
 spec:
-  workspace:
-    type: Reference
-    reference:
-      id: "${IBMPOWERVS_WORKSPACE_ID}"
-  network:
-    name: "${IBMPOWERVS_NETWORK_NAME}"
   controlPlaneEndpoint:
     host: "${IBMPOWERVS_VIP_EXTERNAL}"
     port: ${API_SERVER_PORT:=6443}
+  network:
+    name: "${IBMPOWERVS_NETWORK_NAME}"
+  topology: VirtualIP
+  workspace:
+    reference:
+      id: "${IBMPOWERVS_WORKSPACE_ID}"
+    type: Reference

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -72,6 +72,7 @@ spec:
         port: ${API_SERVER_PORT:=6443}
       network:
         name: ${IBMPOWERVS_NETWORK_NAME}
+      topology: VirtualIP
       workspace:
         reference:
           id: ${IBMPOWERVS_WORKSPACE_ID}

--- a/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
+++ b/templates/cluster-template-powervs-clusterclass/cluster-with-kcp.yaml
@@ -72,10 +72,11 @@ spec:
         port: ${API_SERVER_PORT:=6443}
       network:
         name: "${IBMPOWERVS_NETWORK_NAME}"
+      topology: VirtualIP
       workspace:
-        type: Reference
         reference:
           id: "${IBMPOWERVS_WORKSPACE_ID}"
+        type: Reference
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -27,13 +27,12 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
 kind: IBMPowerVSCluster
 metadata:
-  annotations:
-    powervs.cluster.x-k8s.io/create-infra: "true"
   labels:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
+  topology: LoadBalancer
   resourceGroup:
     name: ${IBM_RESOURCE_GROUP}
   zone: ${IBMPOWERVS_ZONE}

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -35,6 +35,7 @@ spec:
     port: ${API_SERVER_PORT:=6443}
   network:
     name: ${IBMPOWERVS_NETWORK_NAME}
+  topology: VirtualIP
   workspace:
     reference:
       id: ${IBMPOWERVS_WORKSPACE_ID}

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -527,6 +527,7 @@ spec:
     port: ${API_SERVER_PORT:=6443}
   network:
     name: ${IBMPOWERVS_NETWORK_NAME}
+  topology: VirtualIP
   workspace:
     reference:
       id: ${IBMPOWERVS_WORKSPACE_ID}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This is a PR for API enhancement as per the proposal https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/docs/proposal/20260421-powervs-v1beta3-api-modernization.md

This PR adds the Topology field into IBMPowerVSCluster object, this is the plan to remove depending on the annotation to follow two different cluster creation paths.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Part of https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2401

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Topology field into IBMPowerVSCluster
```
