### PR TITLE
:seedling: Refactor reconcile method to avoid using locks for updating IBMPowerVSCluster object

### DIFF
--- a/internal/controllers/powervs/ibmpowervscluster_controller.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller.go
@@ -75,14 +75,12 @@ type IBMPowerVSClusterReconciler struct {
 	ClientFactory powervsscope.ClientFactory
 }
 
-type powerVSCluster struct {
-	cluster *infrav1.IBMPowerVSCluster
-	mu      sync.Mutex
-}
-
-type reconcileResult struct {
-	reconcile.Result
-	error
+// componentResult holds the outcome of a concurrent component reconciliation.
+type componentResult struct {
+	requeue    bool
+	err        error
+	conditions []metav1.Condition
+	legacy     []*clusterv1.Condition
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=get;list;watch;create;update;patch;delete
@@ -161,17 +159,17 @@ func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return r.reconcile(ctx, clusterScope)
 }
 
-func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) { //nolint:gocyclo
+func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	// 1. If it's VirtualIP, do the minimal logic and return early.
+	// If it's VirtualIP, do the minimal logic and return early.
 	if clusterScope.IBMPowerVSCluster.Spec.Topology == infrav1.PowerVSVirtualIPTopology {
 		log.Info("Reconciling in VirtualIP topology mode")
 		clusterScope.IBMPowerVSCluster.Status.Initialization.Provisioned = ptr.To(true)
 		return ctrl.Result{}, nil
 	}
 
-	// 2. Otherwise, assume LoadBalancer and proceed with the heavy VPC/TG logic.
+	// Otherwise, assume LoadBalancer and proceed with the heavy VPC/TG logic.
 	if clusterScope.IBMPowerVSCluster.Spec.Topology != infrav1.PowerVSLoadBalancerTopology {
 		return ctrl.Result{}, fmt.Errorf("unknown topology: %q", clusterScope.IBMPowerVSCluster.Spec.Topology)
 	}
@@ -188,101 +186,75 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile resource group: %w", err)
 	}
 
-	powerVSCluster := &powerVSCluster{
-		cluster: clusterScope.IBMPowerVSCluster,
-	}
-
 	var wg sync.WaitGroup
-	ch := make(chan reconcileResult)
+	ch := make(chan componentResult, 2)
 
-	// reconcile PowerVS resources
-	wg.Add(1)
-	go r.reconcilePowerVSResources(ctx, clusterScope, powerVSCluster, ch, &wg)
+	wg.Go(func() {
+		ch <- r.reconcilePowerVSResources(ctx, clusterScope)
+	})
 
-	// reconcile VPC
-	wg.Add(1)
-	go r.reconcileVPCResources(ctx, clusterScope, powerVSCluster, ch, &wg)
+	wg.Go(func() {
+		ch <- r.reconcileVPCResources(ctx, clusterScope)
+	})
 
-	// wait for above reconcile to complete and close the channel
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
+	wg.Wait()
+	close(ch)
 
-	var requeue bool
 	var errList []error
