### PR TITLE
Update PowerVS cloud controller commit to include security fixes

### DIFF
--- a/hack/ccm/Makefile
+++ b/hack/ccm/Makefile
@@ -20,7 +20,7 @@ REGISTRY=gcr.io/k8s-staging-capi-ibmcloud
 IMG=powervs-cloud-controller-manager
 
 # POWERVS_CLOUD_CONTROLLER_COMMIT can be fetched from here https://github.com/openshift/cloud-provider-powervs/commits/main
-POWERVS_CLOUD_CONTROLLER_COMMIT?=626c77c
+POWERVS_CLOUD_CONTROLLER_COMMIT?=18eb523
 TAG?=$(POWERVS_CLOUD_CONTROLLER_COMMIT)
 
 build-image: init-buildx gcloud-auth


### PR DESCRIPTION
Bumps `POWERVS_CLOUD_CONTROLLER_COMMIT` from `626c77c` to `18eb523` to pull in security fixes merged in [openshift/cloud-provider-powervs#107](https://github.com/openshift/cloud-provider-powervs/pull/107):

| Advisory | Severity | Package | Before | After |
|---|---|---|---|---|
| GHSA-gcjh-h69q-9w9g | MEDIUM | `github.com/google/cel-go` | `v0.27.0` | `v0.29.0` |
| GHSA-hrxh-6v49-42gf | HIGH | `google.golang.org/grpc` | `v1.79.3` | `v1.82.1` |
| CVE-2026-56852 | HIGH | `golang.org/x/text` | `v0.37.0` | `v0.39.0` |

/cherry-pick release-0.13
/cherry-pick release-0.14