### PR TITLE
 [release-0.14] powervs: change default systemType from s922 to s1022

### DIFF
--- a/api/powervs/v1beta2/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta2/ibmpowervsmachine_types.go
@@ -80,7 +80,7 @@ type IBMPowerVSMachineSpec struct {
 	// systemType determines the number of cores and memory that is available.
 	// Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
-	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+	// reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
 	// +kubebuilder:validation:Enum:="s922";"e980";"s1022";"e1050";"e1080";""
 	// +optional

--- a/api/powervs/v1beta3/ibmpowervsmachine_types.go
+++ b/api/powervs/v1beta3/ibmpowervsmachine_types.go
@@ -73,7 +73,7 @@ type IBMPowerVSMachineSpec struct {
 	// systemType determines the number of cores and memory that is available.
 	// Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
 	// When omitted, this means that the user has no opinion and the platform is left to choose a
-	// reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+	// reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
 	// + This is not an enum because we expect other values to be added later which should be supported implicitly.
 	// +kubebuilder:validation:Enum:="s922";"e980";"s1022";"e1050";"e1080";""
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachines.yaml
@@ -220,7 +220,7 @@ spec:
                   systemType determines the number of cores and memory that is available.
                   Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
-                  reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                  reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                 enum:
                 - s922
                 - e980
@@ -638,7 +638,7 @@ spec:
                   systemType determines the number of cores and memory that is available.
                   Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                   When omitted, this means that the user has no opinion and the platform is left to choose a
-                  reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                  reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                 enum:
                 - s922
                 - e980

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsmachinetemplates.yaml
@@ -192,7 +192,7 @@ spec:
                           systemType determines the number of cores and memory that is available.
                           Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
-                          reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                          reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                         enum:
                         - s922
                         - e980
@@ -425,7 +425,7 @@ spec:
                           systemType determines the number of cores and memory that is available.
                           Few of the supported SystemTypes are s922,e980,s1022,e1050,e1080.
                           When omitted, this means that the user has no opinion and the platform is left to choose a
-                          reasonable default, which is subject to change over time. The current default is s922 which is generally available.
+                          reasonable default, which is subject to change over time. The current default is s1022 which is generally available.
                         enum:
                         - s922
                         - e980

--- a/internal/webhooks/powervs/powervs.go
+++ b/internal/webhooks/powervs/powervs.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultSystemType = "s922"
+	defaultSystemType = "s1022"
 )
 
 func defaultIBMPowerVSMachineSpec(spec *infrav1.IBMPowerVSMachineSpec) {

--- a/templates/bases/powervs/kcp.yaml
+++ b/templates/bases/powervs/kcp.yaml
@@ -187,5 +187,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}

--- a/templates/bases/powervs/md.yaml
+++ b/templates/bases/powervs/md.yaml
@@ -35,5 +35,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_COMPUTE_MEMORY:=4}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}

--- a/templates/cluster-template-powervs-clusterclass.yaml
+++ b/templates/cluster-template-powervs-clusterclass.yaml
@@ -290,7 +290,7 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
 kind: IBMPowerVSMachineTemplate
@@ -309,7 +309,7 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet

--- a/templates/cluster-template-powervs-clusterclass/md.yaml
+++ b/templates/cluster-template-powervs-clusterclass/md.yaml
@@ -44,7 +44,7 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -63,5 +63,5 @@ spec:
         name: "${IBMPOWERVS_NETWORK_NAME}"
       memoryGiB: ${IBMPOWERVS_CONTROL_PLANE_MEMORY:=4}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}

--- a/templates/cluster-template-powervs-create-infra.yaml
+++ b/templates/cluster-template-powervs-create-infra.yaml
@@ -110,7 +110,7 @@ spec:
       processorType: ${IBMPOWERVS_CONTROL_PLANE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_CONTROL_PLANE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
       serviceInstance:
         name: ${CLUSTER_NAME}-serviceInstance
 ---
@@ -150,7 +150,7 @@ spec:
       processorType: ${IBMPOWERVS_COMPUTE_PROCTYPE:="Shared"}
       processors: ${IBMPOWERVS_COMPUTE_PROCESSORS:="0.25"}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
       serviceInstance:
         name: ${CLUSTER_NAME}-serviceInstance
 ---

--- a/templates/cluster-template-powervs.yaml
+++ b/templates/cluster-template-powervs.yaml
@@ -228,7 +228,7 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
@@ -268,7 +268,7 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
+++ b/test/e2e/data/templates/cluster-template-powervs-md-remediation.yaml
@@ -547,7 +547,7 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_CONTROL_PLANE_SYSTYPE:="s1022"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
 kind: IBMPowerVSMachineTemplate
@@ -566,4 +566,4 @@ spec:
       serviceInstance:
         id: ${IBMPOWERVS_SERVICE_INSTANCE_ID}
       sshKey: ${IBMPOWERVS_SSHKEY_NAME}
-      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s922"}
+      systemType: ${IBMPOWERVS_COMPUTE_SYSTYPE:="s1022"}


### PR DESCRIPTION
**What this PR does / why we need it**:

The PowerVS zones used by CI now run newer Power10 hardware — `lon06`
provides `s1022`, and `eu-de-1` provides `e1050`, `e1080`, `e1180`,
`s1022` and `s1122`. The templates on this branch still default to the
Power9 `s922`, so machine creation fails with
`InvalidMachineConfiguration` and this branch's weekly e2e job will hit
the same wall main did. `s1022` is available in both zones.

This changes the webhook default and the templates to `s1022`. The
webhook default matters as much as the templates — without it, anyone
who omits `systemType` still lands on `s922`.

**Special notes for your reviewer**:

The webhook defaulting tests aren't touched because they assert against
`defaultSystemType` rather than a literal, so the const change covers
them. Tests weren't run locally (no envtest available); `make lint` and
`make verify-gen` are clean.

**Which issue(s) this PR fixes**:

/area provider/ibmcloud

**Release note**:

```release-note
Change the default PowerVS systemType from s922 to s1022
```