-	// receive return values from the channel and decide the requeue
-	for val := range ch {
-		if val.RequeueAfter > 0 {
-			requeue = true
+	var needsRequeue bool
+
+	for res := range ch {
+		if res.err != nil {
+			errList = append(errList, res.err)
 		}
-		if val.error != nil {
-			errList = append(errList, val.error)
+		if res.requeue {
+			needsRequeue = true
+		}
+
+		for i := range res.conditions {
+			conditions.Set(clusterScope.IBMPowerVSCluster, res.conditions[i])
+			deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, res.legacy[i])
 		}
 	}
 
-	if requeue && len(errList) > 1 {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, kerrors.NewAggregate(errList)
-	} else if requeue {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	} else if len(errList) > 1 {
+	if len(errList) > 0 {
 		return ctrl.Result{}, kerrors.NewAggregate(errList)
 	}
+	if needsRequeue {
+		log.Info("PowerVS or VPC infrastructure components are still provisioning, requeuing before proceeding to Transit Gateway")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 
-	// reconcile Transit Gateway
 	log.Info("Reconciling transit gateway")
 	if requeue, err := clusterScope.ReconcileTransitGateway(ctx); err != nil {
-		deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition, infrav1.TransitGatewayReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.TransitGatewayReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.TransitGatewayNotReadyReason,
-			Message: err.Error(),
-		})
+		condition, legacyCondition := r.buildConditions(infrav1.TransitGatewayReadyCondition, infrav1.TransitGatewayReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.TransitGatewayNotReadyReason, infrav1.TransitGatewayReconciliationFailedV1Beta2Reason, err.Error())
+		conditions.Set(clusterScope.IBMPowerVSCluster, condition)
+		deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, legacyCondition)
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile transit gateway: %w", err)
 	} else if requeue {
 		log.Info("Creating a transit gateway is pending, requeuing")
 		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
-	deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition)
-	powerVSCluster.updateCondition(metav1.Condition{
-		Type:   infrav1.TransitGatewayReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.TransitGatewayReadyReason,
-	})
 
-	// reconcile COSInstance
+	condition, legacyCondition := r.buildConditions(infrav1.TransitGatewayReadyCondition, infrav1.TransitGatewayReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.TransitGatewayReadyReason, "", "")
+	conditions.Set(clusterScope.IBMPowerVSCluster, condition)
+	deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, legacyCondition)
+
 	if clusterScope.IBMPowerVSCluster.Spec.COSInstance.Type != "" {
 		log.Info("Reconciling COS service instance")
 		if err := clusterScope.ReconcileCOSInstance(ctx); err != nil {
-			deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition, infrav1.COSInstanceReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
-			powerVSCluster.updateCondition(metav1.Condition{
-				Type:    infrav1.COSInstanceReadyCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.COSInstanceNotReadyReason,
-				Message: err.Error(),
-			})
+			condition, legacyCondition := r.buildConditions(infrav1.COSInstanceReadyCondition, infrav1.COSInstanceReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.COSInstanceNotReadyReason, infrav1.COSInstanceReconciliationFailedV1Beta2Reason, err.Error())
+			conditions.Set(clusterScope.IBMPowerVSCluster, condition)
+			deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, legacyCondition)
 			return reconcile.Result{}, fmt.Errorf("failed to reconcile COS instance: %w", err)
 		}
-		deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition)
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:   infrav1.COSInstanceReadyCondition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.COSInstanceReadyReason,
-		})
+		condition, legacyCondition := r.buildConditions(infrav1.COSInstanceReadyCondition, infrav1.COSInstanceReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.COSInstanceReadyReason, "", "")
+		conditions.Set(clusterScope.IBMPowerVSCluster, condition)
+		deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, legacyCondition)
 	}
 
