### PR TITLE
Use ds.meta_data.name for hostname in PowerVS create-infra template

### DIFF
--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -91,7 +91,7 @@ spec:
           value: external
         - name: eviction-hard
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        name: '{{ v1.local_hostname }}'
+        name: '{{ ds.meta_data.name }}'
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -100,13 +100,13 @@ spec:
           value: external
         - name: eviction-hard
           value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        name: '{{ v1.local_hostname }}'
+        name: '{{ ds.meta_data.name }}'
     preKubeadmCommands:
-    - hostname "{{ v1.local_hostname }}"
+    - hostname "{{ ds.meta_data.name }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
-    - echo "{{ v1.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.name }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.name }}" >/etc/hostname
   machineTemplate:
     spec:
       infrastructureRef:
@@ -193,13 +193,13 @@ spec:
             value: external
           - name: eviction-hard
             value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-          name: '{{ v1.local_hostname }}'
+          name: '{{ ds.meta_data.name }}'
       preKubeadmCommands:
-      - hostname "{{ v1.local_hostname }}"
+      - hostname "{{ ds.meta_data.name }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ v1.local_hostname }}" >>/etc/hosts
-      - echo "{{ v1.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.name }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.name }}" >/etc/hostname
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
 kind: IBMPowerVSImage


### PR DESCRIPTION
## What this PR does / why we need it:

`templates/cluster-template-powervs-create-infra.yaml` currently uses `{{ v1.local_hostname }}` to configure the node hostname.

During manual validation of the PowerVS `create-infra` workflow, we observed intermittent hostname mismatches on some PowerVS VMs. In those cases, `v1.local_hostname` resolved to an internal PowerVS-generated hostname instead of the expected CAPI machine name. This prevented the Cloud Controller Manager (CCM) from matching the Kubernetes Node with the corresponding PowerVS instance, leaving the `providerID` unset.

Using `{{ ds.meta_data.name }}` consistently produced the expected CAPI machine name during our validation and avoided the hostname mismatch. On images where `v1.local_hostname` already resolves to the expected value (for example, our CentOS Stream 9 validation), this change is effectively a no-op, as both fields resolve to the same hostname.

This change is intentionally scoped to `templates/cluster-template-powervs-create-infra.yaml` only. The base templates (`templates/bases/powervs/*.yaml`) and other generated templates are left unchanged while the underlying hostname behavior is investigated further.

Ref: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2791#issuecomment-4978351218

## Special notes for your reviewer:

/area provider/ibmcloud

This is a targeted mitigation for the `create-infra` template used for manual validation and the packaged release flavor. It is **not** intended to address the underlying cause of why `v1.local_hostname` and `ds.meta_data.name` can differ on some PowerVS instances. That investigation is ongoing.

## Release note:

```release-note
Use `ds.meta_data.name` instead of `v1.local_hostname` in the PowerVS `create-infra` cluster template to avoid intermittent hostname mismatches observed during cluster creation.
```