### PR TITLE
Improved additional volumes update logic

### DIFF
--- a/cloud/scope/vpc/helper_test.go
+++ b/cloud/scope/vpc/helper_test.go
@@ -29,8 +29,7 @@ const (
 	clusterName      = "foo-cluster"
 	machineName      = "foo-machine"
 	defaultNamespace = "default"
-	testVPC = "foo-vpc"
-
+	testVPC          = "foo-vpc"
 )
 
 func newCluster(name string) *clusterv1.Cluster {

--- a/cloud/scope/vpc/machine.go
+++ b/cloud/scope/vpc/machine.go
@@ -1239,3 +1239,11 @@ func (m *MachineScope) AttachVolume(deleteOnInstanceDelete bool, volumeID, volum
 	}
 	return err
 }
+
+func (m *MachineScope) DeleteVolume(volumeID string) error {
+	deletionOptions := vpcv1.DeleteVolumeOptions{
+		ID: &volumeID,
+	}
+	_, err := m.IBMVPCClient.DeleteVolume(&deletionOptions)
+	return err
+}

--- a/internal/controllers/vpc/ibmvpcmachine_controller.go
+++ b/internal/controllers/vpc/ibmvpcmachine_controller.go
@@ -426,6 +426,7 @@ func patchIBMVPCMachine(ctx context.Context, patchHelper *v1beta1patch.Helper, i
 		clusterv1beta1.PausedV1Beta2Condition,
 	}})
 }
+
 func (r *IBMVPCMachineReconciler) reconcileAdditionalVolumes(ctx context.Context, machineScope *vpc.MachineScope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// Return immediately if no additional volumes exist
@@ -483,12 +484,25 @@ func (r *IBMVPCMachineReconciler) reconcileAdditionalVolumes(ctx context.Context
 		} else {
 			// volume does not exist, create it and requeue so that it becomes available
 			volumeID, err := machineScope.CreateVolume(machineVolumes[v])
-			machineScope.IBMVPCMachine.Status.V1Beta2.AdditionalVolumeIDs[v] = volumeID
 			if err != nil {
-				log.Error(err, "Could not update Machine status. Created Volume needs to be cleaned up manually", "VolumeID", volumeID)
+				log.Error(err, "Could not create new Volume")
 				errList = append(errList, err)
+			} else {
+				machineScope.IBMVPCMachine.Status.V1Beta2.AdditionalVolumeIDs[v] = volumeID
+				err = r.Status().Update(ctx, machineScope.IBMVPCMachine)
+				if err != nil {
+					log.Error(err, "Could not update Machine status. trying to clean up volume manually", "VolumeID", volumeID)
+					errList = append(errList, err)
+					if deleteError := machineScope.DeleteVolume(volumeID); deleteError != nil {
+						log.Error(deleteError, "Could not delete volume. Created volume has to be cleaned up manually", "VolumeID", volumeID)
+						errList = append(errList, deleteError)
+					} else {
+						log.Info("Successfully cleaned up orphaned volume")
+					}
+				} else {
+					log.Info("Created new volume", "name", machineVolumes[v].Name, "VolumeID", volumeID)
+				}
 			}
-			log.Info("Created new volume", "name", machineVolumes[v].Name, "VolumeID", volumeID)
 			result = ctrl.Result{RequeueAfter: 10 * time.Second}
 		}
 	}

--- a/pkg/cloud/services/vpc/service.go
+++ b/pkg/cloud/services/vpc/service.go
@@ -541,6 +541,11 @@ func (s *Service) AttachVolumeToInstance(options *vpcv1.CreateInstanceVolumeAtta
 	return s.vpcService.CreateInstanceVolumeAttachment(options)
 }
 
+// DeleteVolume deletes a volume.
+func (s *Service) DeleteVolume(options *vpcv1.DeleteVolumeOptions) (*core.DetailedResponse, error) {
+	return s.vpcService.DeleteVolume(options)
+}
+
 // GetVolume fetches the given volume's status.
 func (s *Service) GetVolume(options *vpcv1.GetVolumeOptions) (result *vpcv1.Volume, response *core.DetailedResponse, err error) {
 	return s.vpcService.GetVolume(options)

--- a/pkg/cloud/services/vpc/vpc.go
+++ b/pkg/cloud/services/vpc/vpc.go
@@ -77,4 +77,5 @@ type Vpc interface {
 	AttachVolumeToInstance(options *vpcv1.CreateInstanceVolumeAttachmentOptions) (*vpcv1.VolumeAttachment, *core.DetailedResponse, error)
 	GetVolumeAttachments(options *vpcv1.ListInstanceVolumeAttachmentsOptions) (result *vpcv1.VolumeAttachmentCollection, response *core.DetailedResponse, err error)
 	GetVolume(options *vpcv1.GetVolumeOptions) (result *vpcv1.Volume, response *core.DetailedResponse, err error)
+	DeleteVolume(options *vpcv1.DeleteVolumeOptions) (*core.DetailedResponse, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Currently some dangling volumes are created when a new cluster is created with additional volumes. 
This is happening due to a delay in when the additional volume status is updated. There is a timing issue where if two reconciles are called for the same CR, both the reconciles end up creating volumes because they both check for existing volumes in the status and find nothing.

With these code changes, if the scenario above occurs, one of the reconcile calls is guaranteed to fail because it will try to update an earlier version of the CR. When this happens the volumes deletion is initiated, thus avoiding the dangling volume issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improved additional volumes update logic
```