-	var networkReady, loadBalancerReady bool
-	for _, cond := range clusterScope.IBMPowerVSCluster.Status.Conditions {
-		if cond.Type == infrav1.NetworkReadyCondition && cond.Status == metav1.ConditionTrue {
-			networkReady = true
-		}
-		if cond.Type == infrav1.LoadBalancerReadyCondition && cond.Status == metav1.ConditionTrue {
-			loadBalancerReady = true
-		}
-	}
-
-	if !networkReady || !loadBalancerReady {
+	if !conditions.IsTrue(clusterScope.IBMPowerVSCluster, infrav1.NetworkReadyCondition) ||
+		!conditions.IsTrue(clusterScope.IBMPowerVSCluster, infrav1.VPCLoadBalancerReadyCondition) {
 		log.Info("Network or LoadBalancer still not ready, requeuing")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
@@ -297,225 +269,124 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// update cluster object with load balancer host name
 	clusterScope.IBMPowerVSCluster.Spec.ControlPlaneEndpoint.Host = *hostName
 	clusterScope.IBMPowerVSCluster.Spec.ControlPlaneEndpoint.Port = clusterScope.APIServerPort()
 	clusterScope.IBMPowerVSCluster.Status.Initialization.Provisioned = ptr.To(true)
+
 	return ctrl.Result{}, nil
 }
 
-func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Context, clusterScope *powervsscope.ClusterScope, powerVSCluster *powerVSCluster, ch chan reconcileResult, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	log := ctrl.LoggerFrom(ctx)
-	log = log.WithName("powervs")
+func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Context, clusterScope *powervsscope.ClusterScope) componentResult {
+	log := ctrl.LoggerFrom(ctx).WithName("powervs")
+	res := componentResult{}
 
 	log.Info("Reconciling PowerVS resources")
 	defer log.Info("Finished Reconciling PowerVS resources")
 
-	// reconcile PowerVS Workspace.
 	log.Info("Reconciling PowerVS workspace")
 	if requeue, err := clusterScope.ReconcileWorkspace(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.ServiceInstanceReadyV1Beta2Condition,
-			Reason:   infrav1.ServiceInstanceReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.WorkspaceReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.WorkspaceNotReadyReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile PowerVS workspace: %w", err)}
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.WorkspaceReadyCondition, infrav1.ServiceInstanceReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.WorkspaceNotReadyReason, infrav1.ServiceInstanceReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile PowerVS workspace: %w", err)
+		return res
 	} else if requeue {
-		log.Info("PowerVS workspace creation is pending, requeuing")
-		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
-		return
+		log.Info("PowerVS workspace creation is pending")
+		res.requeue = true
+		return res
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-		Status: corev1.ConditionTrue,
-		Type:   infrav1.ServiceInstanceReadyV1Beta2Condition,
-	})
-	powerVSCluster.updateCondition(metav1.Condition{
-		Type:   infrav1.WorkspaceReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.WorkspaceReadyReason,
-	})
+	condition, legacyCondition := r.buildConditions(infrav1.WorkspaceReadyCondition, infrav1.ServiceInstanceReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.WorkspaceReadyReason, "", "")
+	res.conditions = append(res.conditions, condition)
+	res.legacy = append(res.legacy, legacyCondition)
 
 	clusterScope.IBMPowerVSClient.WithClients(powervs.ServiceOptions{CloudInstanceID: clusterScope.IBMPowerVSCluster.Status.Workspace.ID})
 
-	// reconcile network
 	log.Info("Reconciling network")
 	if networkActive, err := clusterScope.ReconcileNetwork(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.NetworkReadyV1Beta2Condition,
-			Reason:   infrav1.NetworkReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.NetworkReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.NetworkNotReadyReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile network: %w", err)}
-		return
-	} else if networkActive {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status: corev1.ConditionTrue,
-			Type:   infrav1.NetworkReadyV1Beta2Condition,
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:   infrav1.NetworkReadyCondition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.NetworkReadyReason,
-		})
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.NetworkReadyCondition, infrav1.NetworkReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.NetworkNotReadyReason, infrav1.NetworkReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile network: %w", err)
+		return res
+	} else if !networkActive {
+		log.Info("PowerVS network creation is pending")
+	} else {
+		condition, legacyCondition = r.buildConditions(infrav1.NetworkReadyCondition, infrav1.NetworkReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.NetworkReadyReason, "", "")
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
 	}
-	// Do not want to block the reconciliation of other resources like setting up TG and COS, so skipping the requeue and only logging the info.
-	log.Info("PowerVS network creation is pending")
+
+	return res
 }
 
