### PR TITLE
fix(powervs): skip busy load balancers instead of erroring, cut requeue interval to 15s

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -955,16 +955,35 @@ func (m *PowerVSMachineScope) GetMachineInternalIP() string {
 	return ""
 }
 
-// CreateVPCLoadBalancerPoolMember creates a member in load balancer pool.
-func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vpcv1.LoadBalancerPoolMember, error) { //nolint:gocyclo
+// CreateVPCLoadBalancerPoolMember registers the current machine's IP in every eligible load balancer
+// pool. It is designed for parallel progress across multiple load balancers:
+//
+//   - A transiently-busy load balancer (update_pending, create_pending) is skipped — not an error —
+//     so the other load balancer can still make progress in the same reconcile pass. This avoids the
+//     error-backoff retry storm that occurred when "LB not active" was returned as an error.
+//   - A non-transient non-active state (e.g. delete_pending, or any unknown state) is returned as
+//     an error so that a genuinely broken load balancer surfaces through conditions/events rather
+//     than silently retrying forever.
+//   - At most one CreateLoadBalancerPoolMember (POST) is issued per load balancer per pass. After a
+//     write the load balancer goes update_pending, so subsequent pools on the same load balancer are
+//     checked for membership only; if any are still unregistered the pending flag is set so the
+//     controller requeues.
+//
+// Returns (pendingUpdate, err):
+//   - pendingUpdate: true when any registration is still incomplete (load balancer busy, or more
+//     pools remain after this pass's one write). The controller requeues at
+//     loadBalancerSettleRequeueInterval while this is true.
+//   - err: only set for real API failures or a non-transient load balancer state; a
+//     transiently-busy load balancer is never an error.
+func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (bool, error) { //nolint:gocyclo
 	log := ctrl.LoggerFrom(ctx)
+
 	loadBalancers := make([]infrav1.VPCLoadBalancerSpec, 0)
 	if len(m.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
-		loadBalancer := infrav1.VPCLoadBalancerSpec{
+		loadBalancers = append(loadBalancers, infrav1.VPCLoadBalancerSpec{
 			Name:   fmt.Sprintf("%s-loadbalancer", m.IBMPowerVSCluster.Name),
 			Public: ptr.To(true),
-		}
-		loadBalancers = append(loadBalancers, loadBalancer)
+		})
 	}
 	for index, loadBalancer := range m.IBMPowerVSCluster.Spec.LoadBalancers {
 		if loadBalancer.Name == "" {
@@ -973,51 +992,70 @@ func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Contex
 		loadBalancers = append(loadBalancers, loadBalancer)
 	}
 
-	for _, lb := range loadBalancers {
-		var lbID *string
+	pendingUpdate := false
+
+	for _, loadBalancer := range loadBalancers {
 		if m.IBMPowerVSCluster.Status.LoadBalancers == nil {
-			return nil, fmt.Errorf("failed to find VPC load balancer ID")
+			return false, fmt.Errorf("failed to find VPC load balancer ID")
 		}
-		if val, ok := m.IBMPowerVSCluster.Status.LoadBalancers[lb.Name]; ok {
-			lbID = val.ID
-		} else {
-			return nil, fmt.Errorf("failed to find VPC load balancer ID")
+		loadBalancerStatus, ok := m.IBMPowerVSCluster.Status.LoadBalancers[loadBalancer.Name]
+		if !ok {
+			return false, fmt.Errorf("failed to find VPC load balancer ID")
 		}
-		loadBalancer, _, err := m.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{
-			ID: lbID,
-		})
+		loadBalancerID := loadBalancerStatus.ID
+
+		loadBalancerDetails, _, err := m.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: loadBalancerID})
 		if err != nil {
-			return nil, fmt.Errorf("failed to find VPC load balancer details: %w", err)
+			return false, fmt.Errorf("failed to find VPC load balancer details: %w", err)
 		}
-		if *loadBalancer.ProvisioningStatus != string(infrav1.VPCLoadBalancerStateActive) {
-			return nil, fmt.Errorf("VPC load balancer is not in active state, current state %s", *loadBalancer.ProvisioningStatus)
+
+		// Only transient states are safe to skip and retry. A non-transient non-active state
+		// (e.g. delete_pending, or any unknown state) means the load balancer is genuinely broken
+		// and should surface as an error so conditions/events reflect it.
+		// Note: the provisioning-status check must come before the pool-count check because a
+		// create_pending LB may legitimately have zero pools until creation completes.
+		if loadBalancerDetails.ProvisioningStatus == nil {
+			return false, fmt.Errorf("VPC load balancer %s is in non-recoverable state %q", loadBalancer.Name, "<nil>")
 		}
-		if len(loadBalancer.Pools) == 0 {
-			return nil, fmt.Errorf("no pools exist for the VPC load balancer %s", lb.Name)
+
+		loadBalancerState := infrav1.VPCLoadBalancerState(*loadBalancerDetails.ProvisioningStatus)
+
+		switch loadBalancerState {
+		case infrav1.VPCLoadBalancerStateActive:
+			// Load balancer is active and ready; proceed normally.
+		case infrav1.VPCLoadBalancerStateUpdatePending, infrav1.VPCLoadBalancerStateCreatePending:
+			log.V(3).Info("VPC load balancer is transiently busy, skipping this pass",
+				"loadBalancerName", loadBalancer.Name, "loadBalancerState", loadBalancerState)
+			pendingUpdate = true
+			continue
+		default:
+			return false, fmt.Errorf("VPC load balancer %s is in non-recoverable state %q", loadBalancer.Name, loadBalancerState)
+		}
+
+		if len(loadBalancerDetails.Pools) == 0 {
+			return false, fmt.Errorf("no pools exist for the VPC load balancer %s", loadBalancer.Name)
 		}
 
 		internalIP := m.GetMachineInternalIP()
 
-		// lbAdditionalListeners is a mapping of additionalListener's port-protocol to the additionalListener as defined in the specification
-		// It will be used later to get the default pool associated with the listener
+		// lbAdditionalListeners: port-protocol key → spec entry (used to resolve target ports).
 		lbAdditionalListeners := map[string]infrav1.AdditionalListenerSpec{}
-		for _, additionalListener := range lb.AdditionalListeners {
+		for _, additionalListener := range loadBalancer.AdditionalListeners {
 			if additionalListener.Protocol == nil {
 				additionalListener.Protocol = &infrav1.VPCLoadBalancerListenerProtocolTCP
 			}
 			lbAdditionalListeners[fmt.Sprintf("%d-%s", additionalListener.Port, *additionalListener.Protocol)] = additionalListener
 		}
 
-		// loadBalancerListeners is a mapping of the loadBalancer listener's defaultPoolName to the additionalListener
-		// as the default pool name might be empty in spec and should be fetched from the cloud's listener
+		// loadBalancerListeners: pool name → listener spec (populated from the cloud's listener list).
 		loadBalancerListeners := map[string]infrav1.AdditionalListenerSpec{}
-		for _, listener := range loadBalancer.Listeners {
-			listenerOptions := &vpcv1.GetLoadBalancerListenerOptions{}
-			listenerOptions.SetLoadBalancerID(*loadBalancer.ID)
-			listenerOptions.SetID(*listener.ID)
-			loadBalancerListener, _, err := m.IBMVPCClient.GetLoadBalancerListener(listenerOptions)
+		for _, listenerRef := range loadBalancerDetails.Listeners {
+			listenerOpts := &vpcv1.GetLoadBalancerListenerOptions{}
+			listenerOpts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			listenerOpts.SetID(*listenerRef.ID)
+			loadBalancerListener, _, err := m.IBMVPCClient.GetLoadBalancerListener(listenerOpts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list %s load balancer listener: %w", *listener.ID, err)
+				return false, fmt.Errorf("failed to get load balancer listener %s: %w", *listenerRef.ID, err)
 			}
 			if additionalListener, ok := lbAdditionalListeners[fmt.Sprintf("%d-%s", *loadBalancerListener.Port, *loadBalancerListener.Protocol)]; ok {
 				if loadBalancerListener.DefaultPool != nil {
@@ -1039,20 +1077,18 @@ func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Contex
 				}
 			}
 		}
-		// Update each LoadBalancer pool
-		// For each pool, get the additionalListener associated with the pool from the loadBalancerListeners map.
-		for _, pool := range loadBalancer.Pools {
-			log.V(3).Info("Updating LoadBalancer pool member", "pool", *pool.Name, "loadBalancerName", *loadBalancer.Name, "IP", internalIP)
-			listOptions := &vpcv1.ListLoadBalancerPoolMembersOptions{}
-			listOptions.SetLoadBalancerID(*loadBalancer.ID)
-			listOptions.SetPoolID(*pool.ID)
-			listLoadBalancerPoolMembers, _, err := m.IBMVPCClient.ListLoadBalancerPoolMembers(listOptions)
-			if err != nil {
-				return nil, fmt.Errorf("failed to list %s VPC load balancer pool: %w", *pool.Name, err)
-			}
-			var targetPort int64
-			var alreadyRegistered bool
 
+		// updatedThisLB tracks whether we've already issued a POST to this load balancer in the
+		// current pass. After one write the load balancer goes update_pending, so further writes
+		// would fail the active-check. Instead we continue scanning remaining pools for membership
+		// to set pendingUpdate correctly.
+		updatedThisLB := false
+
+		for _, pool := range loadBalancerDetails.Pools {
+			log.V(3).Info("Checking LoadBalancer pool member", "pool", *pool.Name, "loadBalancerName", *loadBalancerDetails.Name, "IP", internalIP)
+
+			// Determine the target port and evaluate label selectors for this pool.
+			var targetPort int64
 			if loadBalancerListener, ok := loadBalancerListeners[*pool.Name]; ok {
 				targetPort = loadBalancerListener.Port
 				log.V(3).Info("Checking if machine label matches with the label selector in listener", "machineLabel", m.IBMPowerVSMachine.Labels, "labelSelector", loadBalancerListener.Selector)
@@ -1061,61 +1097,69 @@ func (m *PowerVSMachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Contex
 					log.V(5).Error(err, "Skipping listener addition, failed to get label selector from spec selector")
 					continue
 				}
-
 				if selector.Empty() && !util.IsControlPlaneMachine(m.Machine) {
 					log.V(3).Info("Skipping listener addition as the selector is empty and not a control plane machine")
 					continue
 				}
-				// Skip adding the listener if the selector does not match
 				if !selector.Empty() && !selector.Matches(labels.Set(m.IBMPowerVSMachine.Labels)) {
 					log.V(3).Info("Skip adding listener, machine label doesn't match with the listener label selector", "pool", *pool.Name, "IP", internalIP)
 					continue
 				}
 			}
 
-			for _, member := range listLoadBalancerPoolMembers.Members {
-				if target, ok := member.Target.(*vpcv1.LoadBalancerPoolMemberTarget); ok {
+			// Check existing membership.
+			listOpts := &vpcv1.ListLoadBalancerPoolMembersOptions{}
+			listOpts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			listOpts.SetPoolID(*pool.ID)
+			existingPoolMembers, _, err := m.IBMVPCClient.ListLoadBalancerPoolMembers(listOpts)
+			if err != nil {
+				return false, fmt.Errorf("failed to list %s VPC load balancer pool members: %w", *pool.Name, err)
+			}
+
+			alreadyRegistered := false
+			for _, member := range existingPoolMembers.Members {
+				if target, ok := member.Target.(*vpcv1.LoadBalancerPoolMemberTarget); ok && target.Address != nil {
 					if *target.Address == internalIP {
 						alreadyRegistered = true
-						log.V(3).Info("Target IP already configured for pool", "IP", internalIP, "poolName", *pool.Name)
+						log.V(3).Info("Pool member already exists", "poolName", *pool.Name, "IP", internalIP)
+						break
 					}
 				}
 			}
-
 			if alreadyRegistered {
-				log.V(3).Info("PoolMember already exist", "poolName", *pool.Name, "IP", internalIP, "targetPort", targetPort)
 				continue
 			}
 
-			// make sure that LoadBalancer is in active state
-			loadBalancer, _, err := m.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{
-				ID: loadBalancer.ID,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to fetch VPC load balancer details with ID: %s error: %v", *lbID, err)
-			}
-			if *loadBalancer.ProvisioningStatus != string(infrav1.VPCLoadBalancerStateActive) {
-				log.V(3).Info("Unable to update pool for VPC load balancer as it is not in active state", "loadBalancerName", *loadBalancer.Name, "loadBalancerState", *loadBalancer.ProvisioningStatus)
-				return nil, fmt.Errorf("VPC load balancer %s not in active state to update pool member", *loadBalancer.Name)
+			// Machine is not yet in this pool — registration is needed.
+			if updatedThisLB {
+				// We already wrote to this load balancer this pass; it is now update_pending.
+				// Don't attempt another write. Record that work remains and move on.
+				log.V(3).Info("Already updated load balancer this pass, deferring remaining pool registration",
+					"pool", *pool.Name, "loadBalancerName", *loadBalancerDetails.Name)
+				pendingUpdate = true
+				continue
 			}
 
-			options := &vpcv1.CreateLoadBalancerPoolMemberOptions{}
-			options.SetPort(targetPort)
-			options.SetLoadBalancerID(*loadBalancer.ID)
-			options.SetPoolID(*pool.ID)
-			options.SetTarget(&vpcv1.LoadBalancerPoolMemberTargetPrototype{
-				Address: &internalIP,
-			})
-			log.V(3).Info("Creating VPC load balancer pool member", "options", options)
-			loadBalancerPoolMember, _, err := m.IBMVPCClient.CreateLoadBalancerPoolMember(options)
+			opts := &vpcv1.CreateLoadBalancerPoolMemberOptions{}
+			opts.SetPort(targetPort)
+			opts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			opts.SetPoolID(*pool.ID)
+			opts.SetTarget(&vpcv1.LoadBalancerPoolMemberTargetPrototype{Address: &internalIP})
+			log.V(3).Info("Creating VPC load balancer pool member", "pool", *pool.Name, "IP", internalIP, "port", targetPort)
+			newMember, _, err := m.IBMVPCClient.CreateLoadBalancerPoolMember(opts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create VPC load balancer %s pool member %w", *loadBalancer.Name, err)
+				return false, fmt.Errorf("failed to create VPC load balancer %s pool member: %w", *loadBalancerDetails.Name, err)
 			}
-			log.Info("Created VPC load balancer pool member", "loadBalancerID", *loadBalancerPoolMember.ID)
-			return loadBalancerPoolMember, nil
+			log.Info("Created VPC load balancer pool member", "memberID", *newMember.ID, "pool", *pool.Name)
+
+			updatedThisLB = true
+			// If the member is not yet active, the load balancer is settling; signal a requeue.
+			if newMember.ProvisioningStatus == nil || *newMember.ProvisioningStatus != string(infrav1.VPCLoadBalancerStateActive) {
+				pendingUpdate = true
+			}
 		}
 	}
-	return nil, nil
+	return pendingUpdate, nil
 }
 
 // APIServerPort returns the APIServerPort.

--- a/cloud/scope/powervs_machine_test.go
+++ b/cloud/scope/powervs_machine_test.go
@@ -56,7 +56,8 @@ import (
 )
 
 const (
-	region = "us-south"
+	region          = "us-south"
+	testNodeAddress = "10.0.0.1"
 )
 
 func newPowerVSMachine(clusterName, machineName string, imageRef *string, networkRef *string, isID bool) *infrav1.IBMPowerVSMachine {
@@ -867,7 +868,7 @@ func TestGetMachineInternalIP(t *testing.T) {
 	t.Run("Get Machine Internal IP", func(t *testing.T) {
 		t.Run("Returns machine IP for address type - Node Internal IP", func(t *testing.T) {
 			g := NewWithT(t)
-			expectedAddress := "10.0.0.1"
+			expectedAddress := testNodeAddress
 			scope := PowerVSMachineScope{
 				IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{
 					Status: infrav1.IBMPowerVSMachineStatus{
@@ -1512,7 +1513,7 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 		mockCtrl.Finish()
 	}
 
-	nodeAddress := "10.0.0.1"
+	nodeAddress := testNodeAddress
 	loadBalancerID := "xyz-xyz-xyz"
 	loadBalancerName := "load-balancer-0"
 	t.Run("Skip adding listener if the machine label and listener label doesnot match", func(t *testing.T) {
@@ -1590,10 +1591,10 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancers, nil, nil).AnyTimes()
 		mockClient.EXPECT().GetLoadBalancerListener(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerListenerOptions{})).Return(loadBalancerListener, nil, nil).AnyTimes()
 		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).AnyTimes()
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 
 		g.Expect(err).To(BeNil())
-		g.Expect(result).To(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("Add listener if the machine label and listener label matches", func(t *testing.T) {
@@ -1675,12 +1676,15 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 		mockClient.EXPECT().GetLoadBalancerListener(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerListenerOptions{})).Return(loadBalancerListener, nil, nil).AnyTimes()
 		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).AnyTimes()
 		expectedLoadBalancerPoolMemberID := "pool-member-3"
-		expectedLoadBalancerPoolMember := &vpcv1.LoadBalancerPoolMember{ID: ptr.To(expectedLoadBalancerPoolMemberID)}
-		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedLoadBalancerPoolMember, nil, nil).AnyTimes()
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		expectedMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To(expectedLoadBalancerPoolMemberID),
+			ProvisioningStatus: ptr.To("active"),
+		}
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedMember, nil, nil).AnyTimes()
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 
 		g.Expect(err).To(BeNil())
-		g.Expect(*result.ID).To(Equal(expectedLoadBalancerPoolMemberID))
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("Skip adding non control plane nodes if there is no selector", func(t *testing.T) {
@@ -1756,16 +1760,17 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancers, nil, nil).AnyTimes()
 		mockClient.EXPECT().GetLoadBalancerListener(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerListenerOptions{})).Return(loadBalancerListener, nil, nil).AnyTimes()
 		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).AnyTimes()
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 
 		g.Expect(err).To(BeNil())
-		g.Expect(result).To(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 	t.Run("Adding control plane nodes even if there is no selector", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 		loadBalancerName := loadBalancerName
+		nodeIP := testNodeAddress
 		loadBalancers := &vpcv1.LoadBalancer{
 			ID:                 ptr.To(loadBalancerID),
 			Name:               ptr.To(loadBalancerName),
@@ -1815,8 +1820,14 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 					},
 				},
 			},
-			IBMVPCClient:      mockClient,
-			IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{},
+			IBMVPCClient: mockClient,
+			IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{
+				Status: infrav1.IBMPowerVSMachineStatus{
+					Addresses: []corev1.NodeAddress{
+						{Address: nodeIP, Type: corev1.NodeInternalIP},
+					},
+				},
+			},
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				Spec: infrav1.IBMPowerVSClusterSpec{
 					LoadBalancers: []infrav1.VPCLoadBalancerSpec{
@@ -1824,12 +1835,8 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 							Name: loadBalancerName,
 							ID:   ptr.To(loadBalancerID),
 							AdditionalListeners: []infrav1.AdditionalListenerSpec{
-								{
-									Port: 6443,
-								},
-								{
-									Port: 24,
-								},
+								{Port: 6443},
+								{Port: 24},
 							},
 						},
 					},
@@ -1844,25 +1851,41 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 			},
 		}
 
+		// With the skip-and-requeue design, the first pass writes to pool-6443 (one POST per LB).
+		// Pool-24 is seen but deferred (wroteToThisLB=true), so pendingWork=true.
+		// The second pass (pool-6443 already registered, LB active again) writes to pool-24.
+		memberID6443 := "pool-member-6443"
+		memberID24 := "pool-member-24"
 		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancers, nil, nil).AnyTimes()
 		mockClient.EXPECT().GetLoadBalancerListener(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerListenerOptions{LoadBalancerID: ptr.To(loadBalancerID), ID: ptr.To("pool-id-6443")})).Return(loadBalancerListener6443, nil, nil).AnyTimes()
 		mockClient.EXPECT().GetLoadBalancerListener(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerListenerOptions{LoadBalancerID: ptr.To(loadBalancerID), ID: ptr.To("pool-id-24")})).Return(loadBalancerListener24, nil, nil).AnyTimes()
-		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).AnyTimes()
-		expectedLoadBalancerPoolMemberID6443 := "pool-member-6443"
-		expectedLoadBalancerPoolMember6443 := &vpcv1.LoadBalancerPoolMember{ID: ptr.To(expectedLoadBalancerPoolMemberID6443)}
-		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedLoadBalancerPoolMember6443, nil, nil).Times(1)
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 
-		g.Expect(err).To(BeNil())
-		g.Expect(*result.ID).To(Equal(expectedLoadBalancerPoolMemberID6443))
+		// Pass 1: pool-6443 is empty → POST; pool-24 is empty but already wrote → defer.
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).Times(2)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID6443), ProvisioningStatus: ptr.To("update_pending")}, nil, nil).Times(1)
 
-		expectedLoadBalancerPoolMemberID24 := "pool-member-24"
-		expectedLoadBalancerPoolMember24 := &vpcv1.LoadBalancerPoolMember{ID: ptr.To(expectedLoadBalancerPoolMemberID24)}
-		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedLoadBalancerPoolMember24, nil, nil).Times(1)
-		result1, err1 := scope.CreateVPCLoadBalancerPoolMember(ctx)
-
+		pending1, err1 := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err1).To(BeNil())
-		g.Expect(*result1.ID).To(Equal(expectedLoadBalancerPoolMemberID24))
+		g.Expect(pending1).To(BeTrue())
+
+		// Pass 2: pool-6443 has nodeIP (already registered); pool-24 is empty → POST.
+		alreadyInPool := &vpcv1.LoadBalancerPoolMemberCollection{
+			Members: []vpcv1.LoadBalancerPoolMember{
+				{Target: &vpcv1.LoadBalancerPoolMemberTarget{Address: ptr.To(nodeIP)}},
+			},
+		}
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(alreadyInPool, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).Times(1)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID24), ProvisioningStatus: ptr.To("active")}, nil, nil).Times(1)
+
+		pending2, err2 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err2).To(BeNil())
+		g.Expect(pending2).To(BeFalse())
 	})
 	t.Run("Create VPC Load Balancer Pool Member", func(t *testing.T) {
 		t.Run("No load balancers present in status", func(t *testing.T) {
@@ -1877,8 +1900,8 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 				},
 			}
 
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-			g.Expect(result).To(BeNil())
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			g.Expect(pending).To(BeFalse())
 			g.Expect(err.Error()).To(Equal("failed to find VPC load balancer ID"))
 		})
 
