### PR TITLE
:bug: Fix panic while validating PER availibility for a zone

### DIFF
--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -70,8 +70,10 @@ func NewService(options ServiceOptions) (PowerVS, error) {
 		return nil, err
 	}
 
+	ctx := context.Background()
 	return &Service{
-		session: session,
+		session:          session,
+		dataCenterClient: instance.NewIBMPIDatacenterClient(ctx, session, ""),
 	}, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

[getPowerVSClient](vscode-webview://0ot0tlvd4dqfcskp6il2tm8847un4qpfgr9c9jl69sq77f2rvfjg/cloud/scope/powervs/powervs_cluster.go:253) calls [powervs.NewService](vscode-webview://0ot0tlvd4dqfcskp6il2tm8847un4qpfgr9c9jl69sq77f2rvfjg/pkg/cloud/services/powervs/service.go:52), which only creates the session — it returns a &Service{session: session} with all clients nil. [WithClients](vscode-webview://0ot0tlvd4dqfcskp6il2tm8847un4qpfgr9c9jl69sq77f2rvfjg/pkg/cloud/services/powervs/service.go:79) (which initialises dataCenterClient) is never called in the cluster scope setup path.

So when ValidateZoneSupportsPER calls s.IBMPowerVSClient.GetDatatcenterDetails(zone) → s.dataCenterClient.Get(zone), dataCenterClient is nil → panic.

The dataCenterClient is zone-scoped (doesn't need a CloudInstanceID — the datacenter API is global). WithClients requires a CloudInstanceID which isn't known at cluster scope creation time (the workspace hasn't been provisioned yet). The fix is to initialise dataCenterClient separately, independent of WithClients.


Introduced as part of PR: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2749

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix panic while validating PER availibility for a zone
```