-func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context, clusterScope *powervsscope.ClusterScope, powerVSCluster *powerVSCluster, ch chan reconcileResult, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	log := ctrl.LoggerFrom(ctx)
-	log = log.WithName("vpc")
+func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context, clusterScope *powervsscope.ClusterScope) componentResult {
+	log := ctrl.LoggerFrom(ctx).WithName("vpc")
+	res := componentResult{}
 
 	log.Info("Reconciling VPC")
-	defer log.Info("Finished VPC reconciliation")
-
 	if requeue, err := clusterScope.ReconcileVPC(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.VPCReadyV1Beta2Condition,
-			Reason:   infrav1.VPCReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.VPCReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VPCNotReadyReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC: %w", err)}
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.VPCReadyCondition, infrav1.VPCReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.VPCNotReadyReason, infrav1.VPCReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile VPC: %w", err)
+		return res
 	} else if requeue {
-		log.Info("VPC creation is pending, requeuing")
-		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
-		return
+		log.Info("VPC creation is pending")
+		res.requeue = true
+		return res
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-		Status: corev1.ConditionTrue,
-		Type:   infrav1.VPCReadyV1Beta2Condition,
-	})
-	powerVSCluster.updateCondition(metav1.Condition{
-		Type:   infrav1.VPCReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.VPCReadyReason,
-	})
+	condition, legacyCondition := r.buildConditions(infrav1.VPCReadyCondition, infrav1.VPCReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.VPCReadyReason, "", "")
+	res.conditions = append(res.conditions, condition)
+	res.legacy = append(res.legacy, legacyCondition)
 
 	// reconcile VPC Subnet
 	log.Info("Reconciling VPC subnets")
 	if requeue, err := clusterScope.ReconcileVPCSubnets(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.VPCSubnetReadyV1Beta2Condition,
-			Reason:   infrav1.VPCSubnetReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.VPCSubnetReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VPCSubnetNotReadyReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC subnets: %w", err)}
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.VPCSubnetReadyCondition, infrav1.VPCSubnetReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.VPCSubnetNotReadyReason, infrav1.VPCSubnetReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile VPC subnets: %w", err)
+		return res
 	} else if requeue {
-		log.Info("VPC subnet creation is pending, requeuing")
-		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
-		return
+		log.Info("VPC subnet creation is pending")
+		res.requeue = true
+		return res
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-		Status: corev1.ConditionTrue,
-		Type:   infrav1.VPCSubnetReadyV1Beta2Condition,
-	})
-	powerVSCluster.updateCondition(metav1.Condition{
-		Type:   infrav1.VPCSubnetReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.VPCSubnetReadyReason,
-	})
+	condition, legacyCondition = r.buildConditions(infrav1.VPCSubnetReadyCondition, infrav1.VPCSubnetReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.VPCSubnetReadyReason, "", "")
+	res.conditions = append(res.conditions, condition)
+	res.legacy = append(res.legacy, legacyCondition)
 
 	// reconcile VPC security group
 	log.Info("Reconciling VPC security group")
 	if err := clusterScope.ReconcileVPCSecurityGroups(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.VPCSecurityGroupReadyV1Beta2Condition,
-			Reason:   infrav1.VPCSecurityGroupReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.VPCSecurityGroupReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VPCSecurityGroupReconciliationFailedReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC security groups: %w", err)}
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.VPCSecurityGroupReadyCondition, infrav1.VPCSecurityGroupReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.VPCSecurityGroupReconciliationFailedReason, infrav1.VPCSecurityGroupReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile VPC security groups: %w", err)
+		return res
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-		Status: corev1.ConditionTrue,
-		Type:   infrav1.VPCSecurityGroupReadyV1Beta2Condition,
-	})
-	powerVSCluster.updateCondition(metav1.Condition{
-		Type:   infrav1.VPCSecurityGroupReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.VPCSecurityGroupReadyCondition,
-	})
+	condition, legacyCondition = r.buildConditions(infrav1.VPCSecurityGroupReadyCondition, infrav1.VPCSecurityGroupReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.VPCSecurityGroupReadyReason, "", "")
+	res.conditions = append(res.conditions, condition)
+	res.legacy = append(res.legacy, legacyCondition)
 
 	// reconcile LoadBalancer
 	log.Info("Reconciling VPC load balancers")
 	if loadBalancerReady, err := clusterScope.ReconcileLoadBalancers(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status:   corev1.ConditionFalse,
-			Type:     infrav1.LoadBalancerReadyV1Beta2Condition,
-			Reason:   infrav1.LoadBalancerReconciliationFailedV1Beta2Reason,
-			Severity: clusterv1.ConditionSeverityError,
-			Message:  err.Error(),
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:    infrav1.VPCLoadBalancerReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VPCLoadBalancerNotReadyReason,
-			Message: err.Error(),
-		})
-		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC load balancers: %w", err)}
-		return
-	} else if loadBalancerReady {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
-			Status: corev1.ConditionTrue,
-			Type:   infrav1.LoadBalancerReadyV1Beta2Condition,
-		})
-		powerVSCluster.updateCondition(metav1.Condition{
-			Type:   infrav1.VPCLoadBalancerReadyCondition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.VPCLoadBalancerReadyReason,
-		})
-		return
+		condition, legacyCondition := r.buildConditions(infrav1.VPCLoadBalancerReadyCondition, infrav1.LoadBalancerReadyV1Beta2Condition, metav1.ConditionFalse, infrav1.VPCLoadBalancerNotReadyReason, infrav1.LoadBalancerReconciliationFailedV1Beta2Reason, err.Error())
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
+		res.err = fmt.Errorf("failed to reconcile VPC load balancers: %w", err)
+		return res
+	} else if !loadBalancerReady {
+		log.Info("VPC load balancer creation is pending")
+		// Not blocking here.
+	} else {
+		condition, legacyCondition = r.buildConditions(infrav1.VPCLoadBalancerReadyCondition, infrav1.LoadBalancerReadyV1Beta2Condition, metav1.ConditionTrue, infrav1.VPCLoadBalancerReadyReason, "", "")
+		res.conditions = append(res.conditions, condition)
+		res.legacy = append(res.legacy, legacyCondition)
 	}
