### PR TITLE
CAPI changes to support staging Overrides, backport release-0.12

### DIFF
--- a/cloud/scope/powervs_cluster.go
+++ b/cloud/scope/powervs_cluster.go
@@ -2377,7 +2377,7 @@ func (s *PowerVSClusterScope) createCOSBucket() error {
 func (s *PowerVSClusterScope) checkCOSServiceInstance(ctx context.Context) (*resourcecontrollerv2.ResourceInstance, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// check cos service instance
-	serviceInstance, err := s.ResourceClient.GetInstanceByName(*s.GetServiceName(infrav1.ResourceTypeCOSInstance), resourcecontroller.CosResourceID, resourcecontroller.CosResourcePlanID)
+	serviceInstance, err := s.ResourceClient.GetInstanceByName(*s.GetServiceName(infrav1.ResourceTypeCOSInstance), resourcecontroller.CosResourceID, resourcecontroller.GetCOSResourcePlanID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get COS service instance: %w", err)
 	}
@@ -2404,7 +2404,7 @@ func (s *PowerVSClusterScope) createCOSServiceInstance() (*resourcecontrollerv2.
 		Name:           s.GetServiceName(infrav1.ResourceTypeCOSInstance),
 		Target:         &target,
 		ResourceGroup:  &resourceGroupID,
-		ResourcePlanID: ptr.To(resourcecontroller.CosResourcePlanID),
+		ResourcePlanID: ptr.To(resourcecontroller.GetCOSResourcePlanID()),
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/scope/powervs_image.go
+++ b/cloud/scope/powervs_image.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/resourcecontroller"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/endpoints"
@@ -78,7 +79,9 @@ func NewPowerVSImageScope(ctx context.Context, params PowerVSImageScopeParams) (
 	scope.IBMPowerVSImage = params.IBMPowerVSImage
 
 	// Create Resource Controller client.
-	var serviceOption resourcecontroller.ServiceOptions
+	serviceOption := resourcecontroller.ServiceOptions{
+		ResourceControllerV2Options: &resourcecontrollerv2.ResourceControllerV2Options{},
+	}
 	// Fetch the resource controller endpoint.
 	rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
 	if rcEndpoint != "" {
@@ -132,11 +135,20 @@ func NewPowerVSImageScope(ctx context.Context, params PowerVSImageScopeParams) (
 		},
 	}
 
-	// Fetch the service endpoint.
-	if svcEndpoint := endpoints.FetchPVSEndpoint(endpoints.ConstructRegionFromZone(*res.RegionID), params.ServiceEndpoint); svcEndpoint != "" {
+	// Use FetchEndpoints (ID-only match) so that PowerVS service URL overrides are applied
+	// regardless of whether res.RegionID round-trips through ConstructRegionFromZone to the
+	// same region string stored in the ServiceEndpoint list.
+	if svcEndpoint := endpoints.FetchEndpoints(string(endpoints.PowerVS), params.ServiceEndpoint); svcEndpoint != "" {
 		options.IBMPIOptions.URL = svcEndpoint
 		log.V(3).Info("Overriding the default PowerVS service endpoint", "serviceEndpoint", svcEndpoint)
 	}
+
+	// Get the authenticator to ensure IAM endpoint overrides are respected.
+	auth, err := authenticator.GetIAMAuthenticator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticator: %w", err)
+	}
+	options.Authenticator = auth
 
 	c, err := powervs.NewService(options)
 	if err != nil {

--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -41,6 +41,7 @@ import (
 	"github.com/IBM/ibm-cos-sdk-go/aws"
 	cosSession "github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
+	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -140,7 +141,9 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 	}
 
 	// Create Resource Controller client.
-	var serviceOption resourcecontroller.ServiceOptions
+	serviceOption := resourcecontroller.ServiceOptions{
+		ResourceControllerV2Options: &resourcecontrollerv2.ResourceControllerV2Options{},
+	}
 	// Fetch the resource controller endpoint.
 	rcEndpoint := endpoints.FetchEndpoints(string(endpoints.RC), params.ServiceEndpoint)
 	if rcEndpoint != "" {
@@ -190,8 +193,10 @@ func NewPowerVSMachineScope(params PowerVSMachineScopeParams) (scope *PowerVSMac
 		CloudInstanceID: serviceInstanceID,
 	}
 
-	// Fetch the service endpoint.
-	if svcEndpoint := endpoints.FetchPVSEndpoint(region, params.ServiceEndpoint); svcEndpoint != "" {
+	// Use FetchEndpoints (ID-only match) so that PowerVS service URL overrides are applied
+	// regardless of whether res.RegionID round-trips through ConstructRegionFromZone to the
+	// same region string stored in the ServiceEndpoint list.
+	if svcEndpoint := endpoints.FetchEndpoints(string(endpoints.PowerVS), params.ServiceEndpoint); svcEndpoint != "" {
 		serviceOptions.IBMPIOptions.URL = svcEndpoint
 		params.Logger.V(3).Info("Overriding the default PowerVS service endpoint", "serviceEndpoint", svcEndpoint)
 	}
@@ -559,7 +564,7 @@ func (m *PowerVSMachineScope) createCOSClient(ctx context.Context) (cos.Cos, err
 		cosInstanceName = m.IBMPowerVSCluster.Spec.CosInstance.Name
 	}
 
-	serviceInstance, err := m.ResourceClient.GetInstanceByName(cosInstanceName, resourcecontroller.CosResourceID, resourcecontroller.CosResourcePlanID)
+	serviceInstance, err := m.ResourceClient.GetInstanceByName(cosInstanceName, resourcecontroller.CosResourceID, resourcecontroller.GetCOSResourcePlanID())
 	if err != nil {
 		log.Error(err, "failed to get COS service instance", "name", cosInstanceName)
 		return nil, err

--- a/controllers/ibmpowervsimage_controller.go
+++ b/controllers/ibmpowervsimage_controller.go
@@ -232,9 +232,9 @@ func reconcileImage(ctx context.Context, img *models.ImageReference, imageScope 
 		}
 
 		imageScope.SetImageID(image.ImageID)
-		log.Info("ImageID", imageScope.GetImageID())
+		log.Info("Setting image ID", "imageID", imageScope.GetImageID())
 		imageScope.SetImageState(image.State)
-		log.Info("ImageState", image.State)
+		log.Info("Current image state", "imageState", image.State)
 
 		switch imageScope.GetImageState() {
 		case infrav1.PowerVSImageStateQueued:

--- a/pkg/cloud/services/authenticator/authenticator.go
+++ b/pkg/cloud/services/authenticator/authenticator.go
@@ -70,8 +70,11 @@ func GetIAMAuthenticator() (*core.IamAuthenticator, error) {
 		fmt.Printf("ibmcloud api key is not provided, set %s environmental variable", "IBMCLOUD_API_KEY")
 	}
 
+	// URL is the IAM token endpoint base URL (e.g. https://iam.test.cloud.ibm.com).
+	// When empty the IBM SDK defaults to the production endpoint (https://iam.cloud.ibm.com).
 	auth := &core.IamAuthenticator{
 		ApiKey: apiKey,
+		URL:    props["AUTH_URL"],
 	}
 
 	return auth, nil

--- a/pkg/cloud/services/cos/service.go
+++ b/pkg/cloud/services/cos/service.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
@@ -29,12 +30,14 @@ import (
 	"github.com/IBM/ibm-cos-sdk-go/aws/request"
 	cosSession "github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
+
+	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 )
 
 // iamEndpoint represent the IAM authorisation URL.
 const (
-	iamEndpoint  = "https://iam.cloud.ibm.com/identity/token"
-	cosURLDomain = "cloud-object-storage.appdomain.cloud"
+	iamEndpointDefault = "https://iam.cloud.ibm.com/identity/token"
+	cosURLDomain       = "cloud-object-storage.appdomain.cloud"
 )
 
 // Service holds the IBM Cloud Resource Controller Service specific information.
@@ -120,6 +123,15 @@ func NewService(options ServiceOptions, apikey, serviceInstance string) (Cos, er
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
+	}
+	// Get IAM endpoint from authenticator properties, fallback to default.
+	iamEndpoint := iamEndpointDefault
+	if props, err := authenticator.GetProperties(); err == nil {
+		if authURL := props["AUTH_URL"]; authURL != "" {
+			authURL = strings.TrimSuffix(authURL, "/identity/token")
+			authURL = strings.TrimSuffix(authURL, "/")
+			iamEndpoint = authURL + "/identity/token"
+		}
 	}
 	options.Config.Credentials = ibmiam.NewStaticCredentials(aws.NewConfig(), iamEndpoint, apikey, serviceInstance)
 

--- a/pkg/cloud/services/resourcecontroller/service.go
+++ b/pkg/cloud/services/resourcecontroller/service.go
@@ -18,6 +18,8 @@ package resourcecontroller
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
@@ -44,7 +46,21 @@ const (
 	// CosResourcePlanID is IBM COS plan id, can be retrieved using ibmcloud cli
 	// ibmcloud catalog service cloud-object-storage.
 	CosResourcePlanID = "1e4e33e4-cfa6-4f12-9016-be594a6d5f87"
+
+	// CosResourceLitePlanID is IBM COS Lite plan id (free, staging/non-paid accounts).
+	// Can be retrieved using: ibmcloud catalog service cloud-object-storage.
+	CosResourceLitePlanID = "2fdf0c08-2d32-4f46-84b5-32e0c92fffd8"
 )
+
+// GetCOSResourcePlanID returns the appropriate COS plan ID based on the IBMCLOUD_STAGING
+// environment variable. Staging (non-paid) accounts require the Lite plan; production uses Standard.
+func GetCOSResourcePlanID() string {
+	v := strings.ToLower(os.Getenv("IBMCLOUD_STAGING"))
+	if v == "true" || v == "1" || v == "yes" || v == "on" {
+		return CosResourceLitePlanID
+	}
+	return CosResourcePlanID
+}
 
 // Service holds the IBM Cloud Resource Controller Service specific information.
 type Service struct {


### PR DESCRIPTION
 These are the CAPI changes needed to support the service endpoint overrides in the installer. Backport of [#2837](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2837) Backport is needed to revendor the installer which pins version 12.2

Changes:

- Use FetchEndpoints (ID-only) instead of deprecated FetchPVSEndpoint in powervs_image.go and powervs_machine.go scope constructors to ensure PowerVS service URL override is applied regardless of region string.
- Initialise ResourceControllerV2Options in serviceOption in powervs_image.go and powervs_machine.go so RC endpoint overrides are propagated.
- Wire GetIAMAuthenticator into NewPowerVSImageScope so IAM endpoint (AUTH_URL) overrides are respected by the PowerVS session.
- Pass AUTH_URL into IamAuthenticator.URL in authenticator.go.
- Make COS NewService read AUTH_URL from authenticator properties so the IAM token endpoint can be overridden for staging environments.
- Fix structured log keys in ibmpowervsimage_controller.go (imageID, imageState) to satisfy structured logging linting.

What this PR does / why we need it:

This PR makes the PowerVS machine, image, and cluster scope constructors correctly
honour service endpoint overrides (e.g. staging/test environment URLs) passed in
via ServiceEndpoint, and ensures those overrides flow through to both the IAM
authenticator and the COS client.

Four concrete bugs are fixed:

1. FetchPVSEndpoint silently dropped PowerVS endpoint overrides in
NewPowerVSImageScope and NewMachineScope. FetchPVSEndpoint (deprecated)
matches on both a region string and a service ID. When the region derived
from serviceInstance.RegionID did not round-trip through
ConstructRegionFromZone to exactly the same string stored in the
ServiceEndpoint list, it returned "", leaving the session URL as the
production default. This caused the PowerVS session to mint a bluemix CRN
instead of a staging CRN, which then made the PowerVS API validate bearer
tokens against iam.cloud.ibm.com/identity/keys instead of
iam.test.cloud.ibm.com/identity/keys, causing auth failures in the installer
on staging. Fixed by switching to FetchEndpoints (ID-only match) in both
scopes, consistent with how ClusterScope.getPowerVSClient already works.

2. ResourceControllerServiceOptions was zero-initialised in
NewPowerVSImageScope and NewMachineScope (var serviceOption resourcecontroller.ServiceOptions), leaving ResourceControllerV2Options as
nil. This prevented RC endpoint URL overrides from being applied. Fixed by
eagerly initializing ResourceControllerV2Options to match the pattern already
established in ClusterScope.

3. IAM authenticator did not pick up AUTH_URL from external configuration
(e.g. IBMCLOUD_AUTH_URL env var / credentials file). The IamAuthenticator
was built with only ApiKey set, so all token requests always went to the
production IAM endpoint. Fixed by wiring props["AUTH_URL"] into
IamAuthenticator.URL, and by calling GetIAMAuthenticator() in
NewPowerVSImageScope to pass the resulting authenticator into the PowerVS
session options.

4. COS NewService hard-coded the production IAM token URL. Fixed by reading
AUTH_URL from authenticator.GetProperties() at runtime and appending
/identity/token, with a fallback to the original production default when the
property is absent.

Additionally, two unstructured log.Info calls in ibmpowervsimage_controller.go
that were missing key-value pairs (log.Info("ImageID", value) instead of
log.Info("ImageID", "imageID", value)) are corrected to satisfy structured
logging requirements.