### PR TITLE
🌱 [release-0.13] fix(docs): update broken links to relocated scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_new_machine_image.md
+++ b/.github/ISSUE_TEMPLATE/add_new_machine_image.md
@@ -25,7 +25,7 @@ title: Onboard new machine images for Kubernetes version v<>
 
 - [ ] Update Kubernetes version in E2E [config files](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/tree/main/test/e2e/config)
 
-- [ ] Update [E2E script](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh) with latest image names
+- [ ] Update [E2E script](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh) with latest image names
 
 
 **Notes**:

--- a/.github/ISSUE_TEMPLATE/cluster_api_version_update.md
+++ b/.github/ISSUE_TEMPLATE/cluster_api_version_update.md
@@ -26,10 +26,10 @@ If Go version is bumped, update it in the following files
 - [ ] [go.mod](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/go.mod)
 - [ ] [hack/tools/go.mod](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/tools/go.mod)
 - [ ] [ .golangci.yaml](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/.golangci.yml)
-- [ ] [hack/ensure-go.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/ensure-go.sh)
+- [ ] [hack/scripts/ensure/ensure-go.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ensure/ensure-go.sh)
 - [ ] [netlify.toml](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/netlify.toml)
 - [ ] [Makefile](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/Makefile#L66)
-- [ ] [hack/ccm/Makefile](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/ccm/Makefile#L16)
+- [ ] [hack/release/ccm/Makefile](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/release/ccm/Makefile#L16)
 - [ ] [Update gcb-docker-gcloud image](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/cloudbuild.yaml#L7)
 
 Previous PR: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2069

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "comment": "Slack workspaces require authentication and block bots",
+      "pattern": "^https://kubernetes\\.slack\\.com/.*"
+    },
+    {
+      "comment": "Slack invites block bots",
+      "pattern": "^https://slack\\.k8s\\.io/.*"
+    }
+  ],
+  "aliveStatusCodes": [200, 206],
+  "retryOn429": true,
+  "retryCount": 2,
+  "timeout": "20s"
+}

--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,7 @@ verify-yamllint:
 MD_FILES := $(shell find . -iname "*.md")
 .PHONY: verify-linkcheck
 verify-linkcheck:
-	@docker run --init -w /input -v $(CURR_DIR):/input ghcr.io/tcort/markdown-link-check:3.12 -q -p $(MD_FILES)
+	@docker run --init -w /input -v $(CURR_DIR):/input ghcr.io/tcort/markdown-link-check:3.15.0 -q -c .markdownlinkcheck.json -p $(MD_FILES)
 
 ## --------------------------------------
 ## Cleanup / Verification

--- a/docs/book/src/developer/dependencies.md
+++ b/docs/book/src/developer/dependencies.md
@@ -43,13 +43,13 @@
 
 | Package | Used by | GitHub |
 | --- | ----------- | ------ |
-| IBM Cloud CLI | [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh) | [ibm-cloud-cli-release](https://github.com/IBM-Cloud/ibm-cloud-cli-release.git) |
-| capibmadm | [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh) | [capibmadm](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/tree/main/cmd/capibmadm) |
+| IBM Cloud CLI | [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh) | [ibm-cloud-cli-release](https://github.com/IBM-Cloud/ibm-cloud-cli-release.git) |
+| capibmadm | [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh) | [capibmadm](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/tree/main/cmd/capibmadm) |
 
 #### Other Tools
 | Package | Used by | Source |
 | --- | ----------- | ------ |
-| kind | [ensure-kind.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/ensure-kind.sh) | [kind](https://github.com/kubernetes-sigs/kind) |
+| kind | [hack/scripts/dev/kind-install.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/dev/kind-install.sh) | [kind](https://github.com/kubernetes-sigs/kind) |
 | kubebuilder | [Makefile](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/Makefile) | [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) |
 
 [go.mod1]: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/go.mod

--- a/docs/book/src/developer/e2e.md
+++ b/docs/book/src/developer/e2e.md
@@ -24,8 +24,8 @@ For development and debugging the E2E tests, they can be executed locally.
 ```
 export E2E_FLAVOR=<e2e-flavor>
 ```
-2. Set the infra environment variables accrodingly based on the flavor being tested. Check the required variables for [VPC](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh#L132-L145) and [PowerVS](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh#L123-L130) being set in [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/scripts/ci-e2e.sh).
-3. Run the e2e test 
+2. Set the infra environment variables accrodingly based on the flavor being tested. Check the required variables for [VPC](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh#L132-L145) and [PowerVS](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh#L123-L130) being set in [ci-e2e.sh](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/hack/scripts/ci/ci-e2e.sh).
+3. Run the e2e test
 ```
-./scripts/ci-e2e.sh
+./hack/scripts/ci/ci-e2e.sh
 ```

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -36,7 +36,7 @@ This book documents Cluster API Provider IBM Cloud v0.13. For other versions ple
 <img src="../../images/ibm-cloud.svg" alt="Supported IBM Cloud IaaS">
 </p>
 
-Currently, the CAPIBM project exclusively facilitates the deployment of Kubernetes (K8s) clusters solely on two IBM infrastructure offerings, namely [IBM VPC (Virtual Server Instances)](https://cloud.ibm.com/docs/vpc?topic=vpc-about-advanced-virtual-servers) and [IBM PowerVS](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-about-virtual-server).
+Currently, the CAPIBM project exclusively facilitates the deployment of Kubernetes (K8s) clusters solely on two IBM infrastructure offerings, namely [IBM VPC (Virtual Server Instances)](https://cloud.ibm.com/docs/vpc?topic=vpc-about-advanced-virtual-servers) and [IBM PowerVS](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-about-power-iaas).
 
 ## Quick Start
 

--- a/docs/book/src/topics/powervs/autoscaler-scalling-from-0.md
+++ b/docs/book/src/topics/powervs/autoscaler-scalling-from-0.md
@@ -1,10 +1,10 @@
 # Using Autoscaler to scale machines from 0 machine
 
-The autoscaler project supports [cluster-api](https://github.com/kubernetes-sigs/cluster-autoscaler/tree/main/pkg/cloudprovider/clusterapi#cluster-autoscaler-on-cluster-api). With this [enhancement](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md#upgrade-strategy) now the user can use cluster-api feature to scaling from 0 machine.
+The autoscaler project supports [cluster-api](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md). With this [enhancement](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md#upgrade-strategy) now the user can use cluster-api feature to scaling from 0 machine.
 
 ## Settinng up the workload cluster
 
-While creating a workload cluster, We need to set the below annotations to machinedeployment inorder to enable the autoscaling, This is one of the [prerequisites](https://github.com/kubernetes-sigs/cluster-autoscaler/tree/main/pkg/cloudprovider/clusterapi#enabling-autoscaling) for autoscaler.
+While creating a workload cluster, We need to set the below annotations to machinedeployment inorder to enable the autoscaling, This is one of the [prerequisites](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#enabling-autoscaling) for autoscaler.
 ```yaml
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -45,7 +45,7 @@ go build .
 ```
 
 Note:
-1. Autoscaler can be run in different ways, the possible ways are described [here](https://github.com/kubernetes-sigs/cluster-autoscaler/tree/main/pkg/cloudprovider/clusterapi#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters).
+1. Autoscaler can be run in different ways, the possible ways are described [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters).
 2. Autoscaler supports various command line flags and more details about it can be found [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca).
 
 ## Use case of cluster-autoscaler 

--- a/docs/book/src/topics/powervs/creating-a-cluster.md
+++ b/docs/book/src/topics/powervs/creating-a-cluster.md
@@ -135,6 +135,7 @@ following the steps below.
     ibm-powervs-1-control-plane-rg6xv    Ready    master   41h   v1.26.2
     ibm-powervs-1-md-0-4dc5c             Ready    <none>   41h   v1.26.2
     ibm-powervs-1-md-0-dbxb7             Ready    <none>   20h   v1.26.2
+    ```
 
 ### Deploy a PowerVS cluster with infrastructure creation
 
@@ -194,7 +195,7 @@ following the steps below.
 - IBMPOWERVS_SSHKEY_NAME : Name of the SSH Key. Refer [here](../../topics/capibmadm/powervs/key.md#3-capibmadm-powervs-key-list) how to get the keys.
 - IBMPOWERVS_VIP, IBMPOWERVS_VIP_EXTERNAL and IBMPOWERVS_VIP_CIDR : Once we have created the network and port, the values will be available on listing the ports. Refer [here](../../topics/capibmadm/powervs/port.md#3-capibmadm-powervs-port-list)
 - IBMPOWERVS_IMAGE_NAME : Name of the custom image. Refer [here](../../topics/capibmadm/powervs/image.md#2-capibmadm-powervs-image-list) to get image details.
-- IBMPOWERVS_SERVICE_INSTANCE_ID : ID of the PowerVS workspace. Refer [here](https://cloud.ibm.com/docs/power-iaas-cli-plugin?topic=power-iaas-cli-plugin-power-iaas-cli-reference-v1#ibmcloud-pi-workspace)
+- IBMPOWERVS_SERVICE_INSTANCE_ID : ID of the PowerVS workspace. Refer [here](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-power-iaas-cli-reference-v1#ibmcloud-pi-workspace)
 - IBMACCOUNT_ID : Go to the Account settings page in the IBM Cloud console to view your account ID and type. The account ID is a 32 character, unique account identifier.Refer [here](https://cloud.ibm.com/account/settings)
 - IBMPOWERVS_NETWORK_NAME : The name of the network. Refer [here](../../topics/capibmadm/powervs/network.md#3-capibmadm-powervs-network-list) how to get the network details.
 - [IBMPOWERVS_REGION](../../reference/regions-zones-mapping.md)

--- a/docs/book/src/topics/powervs/prerequisites.md
+++ b/docs/book/src/topics/powervs/prerequisites.md
@@ -20,7 +20,7 @@ To create an account, go to: [cloud.ibm.com](https://cloud.ibm.com).
 
 ###	Create an IBM Cloud account API key
 
-Please refer to the following [documentation](https://cloud.ibm.com/docs/account?topic=account-userapikey) to create an API key.
+Please refer to the following [documentation](https://cloud.ibm.com/docs/iam?topic=iam-userapikey) to create an API key.
 
 
 ### Create Power Systems Virtual Server Service Instance


### PR DESCRIPTION
**What this PR does / why we need it**:
Scripts were moved from `scripts/` and `hack/` into `hack/scripts/` subdirectories
in #2882, but several doc files still referenced the old paths. A few IBM Cloud
doc topic slugs also changed. This caused `make verify` to fail on the linkcheck
step, blocking unrelated Go PRs from merging (e.g. #2883).

This is a manual cherry-pick of #2898 (release-0.14 fix) with conflict resolution
for context differences between the two branches.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Docs-only change, no Go code touched.
- Cherry-pick of #2898 — conflicts were context-only (different k8s version strings
  and restructured template in `add_new_machine_image.md`), the actual link fixes
  are identical.

/area provider/ibmcloud


**Release note**:
```release-note
Fix broken documentation links caused by script relocation and IBM Cloud doc URL changes.