-	// Do not want to block the reconciliation of other resources like setting up TG and COS, so skipping the requeue and only logging the info.
-	log.Info("VPC load balancer creation is pending")
+
+	return res
 }
 
 func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) {
@@ -646,12 +517,6 @@ func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clust
 	return ctrl.Result{}, nil
 }
 
-func (update *powerVSCluster) updateCondition(condition metav1.Condition) {
-	update.mu.Lock()
-	defer update.mu.Unlock()
-	conditions.Set(update.cluster, condition)
-}
-
 func (r *IBMPowerVSClusterReconciler) deleteIBMPowerVSImage(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	cluster := clusterScope.IBMPowerVSCluster
@@ -775,6 +640,27 @@ func (c *clusterDescendants) filterOwnedDescendants(cluster *infrav1.IBMPowerVSC
 	}
 
 	return ownedDescendants, nil
+}
+
+// buildConditions generates both a metav1.Condition and a legacy v1beta1 Condition simultaneously.
+// reason is used for the modern condition; legacyReason is used for the legacy condition.
+func (r *IBMPowerVSClusterReconciler) buildConditions(condType string, legacyType clusterv1.ConditionType, status metav1.ConditionStatus, reason, legacyReason, msg string) (metav1.Condition, *clusterv1.Condition) {
+	cond := metav1.Condition{
+		Type:    condType,
+		Status:  status,
+		Reason:  reason,
+		Message: msg,
+	}
+	legacy := &clusterv1.Condition{
+		Type:    legacyType,
+		Status:  corev1.ConditionStatus(status),
+		Reason:  legacyReason,
+		Message: msg,
+	}
+	if status == metav1.ConditionFalse {
+		legacy.Severity = clusterv1.ConditionSeverityError
+	}
+	return cond, legacy
 }
 
 // patchIBMPowerVSCluster updates the IBMPowerVSCluster and its status on the API server.

