### PR TITLE
powervs: change default systemType from s922 to s1022

### DIFF
--- a/api/powervs/v1beta2/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta2/ibmpowervsmachine_types.go
@@ -78,11 +78,11 @@ type IBMPowerVSMachineSpec struct {
 
 	// systemType is the System type used to host the instance.
 	// systemType determines the number of cores and memory that is available.
-	// Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+	// Few of the supported SystemTypes are e980,s1022,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
-	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+	// reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
-	// +kubebuilder:validation:Enum:="s922";"e980";"s1022";"e1050";"e1080";""
+	// +kubebuilder:validation:Enum:="e980";"s1022";"e1050";"e1080";""
 	// +optional
 	SystemType string `json:"systemType,omitempty"`
 

--- a/api/powervs/v1beta3/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta3/ibmpowervsmachine_types.go
@@ -83,9 +83,9 @@ type IBMPowerVSMachineSpec struct {
 
 	// systemType is the System type used to host the instance.
 	// systemType determines the number of cores and memory that is available.
-	// Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
+	// Few of the supported SystemTypes are e980,s1022,s1122,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
-	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+	// reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
 	// + The pattern validation allows any systemType matching PowerVS naming convention (lowercase letter + numbers).
 	// + Dynamic validation against PowerVS API is performed by the controller during reconciliation.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -218,11 +218,10 @@ spec:
                 description: |-
                   systemType is the System type used to host the instance.
                   systemType determines the number of cores and memory that is available.
-                  Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+                  Few of the supported SystemTypes are e980,s1022,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
-                  reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                  reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                 enum:
-                - s922
                 - e980
                 - s1022
                 - e1050
@@ -636,9 +635,9 @@ spec:
                 description: |-
                   systemType is the System type used to host the instance.
                   systemType determines the number of cores and memory that is available.
-                  Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
+                  Few of the supported SystemTypes are e980,s1022,s1122,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
-                  reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                  reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                 maxLength: 16
                 minLength: 1
                 pattern: ^[a-z][0-9]+$

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
@@ -190,11 +190,10 @@ spec:
                         description: |-
                           systemType is the System type used to host the instance.
                           systemType determines the number of cores and memory that is available.
-                          Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
+                          Few of the supported SystemTypes are e980,s1022,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
-                          reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                          reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                         enum:
-                        - s922
                         - e980
                         - s1022
                         - e1050
@@ -428,9 +427,9 @@ spec:
                         description: |-
                           systemType is the System type used to host the instance.
                           systemType determines the number of cores and memory that is available.
-                          Few of the supported SystemTypes are s922,e980,s1022,s1122,e1050,e1080.
+                          Few of the supported SystemTypes are e980,s1022,s1122,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
-                          reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                          reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                         maxLength: 16
                         minLength: 1
                         pattern: ^[a-z][0-9]+$

--- a/internal/webhooks/powervs/ibmpowervsmachine_test.go
+++ b/internal/webhooks/powervs/ibmpowervsmachine_test.go
@@ -45,7 +45,7 @@ func TestIBMPowerVSMachine_default(t *testing.T) {
 		},
 	}
 	g.Expect((&IBMPowerVSMachine{}).Default(context.Background(), powervsMachine)).ToNot(HaveOccurred())
-	g.Expect(powervsMachine.Spec.SystemType).To(BeEquivalentTo("s922"))
+	g.Expect(powervsMachine.Spec.SystemType).To(BeEquivalentTo("s1022"))
 	g.Expect(powervsMachine.Spec.ProcessorType).To(BeEquivalentTo(infrav1.PowerVSProcessorTypeShared))
 }
 

--- a/internal/webhooks/powervs/ibmpowervsmachinetemplate_test.go
+++ b/internal/webhooks/powervs/ibmpowervsmachinetemplate_test.go
@@ -49,7 +49,7 @@ func TestIBMPowerVSMachineTemplate_default(t *testing.T) {
 		},
 	}
 	g.Expect((&IBMPowerVSMachineTemplate{}).Default(context.Background(), powervsMachineTemplate)).ToNot(HaveOccurred())
