### PR TITLE
Add CentOS Stream 10 Kubernetes v1.34.7 DHCP image for PowerVS

### DIFF
--- a/docs/book/src/machine-images/powervs.md
+++ b/docs/book/src/machine-images/powervs.md
@@ -13,6 +13,7 @@
 
 | Region   | Bucket           | Object                                                                 | Kubernetes Version |
 |----------|------------------|------------------------------------------------------------------------|--------------------|
+| us-south | power-oss-bucket | [capibm-powervs-centos-streams10-1-34-7-dhcp.ova.gz][centos-streams10-1-34-7-dhcp] | 1.34.7             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-32-3.ova.gz][centos-streams9-1-32-3] | 1.32.3             |
 | us-south | power-oss-bucket | [capibm-powervs-centos-streams9-1-29-3.ova.gz][centos-streams9-1-29-3] | 1.29.3             |
 
@@ -23,6 +24,7 @@
 [streams9-1-32-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-32-3-1747820578.ova.gz
 [streams9-1-31-0]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-31-0-1737533452.ova.gz
 [streams9-1-30-0]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-30-0-1737523124.ova.gz
+[centos-streams10-1-34-7-dhcp]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams10-1-34-7-dhcp.ova.gz
 [centos-streams9-1-32-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-32-3-1746768746.ova.gz
 [centos-streams9-1-29-3]: https://power-oss-bucket.s3.us-south.cloud-object-storage.appdomain.cloud/capibm-powervs-centos-streams9-1-29-3-1719470782.ova.gz
 

--- a/docs/book/src/topics/powervs/creating-a-cluster.md
+++ b/docs/book/src/topics/powervs/creating-a-cluster.md
@@ -147,14 +147,14 @@ following the steps below.
     IBMPOWERVS_SSHKEY_NAME="my-ssh-key" \
     COS_BUCKET_REGION="us-south" \
     COS_BUCKET_NAME="power-oss-bucket" \
-    COS_OBJECT_NAME=capibm-powervs-centos-streams8-1-28-4-1707287079.ova.gz \
+    COS_OBJECT_NAME=capibm-powervs-centos-streams10-1-34-7-dhcp.ova.gz \
     IBMACCOUNT_ID="<account_id>" \
     IBMPOWERVS_REGION="wdc" \
     IBMPOWERVS_ZONE="wdc06" \
     IBMVPC_REGION="us-east" \
     IBM_RESOURCE_GROUP="ibm-resource-group" \
     BASE64_API_KEY=$(echo -n $IBMCLOUD_API_KEY | base64) \
-    clusterctl generate cluster capi-powervs --kubernetes-version v1.28.4 \
+    clusterctl generate cluster capi-powervs --kubernetes-version v1.34.7 \
     --target-namespace default \
     --control-plane-machine-count=3 \
     --worker-machine-count=1 \


### PR DESCRIPTION
What this PR does / why we need it:
Adds the CentOS Stream 10 Kubernetes v1.34.7 DHCP-enabled PowerVS image 
to the machine image documentation and updates the infrastructure-creation 
cluster example to use the new DHCP image artifact.

The image was built using image-builder with a custom DHCP-enabled base OVA 
and validated using the PowerVS infrastructure-creation workflow.

Which issue(s) this PR fixes:
part of #2764

Special notes for your reviewer:
/area provider/ibmcloud

Please confirm that if this PR changes any image versions, then that's the 
sole change this PR makes.

Validation:
- Built DHCP-enabled CentOS Stream 10 image using image-builder
- Uploaded image to power-oss-bucket as capibm-powervs-centos-streams10-1-34-7-dhcp.ova.gz
- Validated cluster creation using cluster-template-powervs-create-infra.yaml
- VM successfully obtained a DHCP lease and completed Kubernetes provisioning

Release note:
Add CentOS Stream 10 Kubernetes v1.34.7 DHCP image for PowerVS infrastructure-creation deployments