--- a/internal/controllers/powervs/ibmpowervscluster_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller_test.go
@@ -19,7 +19,6 @@ package powervs
 import (
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -43,10 +42,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/powervs/v1beta3"
 	powervsscope "sigs.k8s.io/cluster-api-provider-ibmcloud/cloud/scope/powervs"
@@ -536,11 +536,15 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 							Topology:      infrav1.PowerVSLoadBalancerTopology,
 							Zone:          "dal10",
 							ResourceGroup: infrav1.ResourceGroupSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: "rg-id"}},
-							VPC:           infrav1.VPCSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{Name: "vpc-name"}},
+							VPC:           infrav1.VPCSource{Type: infrav1.SourceTypeProvision, Region: "us-south"},
 						},
 						Status: infrav1.IBMPowerVSClusterStatus{
 							Workspace: infrav1.ResourceReferenceV1Beta3{
 								ID: "serviceInstanceID",
+							},
+							VPC: infrav1.VPCStatus{
+								ID:   "vpcID",
+								Name: "vpcName",
 							},
 						},
 					},
@@ -561,8 +565,9 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 
 				clusterScope.ResourceManagerClient = getMockResourceManager(t)
 
+				// VPC is pending (requeue), so both goroutines requeue rather than error.
 				mockVPC := vpcmock.NewMockVpc(gomock.NewController(t))
-				mockVPC.EXPECT().GetVPCByName(gomock.Any()).Return(nil, errors.New("vpc not found"))
+				mockVPC.EXPECT().GetVPC(gomock.Any()).Return(&vpcv1.VPC{Status: ptr.To("pending")}, nil, nil)
 				clusterScope.IBMVPCClient = mockVPC
 
 				return clusterScope
@@ -811,14 +816,28 @@ func TestIBMPowerVSClusterReconciler_reconcile(t *testing.T) {
 				mockPowerVS.EXPECT().WithClients(gomock.Any())
 				clusterScope.IBMPowerVSClient = mockPowerVS
 
-				clusterScope.ResourceClient = getMockResourceController(t)
+				// getMockResourceController expects Times(2); only called once here since TG is not reached.
+				mockRC := resourceclientmock.NewMockResourceController(gomock.NewController(t))
+				mockRC.EXPECT().GetResourceInstance(gomock.Any()).Return(&resourcecontrollerv2.ResourceInstance{
+					Name: ptr.To("serviceInstanceName"), ID: ptr.To("serviceInstanceID"),
+					State: ptr.To("active"), CRN: ptr.To("powervs_crn"),
+				}, nil, nil)
+				clusterScope.ResourceClient = mockRC
 				clusterScope.ResourceManagerClient = getMockResourceManager(t)
-				clusterScope.IBMVPCClient = getMockVPC(t)
-				clusterScope.TransitGatewayClient = getMockTransitGateway(t)
+				// VPC goroutine still runs in parallel; TG is not reached due to error.
+				mockVPC := vpcmock.NewMockVpc(gomock.NewController(t))
+				mockVPC.EXPECT().GetVPC(gomock.Any()).Return(&vpcv1.VPC{Status: ptr.To("active"), CRN: ptr.To("vpc_crn")}, nil, nil)
+				mockVPC.EXPECT().GetSubnet(gomock.Any()).Return(&vpcv1.Subnet{ID: ptr.To("subnet-id"), Name: ptr.To("subnet1"), Status: ptr.To("active")}, nil, nil)
+				mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
+					ID: ptr.To("lb-id"), Name: ptr.To("capi-powervs-cluster-lb-public"),
+					ProvisioningStatus: ptr.To("active"),
+				}, nil, nil)
+				clusterScope.IBMVPCClient = mockVPC
 
 				return clusterScope
 			},