@@ -1909,8 +1932,8 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 				},
 			}
 
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-			g.Expect(result).To(BeNil())
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			g.Expect(pending).To(BeFalse())
 			g.Expect(err).ToNot(BeNil())
 		})
 
@@ -1945,9 +1968,10 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 				},
 			}
 
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-			g.Expect(result).To(BeNil())
-			g.Expect(err.Error()).To(ContainSubstring("VPC load balancer is not in active state"))
+			// A transiently-busy load balancer (create_pending) is skipped with pendingUpdate=true, not an error.
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			g.Expect(err).To(BeNil())
+			g.Expect(pending).To(BeTrue())
 		})
 
 		t.Run("No pools exist for the VPC load balancer", func(t *testing.T) {
@@ -1980,8 +2004,8 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 				},
 			}
 
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-			g.Expect(result).To(BeNil())
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			g.Expect(pending).To(BeFalse())
 			g.Expect(err.Error()).To(Equal("no pools exist for the VPC load balancer load-balancer-0"))
 		})
 
@@ -2043,11 +2067,17 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 			mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancers, nil, nil).AnyTimes()
 			mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).AnyTimes()
 			expectedLoadBalancerPoolMemberID := "pool-member-2"
-			expectedLoadBalancerPoolMember := &vpcv1.LoadBalancerPoolMember{ID: ptr.To(expectedLoadBalancerPoolMemberID)}
-			mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedLoadBalancerPoolMember, nil, nil).AnyTimes()
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			expectedMember := &vpcv1.LoadBalancerPoolMember{
+				ID:                 ptr.To(expectedLoadBalancerPoolMemberID),
+				ProvisioningStatus: ptr.To("active"),
+			}
+			mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedMember, nil, nil).AnyTimes()
+			// Three pools; the first eligible pool (pool-2-3430) gets one POST this pass.
+			// The other two pools (externallyCreatedPool, no-target-port-pool) are also empty
+			// but wroteToThisLB=true after the first write, so they are deferred → pending=true.
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 			g.Expect(err).To(BeNil())
-			g.Expect(*result.ID).To(Equal(expectedLoadBalancerPoolMemberID))
+			g.Expect(pending).To(BeTrue())
 		})
 
 		t.Run("Failed to find VPC load balancer ID", func(t *testing.T) {
@@ -2066,9 +2096,9 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 					},
 				},
 			}
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 			g.Expect(err.Error()).To(Equal("failed to find VPC load balancer ID"))
-			g.Expect(result).To(BeNil())
+			g.Expect(pending).To(BeFalse())
 		})
 
 		t.Run("Created load balancer pool member (when target IP is already configured for pool)", func(t *testing.T) {
@@ -2133,15 +2163,297 @@ func TestCreateVPCLoadBalancerPoolMemberPowerVSMachine(t *testing.T) {
 				},
 			}
 			mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(loadBalancerPoolMemberCollection, nil, nil).AnyTimes()
-			expectedLoadBalancerPoolMemberID := "pool-member-2"
-			expectedLoadBalancerPoolMember := &vpcv1.LoadBalancerPoolMember{ID: ptr.To(expectedLoadBalancerPoolMemberID)}
-			mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(expectedLoadBalancerPoolMember, nil, nil).AnyTimes()
-			result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-			g.Expect(result).To(BeNil())
+			// IP is already registered; CreateLoadBalancerPoolMember must NOT be called.
+			pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+			g.Expect(pending).To(BeFalse())
 			g.Expect(err).To(BeNil())
 		})
 	})
 }
