### PR TITLE
✨ Implement HMAC based authorization for ignition

### DIFF
--- a/api/powervs/v1beta2/conversion_test.go
+++ b/api/powervs/v1beta2/conversion_test.go
@@ -131,10 +131,11 @@ func hubIBMPowerVSClusterStatus(in *infrav1.IBMPowerVSClusterStatus, c randfill.
 	in.VPC = infrav1.VPCStatus{}
 
 	// COSInstance: only ID survives round-trip through v1beta2 (which uses *ResourceReference with only ID).
-	// Name, BucketName, and BucketRegion are not stored in v1beta2 Status.COSInstance.
+	// Name, BucketName, BucketRegion, and HMACSecretName are not stored in v1beta2 Status.COSInstance.
 	in.COSInstance.Name = ""
 	in.COSInstance.BucketName = ""
 	in.COSInstance.BucketRegion = ""
+	in.COSInstance.HMACSecretName = ""
 	if in.COSInstance.ID == "" {
 		in.COSInstance = infrav1.COSInstanceStatus{}
 	}

--- a/api/powervs/v1beta3/ibmpowervscluster_types.go
+++ b/api/powervs/v1beta3/ibmpowervscluster_types.go
@@ -909,7 +909,7 @@ type LoadBalancerStatus struct {
 
 // COSInstanceSource defines how the IBM Cloud COS instance is sourced.
 // +kubebuilder:validation:XValidation:rule="self.type == 'Reference' ? has(self.reference) : !has(self.reference)",message="reference configuration is required when type is Reference, and forbidden otherwise"
-// +kubebuilder:validation:XValidation:rule="self.type == 'Provision' ? has(self.provision) : !has(self.provision)",message="provision configuration is required when type is Provision, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="self.type != 'Provision' ? !has(self.provision) : true",message="provision configuration is forbidden when type is not Provision; it is optional when type is Provision"
 type COSInstanceSource struct {
 	// type defines whether to use an existing COS instance or provision a new one.
 	// +required
@@ -975,6 +975,16 @@ type COSInstanceStatus struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=32
 	BucketRegion string `json:"bucketRegion,omitempty"`
+
+	// hmacSecretName is the name of the Kubernetes Secret (in the same namespace as the
+	// IBMPowerVSCluster) that holds the HMAC credentials for the COS instance.
+	// The Secret contains keys "access_key_id" and "secret_access_key".
+	// These are used by the machine scope to generate short-lived pre-signed URLs for
+	// ignition bootstrap data instead of embedding a long-lived IAM Bearer token.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	HMACSecretName string `json:"hmacSecretName,omitempty"`
 }
 
 const (

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -1320,9 +1320,9 @@ spec:
                 - message: reference configuration is required when type is Reference,
                     and forbidden otherwise
                   rule: 'self.type == ''Reference'' ? has(self.reference) : !has(self.reference)'
-                - message: provision configuration is required when type is Provision,
-                    and forbidden otherwise
-                  rule: 'self.type == ''Provision'' ? has(self.provision) : !has(self.provision)'
+                - message: provision configuration is forbidden when type is not Provision;
+                    it is optional when type is Provision
+                  rule: 'self.type != ''Provision'' ? !has(self.provision) : true'
               ignition:
                 description: ignition defines options related to the bootstrapping
                   systems where Ignition is used.
@@ -2675,6 +2675,16 @@ spec:
                     description: bucketRegion tracks the confirmed region where the
                       bucket resides.
                     maxLength: 32
+                    minLength: 1
+                    type: string
+                  hmacSecretName:
+                    description: |-
+                      hmacSecretName is the name of the Kubernetes Secret (in the same namespace as the
+                      IBMPowerVSCluster) that holds the HMAC credentials for the COS instance.
+                      The Secret contains keys "access_key_id" and "secret_access_key".
+                      These are used by the machine scope to generate short-lived pre-signed URLs for
+                      ignition bootstrap data instead of embedding a long-lived IAM Bearer token.
+                    maxLength: 253
                     minLength: 1
                     type: string
                   id:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -1076,10 +1076,10 @@ spec:
                             Reference, and forbidden otherwise
                           rule: 'self.type == ''Reference'' ? has(self.reference)
                             : !has(self.reference)'
-                        - message: provision configuration is required when type is
-                            Provision, and forbidden otherwise
-                          rule: 'self.type == ''Provision'' ? has(self.provision)
-                            : !has(self.provision)'
+                        - message: provision configuration is forbidden when type
+                            is not Provision; it is optional when type is Provision
+                          rule: 'self.type != ''Provision'' ? !has(self.provision)
+                            : true'
                       ignition:
                         description: ignition defines options related to the bootstrapping
                           systems where Ignition is used.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,8 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch

--- a/docs/proposal/20260814-cos-ignition-auth-analysis.md
+++ b/docs/proposal/20260814-cos-ignition-auth-analysis.md
@@ -1,0 +1,308 @@
+# Secure COS Ignition Bootstrap via HMAC Pre-signed URLs
+
+## Metadata
+* **Authors:** Karthik-K-N
+* **Status:** Implemented
+* **Creation Date:** 2026-08-14
+* **Target Version:** v1beta3
+
+## Summary
+This proposal describes how the PowerVS machine bootstrap workflow was changed to
+eliminate an IAM Bearer token that was being embedded in Ignition user-data. The fix
+provisions a per-cluster COS HMAC service credential during cluster reconciliation,
+stores it in a Kubernetes Secret, and uses it to generate a short-lived SigV4
+pre-signed URL at machine-create time. The bootstrapping node fetches its Ignition
+config with a plain HTTP GET — no credential of any kind is present in user-data.
+
+## Motivation
+During machine bootstrap, `ignitionUserData()` fetched a raw IAM Bearer token and
+embedded it directly in the Ignition JSON config passed to every new node as
+cloud-init user-data:
+
+```go
+auth, err := authenticator.GetIAMAuthenticator()
+iamtoken, err := auth.GetToken()
+token := "Bearer " + iamtoken
+
+// Embedded in Ignition v2/v3 config:
+HTTPHeaders: ignV2Types.HTTPHeaders{{Name: "Authorization", Value: token}}
+```
+
+This approach has three compounding problems:
+
+1. **Long-lived credential in user-data:** The IAM Bearer token is serialised into the
+   Ignition JSON that lives as cloud-init user-data on every new instance. On many
+   platforms, user-data is accessible from the instance metadata endpoint without
+   authentication. Any process on the node, or anyone who could read the bootstrap
+   Secret on the management cluster, obtained a valid IAM Bearer token.
+
+2. **Overly broad scope:** The token is derived from `IBMCLOUD_API_KEY`. It carries the
+   full IAM permissions of that key — far beyond reading a single COS object.
+
+3. **No tight expiry:** IAM tokens live approximately one hour and are renewable. The
+   exposure window is not bounded to the single bootstrap GET.
+
+### Why a Naïve Pre-signed URL Does Not Work With IAM Credentials
+
+The standard S3-compatible fix — calling `req.Presign(1 * time.Hour)` on a
+`GetObjectRequest` — does not work with IBM COS when the client uses IAM
+(`IBMCLOUD_API_KEY`) credentials.
+
+IBM COS SDK v1.x routes signing on `ProviderType`:
+
+| ProviderType | Signer | Mechanism |
+|---|---|---|
+| `""` / `"v4"` | `v4.SignRequestHandler` | HMAC-SHA256 query-string parameters |
+| **`"oauth"`** | `ibmiam.SignRequestHandler` | Sets `Authorization: Bearer <token>` header |
+
+`ibmiam.NewStaticCredentials(...)` sets `ProviderType = "oauth"`. The IBM OAuth signer
+sets an HTTP **header**, not query parameters. `req.Presign()` with an OAuth credential
+produces a URL with no embedded authentication — IBM COS returns 403 when a node makes
+a plain GET without the `Authorization` header.
+
+Pre-signed URLs only work with HMAC credentials (SigV4 signer, `ProviderType = ""`).
+
+## Goals
+* Eliminate the IAM Bearer token from Ignition user-data entirely.
+* Generate a time-limited, self-authenticating pre-signed URL using HMAC SigV4 credentials.
+* Store HMAC credentials in a Kubernetes Secret managed by the cluster controller.
+* Clean up the HMAC Secret during cluster deletion.
+* Add the RBAC permissions required to create and delete Secrets.
+
+## Non-Goals
+* Changing the COS instance provisioning or bucket management logic.
+* Supporting any credential mechanism other than HMAC for pre-signed URL generation.
+* Rotating or revoking HMAC credentials during the cluster lifetime.
+
+---
+
+## Proposal
+
+### 1. HMAC Service Credential Lifecycle in the Cluster Reconciler
+
+**Current Drawback:** `ReconcileCOSInstance` sets up the COS bucket but leaves
+`ignitionUserData` to fetch a fresh IAM token on every machine reconcile and embed it
+in the Ignition config.
+
+**Solution:** Add a new `reconcileCOSHMACKey` step at the end of `ReconcileCOSInstance`.
+After the bucket is confirmed ready, the cluster reconciler calls
+`ResourceClient.CreateResourceKey` with `parameters.SetProperty("HMAC", true)` to
+obtain a `(access_key_id, secret_access_key)` pair scoped to the COS instance. These
+are stored in a Kubernetes Secret named `<cluster>-cos-hmac` in the cluster's namespace.
+The Secret name is written back to `cluster.Status.COSInstance.HMACSecretName`, making
+it discoverable by the machine reconciler without any shared state.
+
+*Before (cluster reconcile end):*
+```go
+// ReconcileCOSInstance returned after reconciling the bucket.
+// ignitionUserData later called GetIAMAuthenticator().GetToken() directly.
+```
+
+*After (cluster reconcile end):*
+```go
+// Step 6: Reconcile the HMAC key Secret for secure ignition pre-signed URL support.
+if err := s.reconcileCOSHMACKey(ctx, instanceCRN); err != nil {
+    return fmt.Errorf("failed to reconcile COS HMAC key: %w", err)
+}
+```
+
+*Idempotency:* If `HMACSecretName` is already set and the Secret exists, the step
+returns immediately without making an IBM Cloud API call.
+
+### 2. HMAC Secret Deletion on Cluster Teardown
+
+**Current Drawback:** `DeleteCOSInstance` issued a recursive IBM Cloud API delete but
+had no knowledge of any Kubernetes Secret to clean up.
+
+**Solution:** `DeleteCOSInstance` now deletes the `<cluster>-cos-hmac` Secret before
+issuing the IBM Cloud recursive instance delete. The deletion is best-effort — a failure
+is logged but does not block the cloud resource deletion.
+
+```go
+// Step 5: Delete the HMAC Secret from Kubernetes (best-effort).
+if cluster.Status.COSInstance.HMACSecretName != "" {
+    // ... get and delete the Secret
+}
+// Step 6: Issue recursive DeleteResourceInstance API call.
+```
+
+### 3. HMAC-Based COS Client in the Machine Reconciler
+
+**Current Drawback:** `ignitionUserData` called `GetIAMAuthenticator().GetToken()` and
+embedded the resulting Bearer token directly in the Ignition redirect document's
+`HTTPHeaders`.
+
+**Solution:** A new `createCOSClient` helper reads `HMACSecretName` from
+`IBMPowerVSCluster.Status.COSInstance`, fetches the Secret, and builds a COS client via
+`cos.NewServiceWithHMAC(accessKeyID, secretAccessKey)`. This client uses
+`credentials.NewStaticCredentials(...)` which selects the SigV4 signer (`ProviderType
+= ""`), enabling `req.Presign()` to embed the HMAC signature as query parameters.
+
+*Before:*
+```go
+auth, err := authenticator.GetIAMAuthenticator()
+iamtoken, err := auth.GetToken()
+token := "Bearer " + iamtoken
+// token embedded in Ignition HTTPHeaders
+```
+
+*After:*
+```go
+cosClient, err := s.createCOSClient(ctx)  // reads HMAC Secret, SigV4 signer
+presignedURL, err := cosClient.PresignedURL(bucket, key, presignExpiry)
+// presignedURL embedded as plain Source — no HTTPHeaders, no credential
+```
+
+The resulting Ignition redirect document carries only a URL:
+
+```go
+// Ignition v3 — no HTTPHeaders field at all
+ignData := &ignV3Types.Config{
+    Ignition: ignV3Types.Ignition{
+        Config: ignV3Types.IgnitionConfig{
+            Replace: ignV3Types.Resource{
+                Source: aws.String(presignedURL),
+            },
+        },
+    },
+}
+```
+
+### 4. New `PresignedURL` Method on the `Cos` Interface
+
+**Current Drawback:** The `Cos` interface only exposed `GetObjectRequest`, which
+returned a raw `*request.Request`. Callers had to call `.Presign()` themselves and
+handle the OAuth-vs-SigV4 signer distinction inline.
+
+**Solution:** A new `PresignedURL(bucket, key string, expiry time.Duration) (string,
+error)` method is added to the `Cos` interface and implemented in `Service`. This
+encapsulates the `req.Presign(expiry)` call and the error wrapping, and is mockable via
+the generated mock.
+
+```go
+// In Cos interface
+PresignedURL(bucket, key string, expiry time.Duration) (string, error)
+
+// In Service
+func (s *Service) PresignedURL(bucket, key string, expiry time.Duration) (string, error) {
+    req, _ := s.client.GetObjectRequest(&s3.GetObjectInput{
+        Bucket: aws.String(bucket),
+        Key:    aws.String(key),
+    })
+    return req.Presign(expiry)
+}
+```
+
+### 5. New `HMACSecretName` Field in `COSInstanceStatus`
+
+**Current Drawback:** `COSInstanceStatus` tracked `ID`, `Name`, `BucketName`, and
+`BucketRegion` but had no field to carry the name of the HMAC Secret to the machine
+reconciler.
+
+**Solution:** A new `HMACSecretName` field is added to `COSInstanceStatus`:
+
+```go
+// hmacSecretName is the name of the Kubernetes Secret (in the same namespace as the
+// IBMPowerVSCluster) that holds the HMAC credentials for the COS instance.
+// The Secret contains keys "access_key_id" and "secret_access_key".
+// +optional
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+HMACSecretName string `json:"hmacSecretName,omitempty"`
+```
+
+### 6. RBAC for Secret Management
+
+**Current Drawback:** The cluster controller's RBAC markers only covered reading
+Secrets (`get;list;watch`), which was insufficient once the controller needed to create
+and delete the HMAC Secret.
+
+**Solution:** The RBAC marker on `IBMPowerVSClusterReconciler` is extended to include
+`create` and `delete`:
+
+```go
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;list;watch
+```
+
+This is reflected in `config/rbac/role.yaml`:
+
+```yaml
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+```
+
+---
+
+## User Experience (UX)
+
+### Before — IAM Bearer token in user-data
+
+The bootstrap node received an Ignition config that looked like this (simplified):
+
+```json
+{
+  "ignition": {
+    "config": {
+      "replace": {
+        "source": "https://s3.us-south.cloud-object-storage.appdomain.cloud/bucket/control-plane/node1",
+        "httpHeaders": [{ "name": "Authorization", "value": "Bearer eyJhb..." }]
+      }
+    }
+  }
+}
+```
+
+The `eyJhb...` token was a full-scope IAM Bearer token valid for ~1 hour, scoped to
+all resources the `IBMCLOUD_API_KEY` can access.
+
+### After — Self-authenticating pre-signed URL
+
+```json
+{
+  "ignition": {
+    "config": {
+      "replace": {
+        "source": "https://s3.us-south.cloud-object-storage.appdomain.cloud/bucket/control-plane/node1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...&X-Amz-Expires=3600&X-Amz-Signature=..."
+      }
+    }
+  }
+}
+```
+
+No credential is present. The HMAC signature embedded in the query string expires after
+one hour. After expiry the URL is worthless even if the user-data is read.
+
+---
+
+## Security Properties
+
+| Property | Before | After |
+|---|---|---|
+| Credential in user-data | ✗ Full IAM Bearer token | ✓ None — URL is self-authenticating |
+| Blast radius if user-data leaked | All IAM-permitted APIs | Zero — URL expires in 1 hour |
+| Pre-signed URL mechanism | Not possible (OAuth signer) | ✓ HMAC SigV4 query-string signature |
+| Kubernetes Secret required | ✗ No | ✓ Yes — `<cluster>-cos-hmac` |
+| Secret deleted on cluster teardown | N/A | ✓ Yes (best-effort) |
+
+---
+
+## Alternatives Considered
+
+* **Scoped Service ID with IAM Policy:** Create a per-cluster IBM Cloud Service ID with
+  a Reader-only IAM policy on the specific bucket, derive a token from its API key, and
+  embed that in Ignition as before. Rejected because a Bearer token is still present in
+  user-data — the root cause is not eliminated. HMAC pre-signing removes the credential
+  entirely at comparable implementation complexity.
+
+* **Public Object + Lifecycle Expiry:** Make the ignition object public-read for the
+  bootstrap window, relying on the URL being hard to guess. Rejected because bootstrap
+  configs contain sensitive cluster data (certificates, kubeconfig fragments). Making
+  them publicly accessible, even temporarily, is not acceptable for production use.

--- a/internal/controllers/powervs/ibmpowervscluster_controller.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller.go
@@ -84,6 +84,7 @@ type componentResult struct {
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=ibmpowervsclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;list;watch
 
 // Reconcile implements controller runtime Reconciler interface and handles reconcileation logic for IBMPowerVSCluster.
 func (r *IBMPowerVSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
@@ -479,7 +480,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileDelete(ctx context.Context, clust
 		allErrs = append(allErrs, fmt.Errorf("failed to delete DHCP server: %w", err))
 	}
 
-	log.Info("Deleting PowerVS service instance")
+	log.Info("Deleting PowerVS workspace")
 	conditions.Set(clusterScope.IBMPowerVSCluster, metav1.Condition{
 		Type:   infrav1.WorkspaceReadyCondition,
 		Status: metav1.ConditionFalse,

--- a/internal/controllers/powervs/ibmpowervsimage_controller.go
+++ b/internal/controllers/powervs/ibmpowervsimage_controller.go
@@ -81,6 +81,9 @@ func (r *IBMPowerVSImageReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Add finalizer first if not set to avoid the race condition between init and delete.
 	if finalizerAdded, err := finalizers.EnsureFinalizer(ctx, r.Client, ibmPowerVSImage, infrav1.IBMPowerVSImageFinalizer); err != nil || finalizerAdded {
+		if err == nil {
+			log.Info("Added finalizer to IBMPowerVSImage, requeuing")
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -146,7 +149,7 @@ func (r *IBMPowerVSImageReconciler) reconcile(ctx context.Context, cluster *infr
 	}
 
 	if r.shouldAdopt(*imageScope.IBMPowerVSImage) {
-		log.Info("Image Controller has not yet set OwnerRef")
+		log.Info("Setting OwnerRef on IBMPowerVSImage, requeuing")
 		imageScope.IBMPowerVSImage.OwnerReferences = clusterv1util.EnsureOwnerRef(imageScope.IBMPowerVSImage.OwnerReferences, metav1.OwnerReference{
 			APIVersion: infrav1.GroupVersion.String(),
 			Kind:       ibmPowerVSClusterKind,
@@ -174,8 +177,10 @@ func (r *IBMPowerVSImageReconciler) reconcile(ctx context.Context, cluster *infr
 
 		imageScope.SetImageState(*job.Status.State)
 
+		log.Info("Polling import job", "jobID", jobID, "state", *job.Status.State)
 		switch imageScope.GetImageState() {
 		case infrav1.PowerVSImageStateCompleted:
+			log.Info("Import job completed, proceeding to reconcile image", "jobID", jobID)
 			r.markCondition(imageScope.IBMPowerVSImage, infrav1.IBMPowerVSImageReadyCondition, infrav1.ImageImportedV1Beta2Condition, metav1.ConditionTrue, infrav1.IBMPowerVSImageReadyReason, clusterv1.ConditionSeverityInfo, "")
 
 		case infrav1.PowerVSImageStateFailed:
@@ -201,7 +206,10 @@ func (r *IBMPowerVSImageReconciler) reconcile(ctx context.Context, cluster *infr
 	}
 
 	if jobRef != nil && jobRef.ID != nil {
+		log.Info("Import job submitted", "jobID", *jobRef.ID)
 		imageScope.SetJobID(*jobRef.ID)
+	} else if img == nil {
+		log.Info("Import job already in progress (no jobRef returned), requeuing")
 	}
 	return r.reconcileImage(ctx, img, imageScope)
 }

--- a/internal/webhooks/powervs/ibmpowervscluster.go
+++ b/internal/webhooks/powervs/ibmpowervscluster.go
@@ -109,7 +109,8 @@ func validateIBMPowerVSClusterLoadBalancers(cluster *infrav1.IBMPowerVSCluster) 
 	}
 
 	for _, loadBalancer := range cluster.Spec.LoadBalancers {
-		if loadBalancer.Type == infrav1.SourceTypeProvision && loadBalancer.Provision.Type == infrav1.LoadBalancerTypePublic {
+		if loadBalancer.Type == infrav1.SourceTypeProvision &&
+			(loadBalancer.Provision.Type == infrav1.LoadBalancerTypePublic || loadBalancer.Provision.Type == "") {
 			return allErrs
 		}
 	}

--- a/pkg/cloud/scope/powervs/powervs_cluster.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster.go
@@ -37,6 +37,9 @@ import (
 	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
@@ -79,6 +82,11 @@ const (
 	// vpcSubnetIPAddressCount is the total IP Addresses for the subnet.
 	// Support for custom address prefixes will be added at a later time. Currently, we use the ip count for subnet creation.
 	vpcSubnetIPAddressCount int64 = 256
+
+	// cosHMACAccessKeyField and cosHMACSecretKeyField are the keys used in the
+	// Kubernetes Secret that stores COS HMAC credentials for pre-signed URL generation.
+	cosHMACAccessKeyField = "access_key_id"
+	cosHMACSecretKeyField = "secret_access_key"
 )
 
 // ClientOptions contains generic configurations required to build IBM Cloud clients.
@@ -2285,87 +2293,35 @@ func (s *ClusterScope) ReconcileCOSInstance(ctx context.Context) error {
 		return nil
 	}
 
-	cosSpec := cluster.Spec.COSInstance
-	var instanceID string
-	var instanceName string
-
-	// 2. Idempotency & State Check: If we already resolved the COS ID, just verify its state.
-	if cluster.Status.COSInstance.ID != "" {
-		instanceID = cluster.Status.COSInstance.ID
-		log.V(3).Info("COS Instance ID is set, verifying presence in cloud", "id", instanceID)
-
-		instance, _, err := s.ResourceClient.GetResourceInstance(&resourcecontrollerv2.GetResourceInstanceOptions{
-			ID: &instanceID,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to fetch COS instance (id: %s) details: %w", instanceID, err)
-		}
-		if instance == nil {
-			return fmt.Errorf("COS instance not found in cloud with ID: %s", instanceID)
-		}
-
-		// Ensure the instance is active before attempting to wire up buckets
-		if *instance.State != string(infrav1.WorkspaceStateActive) {
-			return fmt.Errorf("COS instance is not active, current state: %s", *instance.State)
-		}
-		instanceName = *instance.Name
-	} else {
-		// 3. We don't have an ID yet. Route logic based strictly on the user's explicit intent.
-		log.Info("Resolving IBM Cloud COS Instance", "type", cosSpec.Type)
-
-		var instance *resourcecontrollerv2.ResourceInstance
-		var err error
-
-		switch cosSpec.Type {
-		case infrav1.SourceTypeReference:
-			instance, err = s.reconcileCOSReference(ctx, cosSpec.Reference)
-		case infrav1.SourceTypeProvision:
-			name := cosSpec.Provision.Name
-			if name == "" {
-				name = ResourceName(s.IBMPowerVSCluster.Name, ResourceTypeCOS, "")
-			}
-			instance, err = s.reconcileCOSProvision(ctx, name)
-		default:
-			return fmt.Errorf("unknown COS instance source type: %s", cosSpec.Type)
-		}
-
-		if err != nil {
-			return fmt.Errorf("failed to resolve COS instance: %w", err)
-		}
-
-		instanceID = *instance.GUID
-		instanceName = *instance.Name
+	// 2. Resolve the COS instance to a stable (instanceID, instanceName, instanceCRN).
+	instanceID, instanceName, instanceCRN, err := s.resolveCOSInstance(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Record the resolved instance identity
+	// Record the resolved instance identity.
 	cluster.Status.COSInstance.ID = instanceID
 	cluster.Status.COSInstance.Name = instanceName
 
-	targetBucketName := cluster.Status.COSInstance.BucketName
-	if targetBucketName == "" {
-		targetBucketName = cosSpec.BucketName
-		if targetBucketName == "" {
-			targetBucketName = ResourceName(s.IBMPowerVSCluster.Name, ResourceTypeCOSBucket, "")
-		}
+	// 3. Resolve the bucket name and region, falling back through spec then VPC region.
+	targetBucketName, targetBucketRegion, err := s.resolveCOSBucketParams()
+	if err != nil {
+		return err
 	}
 
-	targetBucketRegion := cluster.Status.COSInstance.BucketRegion
-	if targetBucketRegion == "" {
-		targetBucketRegion = cosSpec.BucketRegion
-		if targetBucketRegion == "" {
-			targetBucketRegion = cluster.Status.VPC.Region
-			if targetBucketRegion == "" {
-				return fmt.Errorf("failed to determine COS bucket region: both bucket region and VPC region are unset")
-			}
-		}
-	}
+	log.V(3).Info("ReconcileCOSInstance: resolved params",
+		"instanceID", instanceID,
+		"instanceCRN", instanceCRN,
+		"bucketName", targetBucketName,
+		"bucketRegion", targetBucketRegion,
+	)
 
-	// 4. Setup the COS Client now that we have a guaranteed active instance ID
-	if err := s.setupCOSClient(instanceID, cosSpec.BucketRegion); err != nil {
+	// 4. Setup the COS Client now that we have a guaranteed active instance ID.
+	if err := s.setupCOSClient(instanceID, targetBucketRegion); err != nil {
 		return fmt.Errorf("failed to configure COS client: %w", err)
 	}
 
-	// 5. Reconcile the Bucket
+	// 5. Reconcile the Bucket.
 	if err := s.reconcileCOSBucket(ctx, targetBucketName); err != nil {
 		return fmt.Errorf("failed to reconcile COS bucket: %w", err)
 	}
@@ -2373,6 +2329,228 @@ func (s *ClusterScope) ReconcileCOSInstance(ctx context.Context) error {
 	cluster.Status.COSInstance.BucketName = targetBucketName
 	cluster.Status.COSInstance.BucketRegion = targetBucketRegion
 
+	// 6. Reconcile the HMAC key Secret for secure ignition pre-signed URL support.
+	if err := s.reconcileCOSHMACKey(ctx, instanceCRN); err != nil {
+		return fmt.Errorf("failed to reconcile COS HMAC key: %w", err)
+	}
+
+	return nil
+}
+
+// resolveCOSInstance returns the (instanceID, instanceName, instanceCRN) for the COS
+// instance declared in the cluster spec. It takes two paths:
+//   - Fast path: if the ID is already in Status, verify liveness in the cloud.
+//   - Slow path: resolve via spec (Reference or Provision) and verify the instance is active.
+func (s *ClusterScope) resolveCOSInstance(ctx context.Context) (instanceID, instanceName, instanceCRN string, err error) {
+	log := ctrl.LoggerFrom(ctx)
+	cluster := s.IBMPowerVSCluster
+
+	if cluster.Status.COSInstance.ID != "" {
+		return s.verifyCOSInstanceByID(ctx, cluster.Status.COSInstance.ID)
+	}
+
+	log.Info("Resolving IBM Cloud COS Instance", "type", cluster.Spec.COSInstance.Type)
+	return s.resolveCOSInstanceFromSpec(ctx)
+}
+
+// verifyCOSInstanceByID fetches the COS instance by its known ID from the cloud and
+// confirms it is active. Returns the (id, name, crn) triple ready for use.
+func (s *ClusterScope) verifyCOSInstanceByID(ctx context.Context, id string) (instanceID, instanceName, instanceCRN string, err error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(3).Info("COS Instance ID is set, verifying presence in cloud", "id", id)
+
+	instance, _, err := s.ResourceClient.GetResourceInstance(&resourcecontrollerv2.GetResourceInstanceOptions{
+		ID: &id,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to fetch COS instance (id: %s) details: %w", id, err)
+	}
+	if instance == nil {
+		return "", "", "", fmt.Errorf("COS instance not found in cloud with ID: %s", id)
+	}
+	if instance.State == nil {
+		return "", "", "", fmt.Errorf("COS instance state is nil for ID: %s", id)
+	}
+	if *instance.State != string(infrav1.WorkspaceStateActive) {
+		return "", "", "", fmt.Errorf("COS instance is not active, current state: %s", *instance.State)
+	}
+
+	if instance.CRN == nil || *instance.CRN == "" {
+		return "", "", "", fmt.Errorf("COS instance (id: %s) has no CRN; cannot create HMAC credential", id)
+	}
+	if instance.Name == nil {
+		return "", "", "", fmt.Errorf("COS instance name is nil for ID: %s", id)
+	}
+	return id, *instance.Name, *instance.CRN, nil
+}
+
+// resolveCOSInstanceFromSpec routes to reconcileCOSReference or reconcileCOSProvision
+// based on the spec type, verifies the instance is active, and returns the identity triple.
+// If the instance is not yet active, it records the ID in Status so the next reconcile
+// can poll via the fast path (verifyCOSInstanceByID) instead of calling the API again.
+func (s *ClusterScope) resolveCOSInstanceFromSpec(ctx context.Context) (instanceID, instanceName, instanceCRN string, err error) {
+	cluster := s.IBMPowerVSCluster
+	cosSpec := cluster.Spec.COSInstance
+
+	var instance *resourcecontrollerv2.ResourceInstance
+
+	switch cosSpec.Type {
+	case infrav1.SourceTypeReference:
+		instance, err = s.reconcileCOSReference(ctx, cosSpec.Reference)
+	case infrav1.SourceTypeProvision:
+		name := cosSpec.Provision.Name
+		if name == "" {
+			name = ResourceName(cluster.Name, ResourceTypeCOS, "")
+		}
+		instance, err = s.reconcileCOSProvision(ctx, name)
+	default:
+		return "", "", "", fmt.Errorf("unknown COS instance source type: %s", cosSpec.Type)
+	}
+
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to resolve COS instance: %w", err)
+	}
+	if instance == nil {
+		return "", "", "", fmt.Errorf("COS instance resolved to nil")
+	}
+	if instance.GUID == nil {
+		return "", "", "", fmt.Errorf("COS instance GUID is nil")
+	}
+
+	// A newly provisioned instance may still be provisioning — record the ID so the
+	// next reconcile loop can skip the provision step and just poll for active state.
+	if instance.State == nil || *instance.State != string(infrav1.WorkspaceStateActive) {
+		state := "unknown"
+		if instance.State != nil {
+			state = *instance.State
+		}
+		cluster.Status.COSInstance.ID = *instance.GUID
+		if instance.Name != nil {
+			cluster.Status.COSInstance.Name = *instance.Name
+		}
+		return "", "", "", fmt.Errorf("COS instance is not yet active, current state: %s", state)
+	}
+
+	if instance.CRN == nil || *instance.CRN == "" {
+		return "", "", "", fmt.Errorf("COS instance has no CRN; cannot create HMAC credential")
+	}
+	if instance.Name == nil {
+		return "", "", "", fmt.Errorf("COS instance name is nil")
+	}
+	return *instance.GUID, *instance.Name, *instance.CRN, nil
+}
+
+// resolveCOSBucketParams determines the target bucket name and region by walking a
+// priority chain: Status (already confirmed) → Spec → derived from VPC region.
+func (s *ClusterScope) resolveCOSBucketParams() (bucketName, bucketRegion string, err error) {
+	cluster := s.IBMPowerVSCluster
+	cosSpec := cluster.Spec.COSInstance
+
+	bucketName = cluster.Status.COSInstance.BucketName
+	if bucketName == "" {
+		bucketName = cosSpec.BucketName
+		if bucketName == "" {
+			bucketName = ResourceName(cluster.Name, ResourceTypeCOSBucket, "")
+		}
+	}
+
+	bucketRegion = cluster.Status.COSInstance.BucketRegion
+	if bucketRegion == "" {
+		bucketRegion = cosSpec.BucketRegion
+		if bucketRegion == "" {
+			bucketRegion = cluster.Status.VPC.Region
+			if bucketRegion == "" {
+				return "", "", fmt.Errorf("failed to determine COS bucket region: both bucket region and VPC region are unset")
+			}
+		}
+	}
+
+	return bucketName, bucketRegion, nil
+}
+
+// reconcileCOSHMACKey ensures a COS HMAC service credential exists for the given
+// COS instance and stores the access_key_id / secret_access_key in a Kubernetes
+// Secret named "<cluster>-cos-hmac" in the cluster's namespace.
+func (s *ClusterScope) reconcileCOSHMACKey(ctx context.Context, instanceCRN string) error {
+	log := ctrl.LoggerFrom(ctx)
+	cluster := s.IBMPowerVSCluster
+
+	secretName := ResourceName(cluster.Name, ResourceTypeCOSHMACKey, "")
+
+	// Idempotency: if we already stored the Secret name and the Secret exists, we are done.
+	if cluster.Status.COSInstance.HMACSecretName != "" {
+		existing := &corev1.Secret{}
+		err := s.Client.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Status.COSInstance.HMACSecretName,
+		}, existing)
+		if err == nil {
+			log.V(3).Info("COS HMAC Secret already exists, skipping creation", "secret", cluster.Status.COSInstance.HMACSecretName)
+			return nil
+		}
+	}
+
+	log.Info("Creating COS HMAC service credential", "instance", instanceCRN)
+
+	params := &resourcecontrollerv2.ResourceKeyPostParameters{}
+	params.SetProperty("HMAC", true)
+
+	keyOpts := &resourcecontrollerv2.CreateResourceKeyOptions{
+		Name:       ptr.To(ResourceName(cluster.Name, ResourceTypeCOSHMACKey, "")),
+		Source:     ptr.To(instanceCRN),
+		Parameters: params,
+	}
+
+	resourceKey, _, err := s.ResourceClient.CreateResourceKey(keyOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create COS HMAC resource key: %w", err)
+	}
+
+	// The IBM Resource Controller returns HMAC keys under the "cos_hmac_keys" property
+	// of the credential credentials object.
+	hmacRaw := resourceKey.Credentials.GetProperty("cos_hmac_keys")
+	if hmacRaw == nil {
+		return fmt.Errorf("COS HMAC key created but cos_hmac_keys property is missing in response")
+	}
+
+	hmacMap, ok := hmacRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("COS HMAC key cos_hmac_keys has unexpected type %T", hmacRaw)
+	}
+
+	accessKeyID, _ := hmacMap[cosHMACAccessKeyField].(string)
+	secretAccessKey, _ := hmacMap[cosHMACSecretKeyField].(string)
+	if accessKeyID == "" || secretAccessKey == "" {
+		return fmt.Errorf("COS HMAC key is missing %s or %s", cosHMACAccessKeyField, cosHMACSecretKeyField)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         infrav1.GroupVersion.String(),
+					Kind:               "IBMPowerVSCluster",
+					Name:               cluster.Name,
+					UID:                cluster.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+		Data: map[string][]byte{
+			cosHMACAccessKeyField: []byte(accessKeyID),
+			cosHMACSecretKeyField: []byte(secretAccessKey),
+		},
+	}
+
+	if err := s.Client.Create(ctx, secret); err != nil {
+		return fmt.Errorf("failed to store COS HMAC Secret %q: %w", secretName, err)
+	}
+
+	cluster.Status.COSInstance.HMACSecretName = secretName
+	log.Info("COS HMAC Secret created successfully", "secret", secretName)
 	return nil
 }
 
@@ -2473,6 +2651,8 @@ func (s *ClusterScope) setupCOSClient(instanceID, bucketRegion string) error {
 		serviceEndpoint = cosServiceEndpoint
 	}
 
+	ctrl.Log.V(3).Info("Setting up COS client", "instanceID", instanceID, "bucketRegion", bucketRegion, "endpoint", serviceEndpoint)
+
 	cosOptions := cos.ServiceOptions{
 		Options: &cosSession.Options{
 			Config: aws.Config{
@@ -2488,6 +2668,7 @@ func (s *ClusterScope) setupCOSClient(instanceID, bucketRegion string) error {
 	}
 
 	s.COSClient = cosClient
+	ctrl.Log.V(3).Info("COS client created successfully")
 	return nil
 }
 
@@ -2507,6 +2688,8 @@ func (s *ClusterScope) reconcileCOSBucket(ctx context.Context, bucketName string
 		return fmt.Errorf("failed to check if COS bucket exists: %w", err)
 	}
 
+	log.V(3).Info("COS bucket lookup returned error", "code", aerr.Code(), "message", aerr.Message(), "origErr", aerr.OrigErr())
+
 	switch aerr.Code() {
 	case s3.ErrCodeNoSuchBucket, "Forbidden", "NotFound":
 		log.Info("Creating new COS bucket", "bucketName", bucketName)
@@ -2515,15 +2698,24 @@ func (s *ClusterScope) reconcileCOSBucket(ctx context.Context, bucketName string
 			Bucket: ptr.To(bucketName),
 		}
 
-		if _, err := s.COSClient.CreateBucket(input); err != nil {
-			// Handle edge case where it was created in the milliseconds between check and create
+		out, err := s.COSClient.CreateBucket(input)
+		if err != nil {
 			if createErr, isAwsErr := err.(awserr.Error); isAwsErr {
-				if createErr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou || createErr.Code() == s3.ErrCodeBucketAlreadyExists {
+				// BucketAlreadyOwnedByYou means we own it
+				if createErr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou {
+					log.V(3).Info("COS bucket already owned by us (concurrent create), treating as success", "bucketName", bucketName)
 					return nil
+				}
+				// BucketAlreadyExists means the name is taken globally by a DIFFERENT account/instance.
+				// The 403 Forbidden on HeadBucket confirms we don't own it. Surface this as a hard error
+				// so the operator can surface it and the user can choose a different bucket name.
+				if createErr.Code() == s3.ErrCodeBucketAlreadyExists {
+					return fmt.Errorf("bucket name %q is already taken in the global IBM COS namespace by a different instance; set a unique bucketName in spec.cosInstance.bucketName: %w", bucketName, err)
 				}
 			}
 			return fmt.Errorf("failed to execute CreateBucket API: %w", err)
 		}
+		log.V(3).Info("COS bucket created successfully", "bucketName", bucketName, "response", out)
 		return nil
 
 	default:
@@ -3127,7 +3319,24 @@ func (s *ClusterScope) DeleteCOSInstance(ctx context.Context) error {
 		}
 	}
 
-	// 5. Issue the recursive Delete API Call
+	// 5. Delete the HMAC Secret from Kubernetes (best-effort; log but do not block on failure).
+	if cluster.Status.COSInstance.HMACSecretName != "" {
+		hmacSecret := &corev1.Secret{}
+		getErr := s.Client.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Status.COSInstance.HMACSecretName,
+		}, hmacSecret)
+		if getErr == nil {
+			if delErr := s.Client.Delete(ctx, hmacSecret); delErr != nil {
+				log.Error(delErr, "Failed to delete COS HMAC Secret; continuing with instance deletion",
+					"secret", cluster.Status.COSInstance.HMACSecretName)
+			} else {
+				log.Info("Deleted COS HMAC Secret", "secret", cluster.Status.COSInstance.HMACSecretName)
+			}
+		}
+	}
+
+	// 6. Issue the recursive Delete API Call
 	log.Info("Issuing recursive delete command for managed COS service instance", "id", instanceID, "name", cluster.Status.COSInstance.Name)
 	if _, err = s.ResourceClient.DeleteResourceInstance(&resourcecontrollerv2.DeleteResourceInstanceOptions{
 		ID:        ptr.To(instanceID),

--- a/pkg/cloud/scope/powervs/powervs_cluster_test.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster_test.go
@@ -32,10 +32,14 @@ import (
 	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/powervs/v1beta3"
 	mockcos "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/cos/mock"
@@ -3865,4 +3869,177 @@ func TestFetchBucketRegionCluster(t *testing.T) {
 			g.Expect(r).To(Equal(tc.expectedBucketRegion))
 		})
 	}
+}
+
+func TestReconcileCOSHMACKey(t *testing.T) {
+	var (
+		mockResourceController *mockRC.MockResourceController
+		mockCtrl               *gomock.Controller
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		mockResourceController = mockRC.NewMockResourceController(mockCtrl)
+	}
+	teardown := func() {
+		mockCtrl.Finish()
+	}
+
+	t.Run("Idempotent: Secret already exists, skip CreateResourceKey", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster-cos-hmac",
+				Namespace: "default",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(existingSecret).Build()
+
+		clusterScope := ClusterScope{
+			Client:         fakeClient,
+			ResourceClient: mockResourceController,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{HMACSecretName: "test-cluster-cos-hmac"},
+				},
+			},
+		}
+		// CreateResourceKey must NOT be called
+		err := clusterScope.reconcileCOSHMACKey(ctx, "crn:v1:bluemix:public:cloud-object-storage:global::::")
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("CreateResourceKey fails, return error", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		clusterScope := ClusterScope{
+			Client:         fakeClient,
+			ResourceClient: mockResourceController,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+			},
+		}
+		mockResourceController.EXPECT().CreateResourceKey(gomock.Any()).Return(nil, nil, fmt.Errorf("API error"))
+		err := clusterScope.reconcileCOSHMACKey(ctx, "crn:v1:test")
+		g.Expect(err).To(MatchError(ContainSubstring("failed to create COS HMAC resource key")))
+	})
+
+	t.Run("CreateResourceKey returns key without cos_hmac_keys, return error", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		clusterScope := ClusterScope{
+			Client:         fakeClient,
+			ResourceClient: mockResourceController,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+			},
+		}
+		creds := &resourcecontrollerv2.Credentials{}
+		rk := &resourcecontrollerv2.ResourceKey{Credentials: creds}
+		mockResourceController.EXPECT().CreateResourceKey(gomock.Any()).Return(rk, nil, nil)
+		err := clusterScope.reconcileCOSHMACKey(ctx, "crn:v1:test")
+		g.Expect(err).To(MatchError(ContainSubstring("cos_hmac_keys property is missing")))
+	})
+
+	t.Run("CreateResourceKey succeeds, Secret created, status updated", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		clusterScope := ClusterScope{
+			Client:         fakeClient,
+			ResourceClient: mockResourceController,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+			},
+		}
+		creds := &resourcecontrollerv2.Credentials{}
+		creds.SetProperty("cos_hmac_keys", map[string]interface{}{
+			"access_key_id":     "AKID123",
+			"secret_access_key": "SECRET456",
+		})
+		rk := &resourcecontrollerv2.ResourceKey{Credentials: creds}
+		mockResourceController.EXPECT().CreateResourceKey(gomock.Any()).Return(rk, nil, nil)
+
+		err := clusterScope.reconcileCOSHMACKey(ctx, "crn:v1:test")
+		g.Expect(err).To(BeNil())
+		g.Expect(clusterScope.IBMPowerVSCluster.Status.COSInstance.HMACSecretName).To(Equal("test-cluster-cos-hmac"))
+
+		// Verify the Secret was written
+		stored := &corev1.Secret{}
+		g.Expect(fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-cluster-cos-hmac"}, stored)).To(Succeed())
+		g.Expect(string(stored.Data["access_key_id"])).To(Equal("AKID123"))
+		g.Expect(string(stored.Data["secret_access_key"])).To(Equal("SECRET456"))
+	})
+}
+
+func TestDeleteCOSInstanceHMACSecret(t *testing.T) {
+	var (
+		mockResourceController *mockRC.MockResourceController
+		mockCtrl               *gomock.Controller
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		mockResourceController = mockRC.NewMockResourceController(mockCtrl)
+	}
+	teardown := func() {
+		mockCtrl.Finish()
+	}
+
+	t.Run("HMAC Secret is deleted before instance deletion", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster-cos-hmac",
+				Namespace: "default",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(existingSecret).Build()
+
+		clusterScope := ClusterScope{
+			Client:         fakeClient,
+			ResourceClient: mockResourceController,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					COSInstance: infrav1.COSInstanceSource{Type: infrav1.SourceTypeProvision},
+				},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{ //nolint:gosec
+						ID:             "cosInstanceID",
+						HMACSecretName: "my-cluster-cos-hmac",
+					},
+				},
+			},
+		}
+		cosInstance := &resourcecontrollerv2.ResourceInstance{
+			ID:    ptr.To("cosInstanceID"),
+			State: ptr.To(string(infrav1.WorkspaceStateActive)),
+		}
+		mockResourceController.EXPECT().GetResourceInstance(gomock.Any()).Return(cosInstance, nil, nil)
+		mockResourceController.EXPECT().DeleteResourceInstance(gomock.Any()).Return(nil, nil)
+
+		err := clusterScope.DeleteCOSInstance(ctx)
+		g.Expect(err).To(BeNil())
+
+		// Secret must be gone
+		deleted := &corev1.Secret{}
+		getErr := fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "my-cluster-cos-hmac"}, deleted)
+		g.Expect(getErr).ToNot(BeNil()) // not found
+	})
 }

--- a/pkg/cloud/scope/powervs/powervs_image.go
+++ b/pkg/cloud/scope/powervs/powervs_image.go
@@ -210,9 +210,12 @@ func (s *ImageScope) GetOrImportImage(ctx context.Context) (*models.ImageReferen
 	if lastJob != nil && lastJob.Status != nil && lastJob.Status.State != nil {
 		state := *lastJob.Status.State
 		if state != string(infrav1.PowerVSImageStateCompleted) && state != string(infrav1.PowerVSImageStateFailed) {
-			log.Info("Previous import job not yet finished", "state", state)
+			log.Info("Previous import job not yet finished, requeuing", "state", state)
 			return nil, nil, nil
 		}
+		log.Info("Previous import job ended, triggering new import", "state", state)
+	} else {
+		log.Info("No prior import job found, triggering first import")
 	}
 
 	// 3. Trigger New Import Job

--- a/pkg/cloud/scope/powervs/powervs_machine.go
+++ b/pkg/cloud/scope/powervs/powervs_machine.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"path"
 	"slices"
 	"sort"
@@ -60,7 +59,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/endpoints"
 	ignV2Types "sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ignition"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/options"
-	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/authenticator"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/cos"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/resourcecontroller"
@@ -69,6 +67,10 @@ import (
 )
 
 const cosURLDomain = "cloud-object-storage.appdomain.cloud"
+
+// presignExpiry is the lifetime of the pre-signed ignition URL embedded in user-data.
+// One hour is enough for any reasonable bootstrap window; after expiry the URL is worthless.
+const presignExpiry = time.Hour
 
 // zoneCacheEntry holds the supported system types and the exact time they were fetched for a specific zone.
 type zoneCacheEntry struct {
@@ -832,24 +834,10 @@ func (s *MachineScope) resolveUserData(ctx context.Context) (string, error) {
 // ignitionUserData uploads the raw bootstrap data to COS via createIgnitionData,
 // then wraps the resulting pre-signed URL in an Ignition v2 or v3 redirect document.
 func (s *MachineScope) ignitionUserData(ctx context.Context, userData []byte) ([]byte, error) {
-	objectURL, err := s.createIgnitionData(ctx, userData)
+	presignedURL, err := s.createIgnitionData(ctx, userData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user data object: %w", err)
 	}
-
-	auth, err := authenticator.GetIAMAuthenticator()
-	if err != nil {
-		return nil, err
-	}
-
-	iamtoken, err := auth.GetToken()
-	if err != nil {
-		return nil, err
-	}
-	if iamtoken == "" {
-		return nil, fmt.Errorf("IAM token is empty")
-	}
-	token := "Bearer " + iamtoken
 
 	ignVersion := s.getIgnitionVersion()
 	semver, err := semver.ParseTolerant(ignVersion)
@@ -864,13 +852,7 @@ func (s *MachineScope) ignitionUserData(ctx context.Context, userData []byte) ([
 				Version: semver.String(),
 				Config: ignV2Types.IgnitionConfig{
 					Replace: &ignV2Types.ConfigReference{
-						Source: objectURL,
-						HTTPHeaders: ignV2Types.HTTPHeaders{
-							{
-								Name:  "Authorization",
-								Value: token,
-							},
-						},
+						Source: presignedURL,
 					},
 				},
 			},
@@ -882,13 +864,7 @@ func (s *MachineScope) ignitionUserData(ctx context.Context, userData []byte) ([
 				Version: semver.String(),
 				Config: ignV3Types.IgnitionConfig{
 					Replace: ignV3Types.Resource{
-						Source: aws.String(objectURL),
-						HTTPHeaders: ignV3Types.HTTPHeaders{
-							{
-								Name:  "Authorization",
-								Value: aws.String(token),
-							},
-						},
+						Source: aws.String(presignedURL),
 					},
 				},
 			},
@@ -899,8 +875,9 @@ func (s *MachineScope) ignitionUserData(ctx context.Context, userData []byte) ([
 	}
 }
 
-// createIgnitionData uploads userData to the COS bucket and returns the HTTPS
-// object URL that Ignition will use to fetch the real bootstrap config.
+// createIgnitionData uploads userData to the COS bucket, then returns a
+// pre-signed HTTPS URL that Ignition uses to fetch the bootstrap config.
+// The URL is signed with HMAC SigV4 credentials — the signature is embedded as query parameters.
 func (s *MachineScope) createIgnitionData(ctx context.Context, data []byte) (string, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if len(data) == 0 {
@@ -915,11 +892,9 @@ func (s *MachineScope) createIgnitionData(ctx context.Context, data []byte) (str
 	key := s.bootstrapDataKey()
 	log.V(3).Info("Bootstrap data key name", "key", key)
 
-	// Fetch directly from the elevated Spec fields
-	bucket := s.IBMPowerVSCluster.Spec.COSInstance.BucketName
-	region := s.IBMPowerVSCluster.Spec.COSInstance.BucketRegion
-	if bucket == "" || region == "" {
-		return "", fmt.Errorf("cannot push ignition data: COS bucket name or region is not set in cluster spec")
+	bucket := s.IBMPowerVSCluster.Status.COSInstance.BucketName
+	if bucket == "" {
+		return "", fmt.Errorf("COS bucket name is not yet populated in cluster status. Waiting for cluster reconciler")
 	}
 
 	if _, err := cosClient.PutObject(&s3.PutObjectInput{
@@ -930,57 +905,48 @@ func (s *MachineScope) createIgnitionData(ctx context.Context, data []byte) (str
 		return "", fmt.Errorf("failed to push object to COS bucket: %w", err)
 	}
 
-	objHost := fmt.Sprintf("%s.s3.%s.%s", bucket, region, cosURLDomain)
-
-	cosServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.COS), s.ServiceEndpoint)
-	if cosServiceEndpoint != "" {
-		log.V(3).Info("Overriding the default COS endpoint in ignition URL", "cosEndpoint", cosServiceEndpoint)
-		cosURL, _ := url.Parse(cosServiceEndpoint)
-		if cosURL.Scheme != "" {
-			objHost = fmt.Sprintf("%s.%s", bucket, cosURL.Host)
-		} else {
-			objHost = fmt.Sprintf("%s.%s", bucket, cosServiceEndpoint)
-		}
+	presignedURL, err := cosClient.PresignedURL(bucket, key, presignExpiry)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate pre-signed URL for ignition data: %w", err)
 	}
 
-	objectURL := &url.URL{
-		Scheme: "https",
-		Host:   objHost,
-		Path:   key,
-	}
-	log.V(3).Info("Generated Ignition URL", "objectURL", objectURL.String())
-
-	return objectURL.String(), nil
+	log.V(3).Info("Generated pre-signed Ignition URL", "bucket", bucket, "key", key)
+	return presignedURL, nil
 }
 
-// createCOSClient creates a new cosClient from the supplied parameters.
+// createCOSClient builds an HMAC-credential COS client for the machine scope.
+// It reads the access_key_id and secret_access_key from the Kubernetes Secret that
+// was created by the cluster reconciler's reconcileCOSHMACKey step.
 func (s *MachineScope) createCOSClient(ctx context.Context) (cos.Cos, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	// 1. Get the ID from IBMPowerVSCluster status.
-	cosID := s.IBMPowerVSCluster.Status.COSInstance.ID
-	if cosID == "" {
-		return nil, fmt.Errorf("COS instance ID is not yet populated in cluster status. Waiting for cluster reconciler")
-	}
-
-	// 2. Fetch the region directly from IBMPowerVSCluster status.
+	// 1. Fetch the region from cluster status.
 	region := s.IBMPowerVSCluster.Status.COSInstance.BucketRegion
 	if region == "" {
 		return nil, fmt.Errorf("COS bucket region is not yet populated in cluster status. Waiting for cluster reconciler")
 	}
 
-	props, err := authenticator.GetProperties()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch service properties: %w", err)
+	// 2. Read the HMAC Secret created by the cluster reconciler.
+	hmacSecretName := s.IBMPowerVSCluster.Status.COSInstance.HMACSecretName
+	if hmacSecretName == "" {
+		return nil, fmt.Errorf("COS HMAC Secret name is not yet populated in cluster status. Waiting for cluster reconciler")
 	}
-	apiKey := props["APIKEY"]
-	if apiKey == "" {
-		return nil, fmt.Errorf("IBM Cloud API key is not provided, set IBMCLOUD_API_KEY environmental variable")
+
+	secret := &corev1.Secret{}
+	if err := s.Client.Get(ctx, types.NamespacedName{
+		Namespace: s.IBMPowerVSCluster.Namespace,
+		Name:      hmacSecretName,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to fetch COS HMAC Secret %q: %w", hmacSecretName, err)
+	}
+
+	accessKeyID := string(secret.Data[cosHMACAccessKeyField])
+	secretAccessKey := string(secret.Data[cosHMACSecretKeyField])
+	if accessKeyID == "" || secretAccessKey == "" {
+		return nil, fmt.Errorf("COS HMAC Secret %q is missing %s or %s", hmacSecretName, cosHMACAccessKeyField, cosHMACSecretKeyField)
 	}
 
 	serviceEndpoint := fmt.Sprintf("s3.%s.%s", region, cosURLDomain)
-
-	// Fetch the custom COS service endpoint if provided
 	cosServiceEndpoint := endpoints.FetchEndpoints(string(endpoints.COS), s.ServiceEndpoint)
 	if cosServiceEndpoint != "" {
 		log.V(3).Info("Overriding the default COS endpoint", "cosEndpoint", cosServiceEndpoint)
@@ -996,10 +962,9 @@ func (s *MachineScope) createCOSClient(ctx context.Context) (cos.Cos, error) {
 		},
 	}
 
-	// Build the client using our cached, validated ID
-	cosClient, err := cos.NewService(cosOptions, apiKey, cosID)
+	cosClient, err := cos.NewServiceWithHMAC(cosOptions, accessKeyID, secretAccessKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create COS client: %w", err)
+		return nil, fmt.Errorf("failed to create HMAC COS client: %w", err)
 	}
 
 	return cosClient, nil

--- a/pkg/cloud/scope/powervs/powervs_machine_test.go
+++ b/pkg/cloud/scope/powervs/powervs_machine_test.go
@@ -793,44 +793,110 @@ func TestSetProviderID(t *testing.T) {
 }
 
 func TestCreateCOSClient(t *testing.T) {
-	var (
-		mockpowervs *mock.MockPowerVS
-		mockCtrl    *gomock.Controller
-	)
+	t.Run("Returns error when COS bucket region is not in cluster status", func(t *testing.T) {
+		g := NewWithT(t)
+		scope := MachineScope{
+			Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{ID: "cos-id"},
+					// BucketRegion empty
+				},
+			},
+		}
+		result, err := scope.createCOSClient(ctx)
+		g.Expect(result).To(BeNil())
+		g.Expect(err).To(MatchError(ContainSubstring("COS bucket region is not yet populated in cluster status")))
+	})
 
-	setup := func(t *testing.T) {
-		t.Helper()
-		mockCtrl = gomock.NewController(t)
-		mockpowervs = mock.NewMockPowerVS(mockCtrl)
-	}
-	teardown := func() {
-		mockCtrl.Finish()
-	}
+	t.Run("Returns error when HMAC Secret name is not in cluster status", func(t *testing.T) {
+		g := NewWithT(t)
+		scope := MachineScope{
+			Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{
+						ID:           "cos-id",
+						BucketRegion: "us-south",
+						// HMACSecretName empty
+					},
+				},
+			},
+		}
+		result, err := scope.createCOSClient(ctx)
+		g.Expect(result).To(BeNil())
+		g.Expect(err).To(MatchError(ContainSubstring("COS HMAC Secret name is not yet populated in cluster status")))
+	})
 
-	t.Run("Create COS client", func(t *testing.T) {
-		t.Run("Returns error when COS instance ID is not in cluster status", func(t *testing.T) {
-			g := NewWithT(t)
-			setup(t)
-			t.Cleanup(teardown)
-			scope := setupPowerVSMachineScope(clusterName, machineName, ptr.To(pvsImage), ptr.To(pvsNetwork), true, mockpowervs)
-			// Status.COSInstance.ID is empty by default
-			result, err := scope.createCOSClient(ctx)
-			g.Expect(result).To(BeNil())
-			g.Expect(err).To(MatchError(ContainSubstring("COS instance ID is not yet populated in cluster status")))
-		})
+	t.Run("Returns error when HMAC Secret does not exist in Kubernetes", func(t *testing.T) {
+		g := NewWithT(t)
+		scope := MachineScope{
+			Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{
+						ID:             "cos-id",
+						BucketRegion:   "us-south",
+						HMACSecretName: "missing-secret",
+					},
+				},
+			},
+		}
+		result, err := scope.createCOSClient(ctx)
+		g.Expect(result).To(BeNil())
+		g.Expect(err).To(MatchError(ContainSubstring("failed to fetch COS HMAC Secret")))
+	})
 
-		t.Run("Returns error when COS bucket region is not set in spec", func(t *testing.T) {
-			g := NewWithT(t)
-			setup(t)
-			t.Cleanup(teardown)
-			scope := setupPowerVSMachineScope(clusterName, machineName, ptr.To(pvsImage), ptr.To(pvsNetwork), true, mockpowervs)
-			scope.IBMPowerVSCluster.Status.COSInstance = infrav1.COSInstanceStatus{ID: "cos-instance-id"}
-			// Spec.COSInstance.BucketRegion is empty — should fail after API key check
-			result, err := scope.createCOSClient(ctx)
-			g.Expect(result).To(BeNil())
-			// Will fail at API key or bucket region; either is acceptable
-			g.Expect(err).ToNot(BeNil())
-		})
+	t.Run("Returns error when HMAC Secret is missing access_key_id", func(t *testing.T) {
+		g := NewWithT(t)
+		hmacSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cos-hmac", Namespace: "default"},
+			Data:       map[string][]byte{"secret_access_key": []byte("secret")},
+		}
+		scope := MachineScope{
+			Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(hmacSecret).Build(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{
+						ID:             "cos-id",
+						BucketRegion:   "us-south",
+						HMACSecretName: "cos-hmac",
+					},
+				},
+			},
+		}
+		result, err := scope.createCOSClient(ctx)
+		g.Expect(result).To(BeNil())
+		g.Expect(err).To(MatchError(ContainSubstring("missing access_key_id or secret_access_key")))
+	})
+
+	t.Run("Returns HMAC COS client when Secret has valid credentials", func(t *testing.T) {
+		g := NewWithT(t)
+		hmacSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cos-hmac", Namespace: "default"},
+			Data: map[string][]byte{
+				"access_key_id":     []byte("AKID"),
+				"secret_access_key": []byte("SECRET"),
+			},
+		}
+		scope := MachineScope{
+			Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(hmacSecret).Build(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					COSInstance: infrav1.COSInstanceStatus{
+						ID:             "cos-id",
+						BucketRegion:   "us-south",
+						HMACSecretName: "cos-hmac",
+					},
+				},
+			},
+		}
+		result, err := scope.createCOSClient(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(result).ToNot(BeNil())
 	})
 }
 
@@ -921,7 +987,7 @@ func TestDeleteMachineIgnition(t *testing.T) {
 			err := scope.DeleteMachineIgnition(ctx)
 			g.Expect(err).To(BeNil())
 		})
-		t.Run("Error creating COS client when COS instance ID not in status", func(t *testing.T) {
+		t.Run("Error creating COS client when COS bucket region not in status", func(t *testing.T) {
 			g := NewWithT(t)
 			scope := MachineScope{
 				IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
@@ -933,14 +999,14 @@ func TestDeleteMachineIgnition(t *testing.T) {
 					Status: infrav1.IBMPowerVSClusterStatus{
 						COSInstance: infrav1.COSInstanceStatus{
 							BucketName: "test-bucket",
-							// ID is empty → createCOSClient will fail
+							// BucketRegion is empty → createCOSClient will fail
 						},
 					},
 				},
 				Machine: &clusterv1.Machine{},
 			}
 			err := scope.DeleteMachineIgnition(ctx)
-			g.Expect(err).To(MatchError(ContainSubstring("COS instance ID is not yet populated in cluster status")))
+			g.Expect(err).To(MatchError(ContainSubstring("COS bucket region is not yet populated in cluster status")))
 		})
 	})
 }

--- a/pkg/cloud/scope/powervs/resource_name.go
+++ b/pkg/cloud/scope/powervs/resource_name.go
@@ -50,6 +50,8 @@ const (
 	ResourceTypeCOS ResourceType = "cos"
 	// ResourceTypeCOSBucket is a COS bucket inside a COS instance.
 	ResourceTypeCOSBucket ResourceType = "cos-bucket"
+	// ResourceTypeCOSHMACKey is a COS HMAC service credential key.
+	ResourceTypeCOSHMACKey ResourceType = "cos-hmac"
 )
 
 // resourceNameMaxLen is the maximum length allowed for IBM Cloud resource names.

--- a/pkg/cloud/services/cos/cos.go
+++ b/pkg/cloud/services/cos/cos.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cos
 
 import (
+	"time"
+
 	"github.com/IBM/ibm-cos-sdk-go/aws"
 	"github.com/IBM/ibm-cos-sdk-go/aws/request"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
@@ -36,4 +38,5 @@ type Cos interface {
 	ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error)
 	DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 	PutPublicAccessBlock(input *s3.PutPublicAccessBlockInput) (*s3.PutPublicAccessBlockOutput, error)
+	PresignedURL(bucket, key string, expiry time.Duration) (string, error)
 }

--- a/pkg/cloud/services/cos/mock/cos_generated.go
+++ b/pkg/cloud/services/cos/mock/cos_generated.go
@@ -26,6 +26,7 @@ package mock
 
 import (
 	reflect "reflect"
+	time "time"
 
 	aws "github.com/IBM/ibm-cos-sdk-go/aws"
 	request "github.com/IBM/ibm-cos-sdk-go/aws/request"
@@ -150,6 +151,21 @@ func (m *MockCos) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput
 func (mr *MockCosMockRecorder) ListObjects(input any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockCos)(nil).ListObjects), input)
+}
+
+// PresignedURL mocks base method.
+func (m *MockCos) PresignedURL(bucket, key string, expiry time.Duration) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PresignedURL", bucket, key, expiry)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PresignedURL indicates an expected call of PresignedURL.
+func (mr *MockCosMockRecorder) PresignedURL(bucket, key, expiry any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PresignedURL", reflect.TypeOf((*MockCos)(nil).PresignedURL), bucket, key, expiry)
 }
 
 // PutObject mocks base method.

--- a/pkg/cloud/services/cos/service.go
+++ b/pkg/cloud/services/cos/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cos
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -25,6 +26,7 @@ import (
 	"golang.org/x/net/http/httpproxy"
 
 	"github.com/IBM/ibm-cos-sdk-go/aws"
+	"github.com/IBM/ibm-cos-sdk-go/aws/credentials"
 	"github.com/IBM/ibm-cos-sdk-go/aws/credentials/ibmiam"
 	"github.com/IBM/ibm-cos-sdk-go/aws/request"
 	cosSession "github.com/IBM/ibm-cos-sdk-go/aws/session"
@@ -75,6 +77,22 @@ func (s *Service) GetObjectRequest(input *s3.GetObjectInput) (*request.Request, 
 	return s.client.GetObjectRequest(input)
 }
 
+// PresignedURL generates a time-limited pre-signed HTTPS URL for a GET on the given
+// bucket/key using AWS SigV4 HMAC signing. The URL encodes the signature as query
+// parameters and requires no Authorization header — it can be fetched by a plain
+// HTTP GET (e.g. from an Ignition bootstrap node). Requires an HMAC-credential client.
+func (s *Service) PresignedURL(bucket, key string, expiry time.Duration) (string, error) {
+	req, _ := s.client.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	presignedURL, err := req.Presign(expiry)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate pre-signed URL for %s/%s: %w", bucket, key, err)
+	}
+	return presignedURL, nil
+}
+
 // ListObjects returns the list of objects in a bucket.
 func (s *Service) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	return s.client.ListObjects(input)
@@ -96,6 +114,45 @@ var NewServiceFunc = NewService // Default to the original function
 // NewServiceWrapper returns a new service for the IBM Cloud COS api client, useful in unit testing.
 func NewServiceWrapper(options ServiceOptions, apikey, serviceInstance string) (Cos, error) {
 	return NewServiceFunc(options, apikey, serviceInstance)
+}
+
+// NewServiceWithHMAC returns a COS client that authenticates via AWS SigV4 HMAC credentials
+// (access_key_id / secret_access_key) rather than an IBM IAM API key. The resulting client
+// supports pre-signed URL generation via PresignedURL().
+func NewServiceWithHMAC(options ServiceOptions, accessKeyID, secretAccessKey string) (Cos, error) {
+	if options.Options == nil {
+		options.Options = &cosSession.Options{}
+	}
+	options.Config.S3ForcePathStyle = aws.Bool(true)
+	options.Config.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(req *http.Request) (*url.URL, error) {
+				return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
+			},
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	// Use plain AWS static credentials — this selects the SigV4 signer (ProviderType ""),
+	// not the IBM IAM OAuth signer, enabling req.Presign() to embed the signature as query
+	// parameters rather than an Authorization header.
+	options.Config.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+
+	sess, err := cosSession.NewSessionWithOptions(*options.Options)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		client: s3.New(sess),
+	}, nil
 }
 
 // NewService returns a new service for the IBM Cloud Resource Controller api client.

--- a/pkg/cloud/services/powervs/service.go
+++ b/pkg/cloud/services/powervs/service.go
@@ -136,8 +136,14 @@ func (s *Service) CreateCosImage(_ context.Context, body *models.CreateCosImageI
 func (s *Service) GetCosImages(_ context.Context, id string) (*models.Job, error) {
 	params := p_cloud_images.NewPcloudV1CloudinstancesCosimagesGetParams().WithCloudInstanceID(id)
 	resp, err := s.session.Power.PCloudImages.PcloudV1CloudinstancesCosimagesGet(params, s.session.AuthInfo(id))
-	if err != nil || resp.Payload == nil {
+	if err != nil {
+		if _, ok := err.(*p_cloud_images.PcloudV1CloudinstancesCosimagesGetNotFound); ok {
+			return nil, nil
+		}
 		return nil, err
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, nil
 	}
 	return resp.Payload, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This improves the security aspect of using ignition with CAPIBM, Now the controller generates HMAC keys and used for presign the ignition URL from COS.
Added the proposal in the PR for more information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement HMAC based authorization for ignition
```