-			expectedResult: ctrl.Result{RequeueAfter: 30 * time.Second},
+			// Network reconciliation errors propagate immediately rather than silently requeueing.
+			expectedError: fmt.Errorf("failed to reconcile network: %w", fmt.Errorf("failed to fetch network by ID: %w", errors.New("error get networkByID"))),
 		},
 		{
 			name: "When getting loadbalancer hostname returns error",
@@ -1563,7 +1582,8 @@ func TestReconcileVPCResources(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		powerVSClusterScopeFunc func() *powervsscope.ClusterScope
-		reconcileResult         reconcileResult
+		wantRequeue             bool
+		wantErr                 error
 		conditions              clusterv1.Conditions
 	}{
 		{
@@ -1584,9 +1604,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("vpc not found"),
-			},
+			wantErr: errors.New("vpc not found"),
 			conditions: clusterv1.Conditions{
 				clusterv1.Condition{
 					Type:               infrav1.VPCReadyCondition,
@@ -1616,11 +1634,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				Result: reconcile.Result{
-					RequeueAfter: 20 * time.Second,
-				},
-			},
+			wantRequeue: true,
 		},
 		{
 			name: "when Reconciling VPC subnets returns error",
@@ -1642,9 +1656,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("vpc subnet not found"),
-			},
+			wantErr: errors.New("vpc subnet not found"),
 
 			conditions: clusterv1.Conditions{
 				getVPCReadyCondition(),
@@ -1681,11 +1693,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				Result: reconcile.Result{
-					RequeueAfter: 20 * time.Second,
-				},
-			},
+			wantRequeue: true,
 			conditions: clusterv1.Conditions{
 				getVPCReadyCondition(),
 			},
@@ -1726,9 +1734,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("failed to reconcile security group: failed to query VPC security group by name 'security-group': vpc security group not found"),
-			},
+			wantErr: errors.New("failed to reconcile security group: failed to query VPC security group by name 'security-group': vpc security group not found"),
 
 			conditions: clusterv1.Conditions{
 				getVPCReadyCondition(),
@@ -1779,9 +1785,7 @@ func TestReconcileVPCResources(t *testing.T) {
 				clusterScope.IBMVPCClient = mockVPC
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("load balancer not found"),
-			},
+			wantErr: errors.New("load balancer not found"),
 
 			conditions: clusterv1.Conditions{
 				clusterv1.Condition{
@@ -1852,26 +1856,22 @@ func TestReconcileVPCResources(t *testing.T) {
 				Client: testEnv.Client,
 			}
 			clusterScope := tc.powerVSClusterScopeFunc()
-			ch := make(chan reconcileResult, 1)
-			pvsCluster := &powerVSCluster{
-				cluster: clusterScope.IBMPowerVSCluster,
-			}
-			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			reconciler.reconcileVPCResources(ctx, clusterScope, pvsCluster, ch, wg)
-			wg.Wait()
-			close(ch)
-			result := <-ch
-			g.Expect(result.Result).To(Equal(tc.reconcileResult.Result))
-			if tc.reconcileResult.error != nil {
-				g.Expect(result).To(MatchError(ContainSubstring(tc.reconcileResult.Error())))
+			res := reconciler.reconcileVPCResources(ctx, clusterScope)
+			g.Expect(res.requeue).To(Equal(tc.wantRequeue))
+			if tc.wantErr != nil {
+				g.Expect(res.err).To(MatchError(ContainSubstring(tc.wantErr.Error())))
 			} else {
-				g.Expect(result.error).To(BeNil())
+				g.Expect(res.err).To(BeNil())
+			}
+			// Apply conditions returned by the helper (mirrors what reconcile() does).
+			for i := range res.conditions {
+				conditions.Set(clusterScope.IBMPowerVSCluster, res.conditions[i])
+				deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, res.legacy[i])
 			}
 			ignoreLastTransitionTime := cmp.Transformer("", func(metav1.Time) metav1.Time {
 				return metav1.Time{}
 			})
-			g.Expect(pvsCluster.cluster.GetV1Beta1Conditions()).To(BeComparableTo(tc.conditions, ignoreLastTransitionTime))
+			g.Expect(clusterScope.IBMPowerVSCluster.GetV1Beta1Conditions()).To(BeComparableTo(tc.conditions, ignoreLastTransitionTime))
 		})
 	}
 }