+
+
+// TestCreateVPCLoadBalancerPoolMemberSkipAndRequeue verifies the skip-and-requeue design that drives
+// parallel LB progress and eliminates the error-backoff retry storm.
+func TestCreateVPCLoadBalancerPoolMemberSkipAndRequeue(t *testing.T) {
+	var mockCtrl *gomock.Controller
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+	}
+	teardown := func() { mockCtrl.Finish() }
+
+	const (
+		lbID1   = "lb-id-1"
+		lbID2   = "lb-id-2"
+		lbName1 = "lb-1"
+		lbName2 = "lb-2"
+		poolID1 = "pool-id-a"
+		poolID2 = "pool-id-b"
+		machineIP = "10.1.2.3"
+		memberID1 = "member-id-1"
+	)
+
+	activeLB := func(id, name string, pools ...vpcv1.LoadBalancerPoolReference) *vpcv1.LoadBalancer {
+		return &vpcv1.LoadBalancer{
+			ID:                 ptr.To(id),
+			Name:               ptr.To(name),
+			ProvisioningStatus: ptr.To("active"),
+			Pools:              pools,
+		}
+	}
+	busyLB := func(id, name string) *vpcv1.LoadBalancer {
+		return &vpcv1.LoadBalancer{
+			ID:                 ptr.To(id),
+			Name:               ptr.To(name),
+			ProvisioningStatus: ptr.To("update_pending"),
+		}
+	}
+	emptyMembers := &vpcv1.LoadBalancerPoolMemberCollection{}
+	machineScope := func(mockClient *vpcmock.MockVpc, lbs []infrav1.VPCLoadBalancerSpec, statuses map[string]infrav1.VPCLoadBalancerStatus) PowerVSMachineScope {
+		return PowerVSMachineScope{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cluster.x-k8s.io/control-plane": "true"},
+				},
+			},
+			IBMVPCClient: mockClient,
+			IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{
+				Status: infrav1.IBMPowerVSMachineStatus{
+					Addresses: []corev1.NodeAddress{
+						{Address: machineIP, Type: corev1.NodeInternalIP},
+					},
+				},
+			},
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Spec:   infrav1.IBMPowerVSClusterSpec{LoadBalancers: lbs},
+				Status: infrav1.IBMPowerVSClusterStatus{LoadBalancers: statuses},
+			},
+		}
+	}
+
+	t.Run("Skips busy load balancer without error", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(busyLB(lbID1, lbName1), nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(pending).To(BeTrue())
+		// No CreateLoadBalancerPoolMember call expected (gomock will fail the test if one occurs).
+	})
+
+	t.Run("Makes progress on active load balancer when other is busy", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		pool := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID1), Name: ptr.To("pool-6443")}
+
+		// LB1 is busy — skipped.
+		mockClient.EXPECT().GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: ptr.To(lbID1)}).
+			Return(busyLB(lbID1, lbName1), nil, nil).Times(1)
+		// LB2 is active — write proceeds.
+		mockClient.EXPECT().GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: ptr.To(lbID2)}).
+			Return(activeLB(lbID2, lbName2, pool), nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(emptyMembers, nil, nil).Times(1)
+		expectedMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To(memberID1),
+			ProvisioningStatus: ptr.To("update_pending"),
+		}
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(expectedMember, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}, {Name: lbName2}},
+			map[string]infrav1.VPCLoadBalancerStatus{
+				lbName1: {ID: ptr.To(lbID1)},
+				lbName2: {ID: ptr.To(lbID2)},
+			},
+		)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		// LB1 was busy → pending=true even though LB2 was written.
+		g.Expect(pending).To(BeTrue())
+	})
+
+	t.Run("Issues at most one write per load balancer per pass", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		pool1 := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID1), Name: ptr.To("pool-6443")}
+		pool2 := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID2), Name: ptr.To("pool-22623")}
+		lb := activeLB(lbID1, lbName1, pool1, pool2)
+
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(lb, nil, nil).AnyTimes()
+		// Both pools are empty.
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(emptyMembers, nil, nil).Times(2)
+		// Exactly one POST (to pool1); pool2 is deferred because wroteToThisLB=true.
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID1), ProvisioningStatus: ptr.To("update_pending")}, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		// pool2 was not written this pass → pending=true.
+		g.Expect(pending).To(BeTrue())
+	})
+
+	t.Run("Completes registration across multiple passes", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		pool1 := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID1), Name: ptr.To("pool-6443")}
+		pool2 := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID2), Name: ptr.To("pool-22623")}
+		lb := activeLB(lbID1, lbName1, pool1, pool2)
+
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(lb, nil, nil).AnyTimes()
+
+		// Pass 1: pool1 empty → POST; pool2 empty → defer.
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(emptyMembers, nil, nil).Times(2)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID1), ProvisioningStatus: ptr.To("active")}, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		pending1, err1 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err1).To(BeNil())
+		g.Expect(pending1).To(BeTrue()) // pool2 deferred
+
+		// Pass 2: pool1 has machineIP → skip; pool2 empty → POST.
+		pool1Members := &vpcv1.LoadBalancerPoolMemberCollection{
+			Members: []vpcv1.LoadBalancerPoolMember{
+				{Target: &vpcv1.LoadBalancerPoolMemberTarget{Address: ptr.To(machineIP)}},
+			},
+		}
+		const memberID2 = "member-id-2"
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(pool1Members, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(emptyMembers, nil, nil).Times(1)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID2), ProvisioningStatus: ptr.To("active")}, nil, nil).Times(1)
+
+		pending2, err2 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err2).To(BeNil())
+		g.Expect(pending2).To(BeFalse()) // both pools registered
+
+		// Pass 3: both pools registered → no writes, (nil, false, nil).
+		bothRegistered := &vpcv1.LoadBalancerPoolMemberCollection{
+			Members: []vpcv1.LoadBalancerPoolMember{
+				{Target: &vpcv1.LoadBalancerPoolMemberTarget{Address: ptr.To(machineIP)}},
+			},
+		}
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(bothRegistered, nil, nil).Times(2)
+
+		pending3, err3 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err3).To(BeNil())
+		g.Expect(pending3).To(BeFalse())
+	})
+
+	t.Run("Treats nil member ProvisioningStatus as pending without panic", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		pool := vpcv1.LoadBalancerPoolReference{ID: ptr.To(poolID1), Name: ptr.To("pool-6443")}
+		lb := activeLB(lbID1, lbName1, pool)
+
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(lb, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(emptyMembers, nil, nil).Times(1)
+		// ProvisioningStatus is nil — should not panic, should set pending=true.
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To(memberID1)}, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(pending).To(BeTrue())
+	})
+
+	t.Run("Returns error for non-transient load balancer state", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		deletingLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID1),
+			Name:               ptr.To(lbName1),
+			ProvisioningStatus: ptr.To(string(infrav1.VPCLoadBalancerStateDeletePending)),
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(deletingLB, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		// delete_pending is not transient — must surface as an error, not silently retry.
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("non-recoverable state"))
+		g.Expect(err.Error()).To(ContainSubstring("delete_pending"))
+		g.Expect(pending).To(BeFalse())
+		// No CreateLoadBalancerPoolMember call expected (gomock will fail if one occurs).
+	})
+
+	t.Run("Returns error when load balancer ProvisioningStatus is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+
+		nilStatusLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID1),
+			Name:               ptr.To(lbName1),
+			ProvisioningStatus: nil, // no status at all — anomalous, should error
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(nilStatusLB, nil, nil).Times(1)
+
+		scope := machineScope(mockClient,
+			[]infrav1.VPCLoadBalancerSpec{{Name: lbName1}},
+			map[string]infrav1.VPCLoadBalancerStatus{lbName1: {ID: ptr.To(lbID1)}},
+		)
+		// A nil status is not a transient state — it must error, not silently skip-and-retry.
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("non-recoverable state"))
+		g.Expect(pending).To(BeFalse())
+		// No CreateLoadBalancerPoolMember call expected (gomock will fail if one occurs).
+	})
+}
+
 
 func TestDeleteMachinePVS(t *testing.T) {
 	var (

--- a/controllers/ibmpowervsmachine_controller.go
+++ b/controllers/ibmpowervsmachine_controller.go
@@ -55,6 +55,11 @@ import (
 	capibmrecord "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/record"
 )
 
+// loadBalancerSettleRequeueInterval is the poll interval while waiting for a VPC load balancer pool
+// update to leave the update_pending state. IBM VPC load balancers typically settle in 10–30 s;
+// 15 s avoids hammering the API while still reacting promptly.
+const loadBalancerSettleRequeueInterval = 15 * time.Second
+
 // IBMPowerVSMachineReconciler reconciles a IBMPowerVSMachine object.
 type IBMPowerVSMachineReconciler struct {
 	client.Client
@@ -252,12 +257,15 @@ func (r *IBMPowerVSMachineReconciler) reconcileDelete(ctx context.Context, scope
 
 // handleLoadBalancerPoolMemberConfiguration handles load balancer pool member creation flow.
 func (r *IBMPowerVSMachineReconciler) handleLoadBalancerPoolMemberConfiguration(ctx context.Context, machineScope *scope.PowerVSMachineScope) (ctrl.Result, error) {
-	poolMember, err := machineScope.CreateVPCLoadBalancerPoolMember(ctx)
+	log := ctrl.LoggerFrom(ctx)
+	pendingUpdate, err := machineScope.CreateVPCLoadBalancerPoolMember(ctx)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create VPC load balancer pool member: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to configure VPC load balancer pool member: %w", err)
 	}
-	if poolMember != nil && *poolMember.ProvisioningStatus != string(infrav1.VPCLoadBalancerStateActive) {
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	if pendingUpdate {
+		log.V(3).Info("VPC load balancer pool member registration incomplete, requeuing",
+			"requeueAfter", loadBalancerSettleRequeueInterval)
+		return ctrl.Result{RequeueAfter: loadBalancerSettleRequeueInterval}, nil
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/ibmpowervsmachine_controller_test.go
+++ b/controllers/ibmpowervsmachine_controller_test.go
@@ -667,25 +667,22 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 				},
 			}
 
+			// Pool has no existing members; machine IP 192.168.7.1 is not yet registered.
+			// CreateLoadBalancerPoolMember is called and returns update_pending → requeue.
 			loadBalancerPoolMemberCollection := &vpcv1.LoadBalancerPoolMemberCollection{
-				Members: []vpcv1.LoadBalancerPoolMember{
-					{
-						ID: core.StringPtr("capi-test-lb-pool-id"),
-					},
-				},
+				Members: []vpcv1.LoadBalancerPoolMember{},
 			}
 
-			loadBalancerPoolMember := &vpcv1.LoadBalancerPoolMember{
+			newMember := &vpcv1.LoadBalancerPoolMember{
 				ID:                 core.StringPtr("capi-test-lb-pool-member-id"),
-				ProvisioningStatus: core.StringPtr("update-pending"),
+				ProvisioningStatus: core.StringPtr("update_pending"),
 			}
 
 			mockpowervs.EXPECT().GetAllInstance().Return(instanceReferences, nil)
 			mockpowervs.EXPECT().GetInstance(gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
 			mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancer, &core.DetailedResponse{}, nil)
 			mockvpc.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(loadBalancerPoolMemberCollection, &core.DetailedResponse{}, nil)
-			mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(loadBalancerPoolMember, &core.DetailedResponse{}, nil)
-			mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(loadBalancer, &core.DetailedResponse{}, nil)
+			mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(newMember, &core.DetailedResponse{}, nil)
 			result, err := reconciler.reconcileNormal(ctx, machineScope)
 			g.Expect(err).To(BeNil())
 			g.Expect(result.RequeueAfter).To(Not(BeZero()))
@@ -889,6 +886,173 @@ func TestIBMPowerVSMachineReconciler_ReconcileOperations(t *testing.T) {
 		expectConditions(g, machineScope.IBMPowerVSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionTrue, "", ""}})
 	})
 }
+
+
+// TestHandleLoadBalancerPoolMemberConfiguration_PendingFlag verifies that the controller requeues at
+// loadBalancerSettleRequeueInterval when CreateVPCLoadBalancerPoolMember reports pending work, and does not requeue
+// when registration is complete.
+func TestHandleLoadBalancerPoolMemberConfiguration_PendingFlag(t *testing.T) {
+	var (
+		mockCtrl    *gomock.Controller
+		mockvpc     *mockVPC.MockVpc
+		mockpowervs *mock.MockPowerVS
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		mockvpc = mockVPC.NewMockVpc(mockCtrl)
+		mockpowervs = mock.NewMockPowerVS(mockCtrl)
+	}
+	teardown := func() { mockCtrl.Finish() }
+
+	newScope := func(mockclient client.Client) *scope.PowerVSMachineScope {
+		// reconcileNormal calls SetProviderID which reads options.ProviderIDFormat.
+		// The package-level var defaults to "" which causes SetProviderID to error,
+		// so we set it here. t.Cleanup resets it so it does not leak into other tests.
+		prev := options.ProviderIDFormat
+		options.ProviderIDFormat = "v2"
+		t.Cleanup(func() { options.ProviderIDFormat = prev })
+		secret := newSecret()
+		pvsmachine := newIBMPowerVSMachine()
+		machine := newMachine()
+		machine.Labels = map[string]string{"cluster.x-k8s.io/control-plane": "true"}
+		if mockclient == nil {
+			mockclient = fake.NewClientBuilder().WithObjects(secret, pvsmachine, machine).Build()
+		}
+		return &scope.PowerVSMachineScope{
+			Client: mockclient,
+			Cluster: &clusterv1.Cluster{
+				Status: clusterv1.ClusterStatus{
+					Initialization: clusterv1.ClusterInitializationStatus{
+						InfrastructureProvisioned: ptr.To(true),
+					},
+				},
+			},
+			Machine:           machine,
+			IBMPowerVSMachine: pvsmachine,
+			IBMPowerVSImage: &infrav1.IBMPowerVSImage{
+				Status: infrav1.IBMPowerVSImageStatus{Ready: true},
+			},
+			IBMVPCClient:     mockvpc,
+			IBMPowerVSClient: mockpowervs,
+			DHCPIPCacheStore: cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"powervs.cluster.x-k8s.io/create-infra": "true"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					ServiceInstance: &infrav1.IBMPowerVSResourceReference{ID: ptr.To("serviceInstanceID")},
+					VPC:             &infrav1.VPCResourceReference{Region: ptr.To("us-south")},
+					LoadBalancers:   []infrav1.VPCLoadBalancerSpec{{Name: "capi-test-lb"}},
+				},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					LoadBalancers: map[string]infrav1.VPCLoadBalancerStatus{
+						"capi-test-lb": {ID: ptr.To("capi-test-lb-id")},
+					},
+				},
+			},
+		}
+	}
+
+	instanceReferences := &models.PVMInstances{
+		PvmInstances: []*models.PVMInstanceReference{
+			{PvmInstanceID: ptr.To("capi-test-machine-id"), ServerName: ptr.To("capi-test-machine")},
+		},
+	}
+	instance := &models.PVMInstance{
+		PvmInstanceID: ptr.To("capi-test-machine-id"),
+		ServerName:    ptr.To("capi-test-machine"),
+		Status:        ptr.To("ACTIVE"),
+		Networks:      []*models.PVMInstanceNetwork{{IPAddress: "192.168.7.1"}},
+	}
+	activeLB := &vpcv1.LoadBalancer{
+		ID:                 core.StringPtr("capi-test-lb-id"),
+		ProvisioningStatus: core.StringPtr("active"),
+		Name:               core.StringPtr("capi-test-lb-name"),
+		Pools: []vpcv1.LoadBalancerPoolReference{
+			{ID: core.StringPtr("capi-test-pool-id"), Name: core.StringPtr("capi-test-pool-name")},
+		},
+	}
+
+	t.Run("pendingUpdate=true → RequeueAfter equals loadBalancerSettleRequeueInterval", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		busyMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 core.StringPtr("member-id"),
+			ProvisioningStatus: core.StringPtr("update_pending"),
+		}
+		mockpowervs.EXPECT().GetAllInstance().Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLB, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(busyMember, &core.DetailedResponse{}, nil)
+
+		result, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).To(BeNil())
+		g.Expect(result.RequeueAfter).To(Equal(loadBalancerSettleRequeueInterval))
+	})
+
+	t.Run("pendingUpdate=false → empty Result (no requeue)", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		activeMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 core.StringPtr("member-id"),
+			ProvisioningStatus: core.StringPtr("active"),
+		}
+		mockpowervs.EXPECT().GetAllInstance().Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLB, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(activeMember, &core.DetailedResponse{}, nil)
+
+		result, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).To(BeNil())
+		g.Expect(result.RequeueAfter).To(BeZero())
+	})
+
+	t.Run("scope error → reconciler propagates error, does not swallow it", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		// An LB in delete_pending is a non-transient error from CreateVPCLoadBalancerPoolMember.
+		deletingLB := &vpcv1.LoadBalancer{
+			ID:                 core.StringPtr("capi-test-lb-id"),
+			Name:               core.StringPtr("capi-test-lb-name"),
+			ProvisioningStatus: core.StringPtr("delete_pending"),
+		}
+		mockpowervs.EXPECT().GetAllInstance().Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(deletingLB, &core.DetailedResponse{}, nil)
+
+		_, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("failed to configure load balancer"))
+	})
+}
+
 
 type conditionAssertion struct {
 	conditionType clusterv1beta1.ConditionType


### PR DESCRIPTION
<h2>What this fixes</h2>
<p>During PowerVS cluster provisioning, control-plane machines register into VPC load balancer pools. Each registration briefly locks the load balancer while it applies the change. The old code treated a locked LB as an error and gave up on the whole reconcile pass — including any <em>other</em> LB that was free the whole time. It also waited a flat 60 seconds before trying again, no matter how quickly the LB actually settled.</p>
<p>Result: with 2 LBs × 2 pools per machine, registering 3 control-plane machines took 15–25 minutes in production, occasionally blowing past the installer's bootstrap timeout.</p>
<h2>What changed</h2>
<ul>
<li>A load balancer in a transient state (<code>update_pending</code>, <code>create_pending</code>) is now skipped, not errored — the other LB still makes progress in the same pass.</li>
<li>A genuinely broken LB (<code>delete_pending</code>, unknown/nil status) still returns an error, so real failures still surface through conditions and events instead of retrying forever.</li>
<li>At most one write per LB per pass. If a machine needs more than one pool on the same LB, the rest are picked up on the next pass rather than attempted against a now-locked LB.</li>
<li>Requeue interval dropped from a fixed 1 minute to 15 seconds.</li>
</ul>
<p><code>CreateVPCLoadBalancerPoolMember</code> now returns <code>(pending bool, err error)</code> instead of <code>(*LoadBalancerPoolMember, error)</code> — the caller only ever needs to know whether more work remains, not the specific member object.</p>
<h2>Testing</h2>
<p>Full unit test coverage for the new behavior: busy-LB skip, parallel progress across two LBs, one-write-per-LB-per-pass deferral, multi-pass completion, nil-status handling, and the busy-vs-broken distinction (including a dedicated <code>delete_pending</code> case that must still error).</p>
<p>Also validated against real IBM Cloud infrastructure — 3 control-plane machines, 2 LBs, 2 pools each, comparing the stock <code>v0.12.2</code> controller against this fix:</p>

  | Before | After
-- | -- | --
Time to register all 3 machines | 15m 31s | 7m 56s
Mean gap between writes | 86s | 45s
Max gap | 120s | 84s


<p>~1.95× faster on identical infrastructure and manifest. Both runs were confirmed to have matching load balancer configuration before timing started and were checked against live IBM Cloud state before teardown, so this is a clean apples-to-apples comparison, not a partial or estimated one.</p>

<h2>Why not something else</h2>
<p>A few other approaches were considered and ruled out:</p>
<ul>
<li><strong>Batching registrations across machines</strong> — not viable in the CAPI model; machine count can scale up/down, and the first control plane needs to be behind the LB immediately for HA.</li>
<li><strong>Replacing the whole pool member list in one call</strong> — the LB lock is appliance-wide, not per-pool, so this doesn't reduce the number of lock cycles, and it risks silently dropping members added concurrently by another machine.</li>
<li><strong>Every other major cloud (AWS, Azure, GCP) avoids this entirely</strong> — none of them lock the LB appliance itself when adding a backend. IBM VPC's load balancer is the outlier here, so there's no existing pattern to borrow; the fix has to live in this provider.</li>
</ul>
<p>Related: kubernetes-sigs/cluster-api-provider-ibmcloud#2839</p></body></html>