-	g.Expect(powervsMachineTemplate.Spec.Template.Spec.SystemType).To(BeEquivalentTo("s922"))
+	g.Expect(powervsMachineTemplate.Spec.Template.Spec.SystemType).To(BeEquivalentTo("s1022"))
 	g.Expect(powervsMachineTemplate.Spec.Template.Spec.ProcessorType).To(BeEquivalentTo(infrav1.PowerVSProcessorTypeShared))
 }
 

--- a/internal/webhooks/powervs/powervs.go
+++ b/internal/webhooks/powervs/powervs.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultSystemType = "s922"
+	defaultSystemType = "s1022"
 )
 
 func defaultIBMPowerVSMachineSpec(spec *infrav1.IBMPowerVSMachineSpec) {

--- a/templates/bases/powervs/kcp.yaml
+++ b/templates/bases/powervs/kcp.yaml
@@ -189,5 +189,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}

--- a/templates/bases/powervs/md.yaml
+++ b/templates/bases/powervs/md.yaml
@@ -37,5 +37,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_COMPUTE_MEMORY:=4}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -293,7 +293,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}
 ---
@@ -314,7 +314,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}
 ---

--- a/templates/cluster-template-powervs-clusterclass/md.yaml
+++ b/templates/cluster-template-powervs-clusterclass/md.yaml
@@ -46,7 +46,7 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -67,5 +67,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -132,7 +132,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       workspace:
         name: ${CLUSTER_NAME}-workspace
 ---
@@ -174,7 +174,7 @@ spec:
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       workspace:
         name: ${CLUSTER_NAME}-workspace
 ---

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -233,7 +233,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}
 ---
@@ -275,7 +275,7 @@ spec:
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}
 ---

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -552,7 +552,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}
 ---
@@ -573,6 +573,6 @@ spec:
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       workspace:
         id: ${IBMPOWERVS_WORKSPACE_ID}


### PR DESCRIPTION
**What this PR does / why we need it**

The periodic PowerVS e2e job has failed on six consecutive runs
(Jul 31 – Aug 5). The Boskos workspaces it leases no longer support
the `s922` system type: `lon06` offers only `s1022`, and `eu-de-1`
offers `e1050`, `e1080`, `e1180`, `s1022` and `s1122`. Every machine
creation fails with `InvalidMachineConfiguration`, no control plane
comes up, and both e2e specs time out.

`s1022` is the only system type available in both workspaces, so it
is the only viable default while Boskos can allocate either one.

Changes:
- `defaultSystemType` in the mutating webhook is now `s1022`. This is
  the user-facing half of the fix — changing only the templates would
  still leave anyone omitting `systemType` defaulting to `s922`.
- All cluster templates and the e2e template default to `s1022`.
- `s922` is removed from the v1beta2 kubebuilder enum and the CRDs are
  regenerated.
- v1beta3 doc comments updated. No enum is added there — the controller
  already validates `systemType` dynamically against the PowerVS API,
  which is why v1beta3 carries only pattern validation.

**Note on the enum change**

Removing `s922` from the v1beta2 enum is a breaking change on the write
path: existing objects with `systemType: s922` will be rejected on any
write once the new CRD is applied. It is taken here because main is
pre-release and v1beta3 is the going-forward API, not because it is
non-breaking — v1beta2 is still served. Release branches are handled
separately.

**Follow-ups**

- Enum parity for `s1122` and `e1180`, which `eu-de-1` supports but
  neither API version lists.
- Whether `e980` (the other Power9, absent from both CI workspaces) is
  globally withdrawn or just not stocked in these two zones.
- `lon06` now has a single supported system type, so it has no fallback
  if `s1022` is ever withdrawn there — worth revisiting the Boskos pool.

**Which issue(s) this PR fixes**

Fixes #<issue>

/area provider/ibmcloud