@@ -1880,7 +1880,8 @@ func TestReconcilePowerVSResources(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		powerVSClusterScopeFunc func() *powervsscope.ClusterScope
-		reconcileResult         reconcileResult
+		wantRequeue             bool
+		wantErr                 error
 		conditions              clusterv1.Conditions
 	}{
 		{
@@ -1900,9 +1901,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope.ResourceClient = mockResourceController
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("error getting resource instance"),
-			},
+			wantErr: errors.New("error getting resource instance"),
 
 			conditions: clusterv1.Conditions{
 				clusterv1.Condition{
@@ -1932,11 +1931,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope.ResourceClient = mockResourceController
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				Result: reconcile.Result{
-					RequeueAfter: 20 * time.Second,
-				},
-			},
+			wantRequeue: true,
 		},
 		{
 			name: "When Reconciling network returns error",
@@ -1971,9 +1966,7 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				clusterScope.IBMPowerVSClient = mockPowerVS
 				return clusterScope
 			},
-			reconcileResult: reconcileResult{
-				error: errors.New("error getting network"),
-			},
+			wantErr: errors.New("error getting network"),
 			conditions: clusterv1.Conditions{
 				clusterv1.Condition{
 					Type:               infrav1.NetworkReadyCondition,
@@ -2037,26 +2030,22 @@ func TestReconcilePowerVSResources(t *testing.T) {
 				Client: testEnv.Client,
 			}
 			clusterScope := tc.powerVSClusterScopeFunc()
-			ch := make(chan reconcileResult, 1)
-			pvsCluster := &powerVSCluster{
-				cluster: clusterScope.IBMPowerVSCluster,
-			}
-			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			reconciler.reconcilePowerVSResources(ctx, clusterScope, pvsCluster, ch, wg)
-			wg.Wait()
-			close(ch)
-			result := <-ch
-			g.Expect(result.Result).To(Equal(tc.reconcileResult.Result))
-			if tc.reconcileResult.error != nil {
-				g.Expect(result).To(MatchError(ContainSubstring(tc.reconcileResult.Error())))
+			res := reconciler.reconcilePowerVSResources(ctx, clusterScope)
+			g.Expect(res.requeue).To(Equal(tc.wantRequeue))
+			if tc.wantErr != nil {
+				g.Expect(res.err).To(MatchError(ContainSubstring(tc.wantErr.Error())))
 			} else {
-				g.Expect(result.error).To(BeNil())
+				g.Expect(res.err).To(BeNil())
+			}
+			// Apply conditions returned by the helper (mirrors what reconcile() does).
+			for i := range res.conditions {
+				conditions.Set(clusterScope.IBMPowerVSCluster, res.conditions[i])
+				deprecatedv1beta1conditions.Set(clusterScope.IBMPowerVSCluster, res.legacy[i])
 			}
 			ignoreLastTransitionTime := cmp.Transformer("", func(metav1.Time) metav1.Time {
 				return metav1.Time{}
 			})
-			g.Expect(pvsCluster.cluster.GetV1Beta1Conditions()).To(BeComparableTo(tc.conditions, ignoreLastTransitionTime))
+			g.Expect(clusterScope.IBMPowerVSCluster.GetV1Beta1Conditions()).To(BeComparableTo(tc.conditions, ignoreLastTransitionTime))
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR refactors the IBMPowerVSCluster reconcile function to avoid usage of locks and simplifies the logic for updating status fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Part of https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2401

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
