### PR TITLE
fix(powervs): skip busy load balancers instead of erroring, cut requeue interval to 15s

### DIFF
--- a/internal/controllers/powervs/ibmpowervsmachine_controller.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller.go
@@ -55,6 +55,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/powervs"
 )
 
+// loadBalancerSettleRequeueInterval is the poll interval while waiting for a VPC load balancer pool
+// update to leave the update_pending state. IBM VPC load balancers typically settle in 10–30 s;
+// 15 s avoids hammering the API while still reacting promptly.
+const loadBalancerSettleRequeueInterval = 15 * time.Second
+
 // IBMPowerVSMachineReconciler reconciles a IBMPowerVSMachine object.
 type IBMPowerVSMachineReconciler struct {
 	client.Client
@@ -424,12 +429,15 @@ func (r *IBMPowerVSMachineReconciler) markCondition(machineScope *powervsscope.M
 
 // handleLoadBalancerPoolMemberConfiguration handles load balancer pool member creation flow.
 func (r *IBMPowerVSMachineReconciler) handleLoadBalancerPoolMemberConfiguration(ctx context.Context, machineScope *powervsscope.MachineScope) (ctrl.Result, error) {
-	poolMember, err := machineScope.CreateVPCLoadBalancerPoolMember(ctx)
+	log := ctrl.LoggerFrom(ctx)
+	pendingUpdate, err := machineScope.CreateVPCLoadBalancerPoolMember(ctx)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create VPC load balancer pool member: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to configure VPC load balancer pool member: %w", err)
 	}
-	if poolMember != nil && (poolMember.ProvisioningStatus == nil || *poolMember.ProvisioningStatus != string(infrav1.LoadBalancerStateActive)) {
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	if pendingUpdate {
+		log.V(3).Info("VPC load balancer pool member registration incomplete, requeuing",
+			"requeueAfter", loadBalancerSettleRequeueInterval)
+		return ctrl.Result{RequeueAfter: loadBalancerSettleRequeueInterval}, nil
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
@@ -663,7 +663,7 @@ func TestIBMPowerVSMachineReconciler_handleLoadBalancerPoolMemberConfiguration(t
 			expect: func(v *mockVPC.MockVpc) {
 				v.EXPECT().GetLoadBalancer(gomock.Any()).Return(nil, &core.DetailedResponse{}, errors.New("lb error"))
 			},
-			expectedError: "failed to create VPC load balancer pool member",
+			expectedError: "failed to configure VPC load balancer pool member",
 		},
 	}
 
@@ -885,6 +885,182 @@ func newIBMPowerVSMachineWithInvalidConfiguration() *infrav1.IBMPowerVSMachine {
 			},
 		},
 	}
+}
+
+// TestHandleLoadBalancerPoolMemberConfiguration_PendingFlag verifies that the controller requeues at
+// loadBalancerSettleRequeueInterval when CreateVPCLoadBalancerPoolMember reports pending work, does
+// not requeue when registration is complete, and propagates hard errors (e.g. delete_pending) rather
+// than swallowing them — the busy-vs-broken distinction end to end.
+func TestHandleLoadBalancerPoolMemberConfiguration_PendingFlag(t *testing.T) {
+	var (
+		mockCtrl    *gomock.Controller
+		mockvpc     *mockVPC.MockVpc
+		mockpowervs *mock.MockPowerVS
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		mockvpc = mockVPC.NewMockVpc(mockCtrl)
+		mockpowervs = mock.NewMockPowerVS(mockCtrl)
+	}
+	teardown := func() { mockCtrl.Finish() }
+
+	// newScope builds a MachineScope wired for reconcileNormal with a single LB "capi-test-lb".
+	newScope := func(mockclient client.Client) *powervsscope.MachineScope {
+		secret := newSecret()
+		pvsmachine := newIBMPowerVSMachine()
+		machine := newMachine()
+		machine.Labels = map[string]string{"cluster.x-k8s.io/control-plane": "true"}
+		if mockclient == nil {
+			mockclient = fake.NewClientBuilder().WithObjects(secret, pvsmachine, machine).Build()
+		}
+		return &powervsscope.MachineScope{
+			Client: mockclient,
+			Cluster: &clusterv1.Cluster{
+				Status: clusterv1.ClusterStatus{
+					Initialization: clusterv1.ClusterInitializationStatus{
+						InfrastructureProvisioned: ptr.To(true),
+					},
+				},
+			},
+			Machine:           machine,
+			IBMPowerVSMachine: pvsmachine,
+			IBMPowerVSImage: &infrav1.IBMPowerVSImage{
+				Status: infrav1.IBMPowerVSImageStatus{ImageState: infrav1.PowerVSImageStateACTIVE},
+			},
+			IBMVPCClient:     mockvpc,
+			IBMPowerVSClient: mockpowervs,
+			DHCPIPCacheStore: cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
+			ProviderIDFormat: "v2",
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"powervs.cluster.x-k8s.io/create-infra": "true"},
+				},
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					Topology: infrav1.PowerVSVirtualIPTopology,
+					Workspace: infrav1.WorkspaceSource{
+						Type:      infrav1.SourceTypeReference,
+						Reference: infrav1.ResourceIdentifier{ID: "serviceInstanceID"},
+					},
+					VPC: infrav1.VPCSource{
+						Type:   infrav1.SourceTypeReference,
+						Region: "us-south",
+					},
+					LoadBalancers: []infrav1.LoadBalancerSource{
+						{
+							Type: infrav1.SourceTypeProvision,
+							Provision: infrav1.LoadBalancerProvision{
+								Name: "capi-test-lb",
+							},
+						},
+					},
+				},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					LoadBalancers: []infrav1.LoadBalancerStatus{
+						{Name: "capi-test-lb", ID: "capi-test-lb-id"},
+					},
+				},
+			},
+		}
+	}
+
+	instanceReferences := &models.PVMInstances{
+		PvmInstances: []*models.PVMInstanceReference{
+			{PvmInstanceID: ptr.To("capi-test-machine-id"), ServerName: ptr.To("capi-test-machine")},
+		},
+	}
+	instance := &models.PVMInstance{
+		PvmInstanceID: ptr.To("capi-test-machine-id"),
+		ServerName:    ptr.To("capi-test-machine"),
+		Status:        ptr.To("ACTIVE"),
+		Networks:      []*models.PVMInstanceNetwork{{IPAddress: "192.168.7.1"}},
+	}
+	activeLB := &vpcv1.LoadBalancer{
+		ID:                 core.StringPtr("capi-test-lb-id"),
+		ProvisioningStatus: core.StringPtr("active"),
+		Name:               core.StringPtr("capi-test-lb-name"),
+		Pools: []vpcv1.LoadBalancerPoolReference{
+			{ID: core.StringPtr("capi-test-pool-id"), Name: core.StringPtr("capi-test-pool-name")},
+		},
+	}
+
+	t.Run("pending=true → RequeueAfter equals loadBalancerSettleRequeueInterval", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		busyMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 core.StringPtr("member-id"),
+			ProvisioningStatus: core.StringPtr("update_pending"),
+		}
+		mockpowervs.EXPECT().ListInstances(gomock.Any()).Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.Any(), gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLB, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(busyMember, &core.DetailedResponse{}, nil)
+
+		result, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).To(BeNil())
+		g.Expect(result.RequeueAfter).To(Equal(loadBalancerSettleRequeueInterval))
+	})
+
+	t.Run("pending=false → empty Result (no requeue)", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		activeMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 core.StringPtr("member-id"),
+			ProvisioningStatus: core.StringPtr("active"),
+		}
+		mockpowervs.EXPECT().ListInstances(gomock.Any()).Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.Any(), gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLB, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(&vpcv1.LoadBalancerPoolMemberCollection{}, &core.DetailedResponse{}, nil)
+		mockvpc.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(activeMember, &core.DetailedResponse{}, nil)
+
+		result, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).To(BeNil())
+		g.Expect(result.RequeueAfter).To(BeZero())
+	})
+
+	t.Run("scope error → reconciler propagates error, does not swallow it", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		reconciler := IBMPowerVSMachineReconciler{
+			Client:   fake.NewClientBuilder().Build(),
+			Recorder: record.NewFakeRecorder(10),
+		}
+		machineScope := newScope(nil)
+
+		// An LB in delete_pending is a non-transient error from CreateVPCLoadBalancerPoolMember.
+		deletingLB := &vpcv1.LoadBalancer{
+			ID:                 core.StringPtr("capi-test-lb-id"),
+			Name:               core.StringPtr("capi-test-lb-name"),
+			ProvisioningStatus: core.StringPtr("delete_pending"),
+		}
+		mockpowervs.EXPECT().ListInstances(gomock.Any()).Return(instanceReferences, nil)
+		mockpowervs.EXPECT().GetInstance(gomock.Any(), gomock.AssignableToTypeOf("capi-test-machine-id")).Return(instance, nil)
+		mockvpc.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(deletingLB, &core.DetailedResponse{}, nil)
+
+		_, err := reconciler.reconcileNormal(ctx, machineScope)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("failed to configure load balancer"))
+	})
 }
 
 func newMachine() *clusterv1.Machine {
@@ -1313,9 +1489,6 @@ func TestIBMPowerVSMachineReconciler_reconcileNormal_additionalBranches(t *testi
 				v.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 					Members: []vpcv1.LoadBalancerPoolMember{},
 				}, nil, nil)
-				v.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
-					ID: ptr.To("lb-id"), ProvisioningStatus: ptr.To("active"),
-				}, nil, nil)
 				v.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
 					ID:                 ptr.To("member-id"),
 					ProvisioningStatus: ptr.To("active"),
@@ -1420,7 +1593,6 @@ func TestIBMPowerVSMachineReconciler_handleLB_additionalBranches(t *testing.T) {
 		mockVPCClient.EXPECT().GetLoadBalancer(gomock.Any()).Return(lb, nil, nil)
 		mockVPCClient.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(
 			&vpcv1.LoadBalancerPoolMemberCollection{Members: []vpcv1.LoadBalancerPoolMember{}}, nil, nil)
-		mockVPCClient.EXPECT().GetLoadBalancer(gomock.Any()).Return(lb, nil, nil)
 		mockVPCClient.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
 			ID:                 ptr.To("m-id"),
 			ProvisioningStatus: ptr.To("create_pending"),

--- a/pkg/cloud/scope/powervs/powervs_machine.go
+++ b/pkg/cloud/scope/powervs/powervs_machine.go
@@ -481,19 +481,31 @@ func (s *MachineScope) DeleteMachineIgnition(ctx context.Context) error {
 	return nil
 }
 
-// CreateVPCLoadBalancerPoolMember creates a member in load balancer pool.
-func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vpcv1.LoadBalancerPoolMember, error) { //nolint:gocyclo
+// CreateVPCLoadBalancerPoolMember registers the current machine's IP in every eligible load balancer
+// pool. It is designed for parallel progress across multiple load balancers:
+//
+//   - A transiently-busy load balancer (update_pending, create_pending) is skipped — not an error —
+//     so the other load balancer can still make progress in the same reconcile pass.
+//   - A non-transient non-active state (e.g. delete_pending, or any unknown state) is returned as
+//     an error so that a genuinely broken load balancer surfaces through conditions/events.
+//   - At most one CreateLoadBalancerPoolMember (POST) is issued per load balancer per pass. After a
+//     write the load balancer goes update_pending, so subsequent pools on the same load balancer are
+//     checked for membership only; if any are still unregistered the pending flag is set.
+//
+// Returns (pendingUpdate, err):
+//   - pendingUpdate: true when any registration is still incomplete.
+//   - err: only set for real API failures or a non-transient load balancer state.
+func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (bool, error) { //nolint:gocyclo
 	log := ctrl.LoggerFrom(ctx)
 	loadBalancers := make([]infrav1.LoadBalancerSource, 0)
 	if len(s.IBMPowerVSCluster.Spec.LoadBalancers) == 0 {
-		loadBalancer := infrav1.LoadBalancerSource{
+		loadBalancers = append(loadBalancers, infrav1.LoadBalancerSource{
 			Type: infrav1.SourceTypeProvision,
 			Provision: infrav1.LoadBalancerProvision{
 				Name: ResourceName(s.IBMPowerVSCluster.Name, ResourceTypeLBPublic, ""),
 				Type: infrav1.LoadBalancerTypePublic,
 			},
-		}
-		loadBalancers = append(loadBalancers, loadBalancer)
+		})
 	}
 	for index, loadBalancer := range s.IBMPowerVSCluster.Spec.LoadBalancers {
 		if loadBalancer.Type == infrav1.SourceTypeProvision && loadBalancer.Provision.Name == "" {
@@ -510,6 +522,8 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 		loadBalancers = append(loadBalancers, loadBalancer)
 	}
 
+	pendingUpdate := false
+
 	for _, lb := range loadBalancers {
 		var lbName string
 		switch lb.Type {
@@ -519,13 +533,13 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 			lbName = lb.Provision.Name
 		}
 		if lbName == "" {
-			return nil, fmt.Errorf("failed to determine VPC load balancer name")
+			return false, fmt.Errorf("failed to determine VPC load balancer name")
 		}
 
-		var lbID string
 		if len(s.IBMPowerVSCluster.Status.LoadBalancers) == 0 {
-			return nil, fmt.Errorf("failed to find VPC load balancer ID")
+			return false, fmt.Errorf("failed to find VPC load balancer ID")
 		}
+		var lbID string
 		found := false
 		for _, val := range s.IBMPowerVSCluster.Status.LoadBalancers {
 			if val.Name == lbName {
@@ -535,24 +549,45 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 			}
 		}
 		if !found || lbID == "" {
-			return nil, fmt.Errorf("failed to find VPC load balancer ID")
+			return false, fmt.Errorf("failed to find VPC load balancer ID")
 		}
 
-		loadBalancer, _, err := s.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{
-			ID: &lbID,
-		})
+		loadBalancerDetails, _, err := s.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: &lbID})
 		if err != nil {
-			return nil, fmt.Errorf("failed to find VPC load balancer details: %w", err)
+			return false, fmt.Errorf("failed to find VPC load balancer details: %w", err)
 		}
-		if loadBalancer.ProvisioningStatus == nil || *loadBalancer.ProvisioningStatus != string(infrav1.LoadBalancerStateActive) {
-			return nil, fmt.Errorf("VPC load balancer is not in active state, current state %s", ptr.Deref(loadBalancer.ProvisioningStatus, ""))
+
+		// Only transient states are safe to skip and retry. A non-transient non-active state
+		// (e.g. delete_pending, or any unknown state) means the load balancer is genuinely broken
+		// and should surface as an error so conditions/events reflect it.
+		// A create_pending load balancer may legitimately have zero pools, so the
+		// provisioning status is checked before the pool count.
+		if loadBalancerDetails.ProvisioningStatus == nil {
+			return false, fmt.Errorf("VPC load balancer %s has no provisioning status", lbName)
 		}
-		if len(loadBalancer.Pools) == 0 {
-			return nil, fmt.Errorf("no pools exist for the VPC load balancer %s", lbName)
+
+		loadBalancerState := infrav1.LoadBalancerState(*loadBalancerDetails.ProvisioningStatus)
+
+		switch loadBalancerState {
+		case infrav1.LoadBalancerStateActive:
+			// Load balancer is active and ready; proceed normally.
+			log.V(3).Info("VPC load balancer is active", "loadBalancerName", lbName, "loadBalancerState", loadBalancerState)
+		case infrav1.LoadBalancerStateUpdatePending, infrav1.LoadBalancerStateCreatePending:
+			log.V(3).Info("VPC load balancer is transiently busy, skipping this pass",
+				"loadBalancerName", lbName, "loadBalancerState", loadBalancerState)
+			pendingUpdate = true
+			continue
+		default:
+			return false, fmt.Errorf("VPC load balancer %s is in non-recoverable state %q", lbName, loadBalancerState)
+		}
+
+		if len(loadBalancerDetails.Pools) == 0 {
+			return false, fmt.Errorf("no pools exist for the VPC load balancer %s", lbName)
 		}
 
 		internalIP := s.GetMachineInternalIP()
 
+		// lbAdditionalListeners: port-protocol key → spec entry (used to resolve target ports).
 		lbAdditionalListeners := map[string]infrav1.AdditionalListener{}
 		for _, additionalListener := range lb.Provision.AdditionalListeners {
 			protocol := additionalListener.Protocol
@@ -562,14 +597,15 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 			lbAdditionalListeners[fmt.Sprintf("%d-%s", additionalListener.Port, protocol)] = additionalListener
 		}
 
+		// loadBalancerListeners: pool name → listener spec (populated from the cloud's listener list).
 		loadBalancerListeners := map[string]infrav1.AdditionalListener{}
-		for _, listener := range loadBalancer.Listeners {
-			listenerOptions := &vpcv1.GetLoadBalancerListenerOptions{}
-			listenerOptions.SetLoadBalancerID(*loadBalancer.ID)
-			listenerOptions.SetID(*listener.ID)
-			loadBalancerListener, _, err := s.IBMVPCClient.GetLoadBalancerListener(listenerOptions)
+		for _, listenerRef := range loadBalancerDetails.Listeners {
+			listenerOpts := &vpcv1.GetLoadBalancerListenerOptions{}
+			listenerOpts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			listenerOpts.SetID(*listenerRef.ID)
+			loadBalancerListener, _, err := s.IBMVPCClient.GetLoadBalancerListener(listenerOpts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list %s load balancer listener: %w", *listener.ID, err)
+				return false, fmt.Errorf("failed to get load balancer listener %s: %w", *listenerRef.ID, err)
 			}
 			if additionalListener, ok := lbAdditionalListeners[fmt.Sprintf("%d-%s", *loadBalancerListener.Port, *loadBalancerListener.Protocol)]; ok {
 				if loadBalancerListener.DefaultPool != nil {
@@ -588,20 +624,17 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 				}
 			}
 		}
-		// Update each LoadBalancer pool
-		// For each pool, get the additionalListener associated with the pool from the loadBalancerListeners map.
-		for _, pool := range loadBalancer.Pools {
-			log.V(3).Info("Updating LoadBalancer pool member", "pool", *pool.Name, "loadBalancerName", *loadBalancer.Name, "IP", internalIP)
-			listOptions := &vpcv1.ListLoadBalancerPoolMembersOptions{}
-			listOptions.SetLoadBalancerID(*loadBalancer.ID)
-			listOptions.SetPoolID(*pool.ID)
-			listLoadBalancerPoolMembers, _, err := s.IBMVPCClient.ListLoadBalancerPoolMembers(listOptions)
-			if err != nil {
-				return nil, fmt.Errorf("failed to list %s VPC load balancer pool: %w", *pool.Name, err)
-			}
-			var targetPort int64
-			var alreadyRegistered bool
 
+		// updatedThisLB tracks whether we've already issued a POST to this load balancer in the
+		// current pass. After one write the load balancer goes update_pending, so further writes
+		// would fail. Instead we continue scanning remaining pools for membership to set pendingUpdate.
+		updatedThisLB := false
+
+		for _, pool := range loadBalancerDetails.Pools {
+			log.V(3).Info("Checking LoadBalancer pool member", "pool", *pool.Name, "loadBalancerName", *loadBalancerDetails.Name, "IP", internalIP)
+
+			// Determine the target port and evaluate label selectors for this pool.
+			var targetPort int64
 			if loadBalancerListener, ok := loadBalancerListeners[*pool.Name]; ok {
 				targetPort = loadBalancerListener.Port
 				log.V(3).Info("Checking if machine label matches with the label selector in listener", "machineLabel", s.IBMPowerVSMachine.Labels, "labelSelector", loadBalancerListener.Selector)
@@ -610,61 +643,69 @@ func (s *MachineScope) CreateVPCLoadBalancerPoolMember(ctx context.Context) (*vp
 					log.V(5).Error(err, "Skipping listener addition, failed to get label selector from spec selector")
 					continue
 				}
-
 				if selector.Empty() && !util.IsControlPlaneMachine(s.Machine) {
 					log.V(3).Info("Skipping listener addition as the selector is empty and not a control plane machine")
 					continue
 				}
-				// Skip adding the listener if the selector does not match
 				if !selector.Empty() && !selector.Matches(labels.Set(s.IBMPowerVSMachine.Labels)) {
 					log.V(3).Info("Skip adding listener, machine label doesn't match with the listener label selector", "pool", *pool.Name, "IP", internalIP)
 					continue
 				}
 			}
 
-			for _, member := range listLoadBalancerPoolMembers.Members {
-				if target, ok := member.Target.(*vpcv1.LoadBalancerPoolMemberTarget); ok {
+			// If we already wrote to this load balancer this pass, it is now update_pending;
+			// further writes would fail. Break out without listing remaining pools.
+			if updatedThisLB {
+				log.V(3).Info("Already updated load balancer this pass, skipping remaining pools",
+					"pool", *pool.Name, "loadBalancerName", *loadBalancerDetails.Name)
+				pendingUpdate = true
+				break
+			}
+
+			// Check existing membership.
+			listOpts := &vpcv1.ListLoadBalancerPoolMembersOptions{}
+			listOpts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			listOpts.SetPoolID(*pool.ID)
+			existingPoolMembers, _, err := s.IBMVPCClient.ListLoadBalancerPoolMembers(listOpts)
+			if err != nil {
+				return false, fmt.Errorf("failed to list %s VPC load balancer pool members: %w", *pool.Name, err)
+			}
+
+			alreadyRegistered := false
+			for _, member := range existingPoolMembers.Members {
+				if target, ok := member.Target.(*vpcv1.LoadBalancerPoolMemberTarget); ok && target.Address != nil {
 					if *target.Address == internalIP {
 						alreadyRegistered = true
-						log.V(3).Info("Target IP already configured for pool", "IP", internalIP, "poolName", *pool.Name)
+						log.V(3).Info("Pool member already exists", "poolName", *pool.Name, "IP", internalIP)
+						break
 					}
 				}
 			}
-
 			if alreadyRegistered {
-				log.V(3).Info("PoolMember already exist", "poolName", *pool.Name, "IP", internalIP, "targetPort", targetPort)
 				continue
 			}
 
-			// make sure that LoadBalancer is in active state
-			loadBalancer, _, err := s.IBMVPCClient.GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{
-				ID: loadBalancer.ID,
-			})
+			// Machine is not yet in this pool — write the membership.
+			opts := &vpcv1.CreateLoadBalancerPoolMemberOptions{}
+			opts.SetPort(targetPort)
+			opts.SetLoadBalancerID(*loadBalancerDetails.ID)
+			opts.SetPoolID(*pool.ID)
+			opts.SetTarget(&vpcv1.LoadBalancerPoolMemberTargetPrototype{Address: &internalIP})
+			log.V(3).Info("Creating VPC load balancer pool member", "pool", *pool.Name, "IP", internalIP, "port", targetPort)
+			newMember, _, err := s.IBMVPCClient.CreateLoadBalancerPoolMember(opts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to fetch VPC load balancer details with ID: %s error: %v", lbID, err)
+				return false, fmt.Errorf("failed to create VPC load balancer %s pool member: %w", *loadBalancerDetails.Name, err)
 			}
-			if loadBalancer.ProvisioningStatus == nil || *loadBalancer.ProvisioningStatus != string(infrav1.LoadBalancerStateActive) {
-				log.V(3).Info("Unable to update pool for VPC load balancer as it is not in active state", "loadBalancerName", *loadBalancer.Name, "loadBalancerState", *loadBalancer.ProvisioningStatus)
-				return nil, fmt.Errorf("VPC load balancer %s not in active state to update pool member", *loadBalancer.Name)
-			}
+			log.Info("Created VPC load balancer pool member", "memberID", *newMember.ID, "pool", *pool.Name)
 
-			options := &vpcv1.CreateLoadBalancerPoolMemberOptions{}
-			options.SetPort(targetPort)
-			options.SetLoadBalancerID(*loadBalancer.ID)
-			options.SetPoolID(*pool.ID)
-			options.SetTarget(&vpcv1.LoadBalancerPoolMemberTargetPrototype{
-				Address: &internalIP,
-			})
-			log.V(3).Info("Creating VPC load balancer pool member", "options", options)
-			loadBalancerPoolMember, _, err := s.IBMVPCClient.CreateLoadBalancerPoolMember(options)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create VPC load balancer %s pool member %w", *loadBalancer.Name, err)
+			updatedThisLB = true
+			// If the member is not yet active, the load balancer is settling; signal a requeue.
+			if newMember.ProvisioningStatus == nil || *newMember.ProvisioningStatus != string(infrav1.LoadBalancerStateActive) {
+				pendingUpdate = true
 			}
-			log.Info("Created VPC load balancer pool member", "loadBalancerID", *loadBalancerPoolMember.ID)
-			return loadBalancerPoolMember, nil
 		}
 	}
-	return nil, nil
+	return pendingUpdate, nil
 }
 
 // SetReady will set the status as ready for the machine.

--- a/pkg/cloud/scope/powervs/powervs_machine_test.go
+++ b/pkg/cloud/scope/powervs/powervs_machine_test.go
@@ -2298,7 +2298,7 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("failed to find VPC load balancer details"))
 	})
 
-	t.Run("error when load balancer is not in active state", func(t *testing.T) {
+	t.Run("update_pending LB is skipped (not an error), returns pending=true", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -2312,9 +2312,9 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 			Listeners:          []vpcv1.LoadBalancerListenerReference{},
 		}, nil, nil)
 
-		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("VPC load balancer is not in active state"))
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pending).To(BeTrue())
 	})
 
 	t.Run("error when load balancer has no pools", func(t *testing.T) {
@@ -2384,36 +2384,26 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 			},
 		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
-	t.Run("error when second GetLoadBalancer call fails before creating member", func(t *testing.T) {
+	t.Run("delete_pending LB is a non-recoverable error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 
 		scope := makeScopeWithLBStatus(mockVPC)
-		// First call succeeds
 		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
 			ID:                 ptr.To(lbID),
 			Name:               ptr.To(lbName),
-			ProvisioningStatus: ptr.To(activeState),
-			Pools: []vpcv1.LoadBalancerPoolReference{
-				{ID: ptr.To(poolID), Name: ptr.To(poolName)},
-			},
-			Listeners: []vpcv1.LoadBalancerListenerReference{},
+			ProvisioningStatus: ptr.To("delete_pending"),
 		}, nil, nil)
-		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
-			Members: []vpcv1.LoadBalancerPoolMember{},
-		}, nil, nil)
-		// Second GetLoadBalancer (re-check before create) fails
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(nil, nil, errors.New("lb re-fetch failed"))
 
 		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("failed to fetch VPC load balancer details"))
+		g.Expect(err.Error()).To(ContainSubstring("non-recoverable state"))
 	})
 
 	t.Run("error when CreateLoadBalancerPoolMember fails", func(t *testing.T) {
@@ -2435,7 +2425,6 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(lbActive, nil, nil)
 		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(nil, nil, errors.New("create member failed"))
 
 		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
@@ -2443,7 +2432,7 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("failed to create VPC load balancer"))
 	})
 
-	t.Run("successfully creates pool member and returns it", func(t *testing.T) {
+	t.Run("successfully creates pool member and returns pending=false when active", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
@@ -2462,15 +2451,14 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(lbActive, nil, nil)
 		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
-			ID: ptr.To(memberID),
+			ID:                 ptr.To(memberID),
+			ProvisioningStatus: ptr.To(activeState),
 		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).NotTo(BeNil())
-		g.Expect(*result.ID).To(Equal(memberID))
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("error when GetLoadBalancerListener fails", func(t *testing.T) {
@@ -2505,7 +2493,7 @@ func TestCreateVPCLoadBalancerPoolMember(t *testing.T) {
 
 		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("failed to list"))
+		g.Expect(err.Error()).To(ContainSubstring("failed to get load balancer listener"))
 	})
 }
 
@@ -2781,13 +2769,11 @@ func TestCreateVPCLoadBalancerPoolMemberSelectorBranches(t *testing.T) {
 			Protocol:    ptr.To("tcp"),
 			DefaultPool: &vpcv1.LoadBalancerPoolReference{ID: ptr.To(selectorPoolID), Name: ptr.To(selectorPoolName)},
 		}, nil, nil)
-		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
-			Members: []vpcv1.LoadBalancerPoolMember{},
-		}, nil, nil)
+		// ListLoadBalancerPoolMembers is NOT called — the selector check (empty + not CP) fires first
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("skips pool when non-empty selector does not match machine labels", func(t *testing.T) {
@@ -2821,42 +2807,28 @@ func TestCreateVPCLoadBalancerPoolMemberSelectorBranches(t *testing.T) {
 			Protocol:    ptr.To("tcp"),
 			DefaultPool: &vpcv1.LoadBalancerPoolReference{ID: ptr.To(selectorPoolID), Name: ptr.To(selectorPoolName)},
 		}, nil, nil)
-		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
-			Members: []vpcv1.LoadBalancerPoolMember{},
-		}, nil, nil)
+		// ListLoadBalancerPoolMembers is NOT called — the selector mismatch check fires first
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
-	t.Run("error when LB not in active state on second GetLoadBalancer call before create", func(t *testing.T) {
+	t.Run("nil provisioning status returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		setup(t)
 		t.Cleanup(teardown)
 
 		scope := makeSelectorScope(mockVPC)
-		lbActive := &vpcv1.LoadBalancer{
+		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
 			ID:                 ptr.To(selectorLBID),
 			Name:               ptr.To(selectorLBName),
-			ProvisioningStatus: ptr.To(selectorActiveState),
-			Pools:              []vpcv1.LoadBalancerPoolReference{{ID: ptr.To(selectorPoolID), Name: ptr.To(selectorPoolName)}},
-			Listeners:          []vpcv1.LoadBalancerListenerReference{},
-		}
-		lbPending := &vpcv1.LoadBalancer{
-			ID:                 ptr.To(selectorLBID),
-			Name:               ptr.To(selectorLBName),
-			ProvisioningStatus: ptr.To("update_pending"),
-		}
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(lbActive, nil, nil)
-		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
-			Members: []vpcv1.LoadBalancerPoolMember{},
+			ProvisioningStatus: nil,
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(lbPending, nil, nil)
 
 		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("not in active state to update pool member"))
+		g.Expect(err.Error()).To(ContainSubstring("has no provisioning status"))
 	})
 }
 
@@ -3260,18 +3232,14 @@ func TestCreateVPCLoadBalancerPoolMemberAdditionalBranches(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
-			ID:                 ptr.To(lbID),
-			Name:               ptr.To(privateLBName),
+		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To("new-member"),
 			ProvisioningStatus: ptr.To(activeState),
 		}, nil, nil)
-		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
-			ID: ptr.To("new-member"),
-		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).NotTo(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("resolves LB name with index qualifier when provision name is empty and index > 0", func(t *testing.T) {
@@ -3335,14 +3303,14 @@ func TestCreateVPCLoadBalancerPoolMemberAdditionalBranches(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(activeLB1, nil, nil)
 		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
-			ID: ptr.To("new-member-1"),
+			ID:                 ptr.To("new-member-1"),
+			ProvisioningStatus: ptr.To(activeState),
 		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).NotTo(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("resolves LB name from reference type", func(t *testing.T) {
@@ -3372,18 +3340,14 @@ func TestCreateVPCLoadBalancerPoolMemberAdditionalBranches(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
-			ID:                 ptr.To(lbID),
-			Name:               ptr.To(refLBName),
+		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To("ref-member"),
 			ProvisioningStatus: ptr.To(activeState),
 		}, nil, nil)
-		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
-			ID: ptr.To("ref-member"),
-		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).NotTo(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 
 	t.Run("listener with port 6443 but nil DefaultPool logs and skips pool mapping", func(t *testing.T) {
@@ -3421,18 +3385,14 @@ func TestCreateVPCLoadBalancerPoolMemberAdditionalBranches(t *testing.T) {
 		mockVPC.EXPECT().ListLoadBalancerPoolMembers(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMemberCollection{
 			Members: []vpcv1.LoadBalancerPoolMember{},
 		}, nil, nil)
-		mockVPC.EXPECT().GetLoadBalancer(gomock.Any()).Return(&vpcv1.LoadBalancer{
-			ID:                 ptr.To(lbID),
-			Name:               ptr.To(lbName),
+		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To("member-after-nil-pool"),
 			ProvisioningStatus: ptr.To(activeState),
 		}, nil, nil)
-		mockVPC.EXPECT().CreateLoadBalancerPoolMember(gomock.Any()).Return(&vpcv1.LoadBalancerPoolMember{
-			ID: ptr.To("member-after-nil-pool"),
-		}, nil, nil)
 
-		result, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		pending, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).NotTo(BeNil())
+		g.Expect(pending).To(BeFalse())
 	})
 }
 
@@ -3803,5 +3763,351 @@ func TestCreateVPCLoadBalancerPoolMemberEmptyLBName(t *testing.T) {
 		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to find VPC load balancer ID"))
+	})
+}
+
+func TestCreateVPCLoadBalancerPoolMemberSkipAndRequeue(t *testing.T) {
+	var mockCtrl *gomock.Controller
+	setupSR := func(t *testing.T) { t.Helper(); mockCtrl = gomock.NewController(t) }
+	teardownSR := func() { mockCtrl.Finish() }
+
+	lbID := "lb-id-1"
+	lbName := "lb-1"
+	poolID := "pool-id-1"
+	poolName := fmt.Sprintf("pool-1-%d", 6443)
+	machineIP := "10.0.0.5"
+
+	baseCluster := func(lbSrc infrav1.LoadBalancerSource, lbStatus infrav1.LoadBalancerStatus) *infrav1.IBMPowerVSCluster {
+		return &infrav1.IBMPowerVSCluster{
+			Spec:   infrav1.IBMPowerVSClusterSpec{LoadBalancers: []infrav1.LoadBalancerSource{lbSrc}},
+			Status: infrav1.IBMPowerVSClusterStatus{LoadBalancers: []infrav1.LoadBalancerStatus{lbStatus}},
+		}
+	}
+	cpMachine := func() *clusterv1.Machine {
+		return &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"cluster.x-k8s.io/control-plane": "true"}}}
+	}
+	machineWithIP := func() *infrav1.IBMPowerVSMachine {
+		return &infrav1.IBMPowerVSMachine{
+			Status: infrav1.IBMPowerVSMachineStatus{
+				Addresses: []clusterv1.MachineAddress{{Address: machineIP, Type: clusterv1.MachineInternalIP}},
+			},
+		}
+	}
+
+	t.Run("Skips busy load balancer without error", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		busyLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateUpdatePending)),
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(busyLB, nil, nil)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		pendingUpdate, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(pendingUpdate).To(BeTrue())
+		// No CreateLoadBalancerPoolMember call expected (gomock will fail the test if one occurs).
+	})
+
+	t.Run("Treats nil member ProvisioningStatus as pending without panic", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		activeLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+			Pools:              []vpcv1.LoadBalancerPoolReference{{ID: ptr.To(poolID), Name: ptr.To(poolName)}},
+		}
+		nilStatusMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To("member-id-nil"),
+			ProvisioningStatus: nil,
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLB, nil, nil)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(
+			&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).Return(nilStatusMember, nil, nil)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		pendingUpdate, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(pendingUpdate).To(BeTrue())
+	})
+
+	t.Run("Returns error for non-transient load balancer state", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		deletingLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateDeletePending)),
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(deletingLB, nil, nil)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("non-recoverable state"))
+	})
+
+	t.Run("Returns error when load balancer ProvisioningStatus is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		nilStatusLB := &vpcv1.LoadBalancer{
+			ID:   ptr.To(lbID),
+			Name: ptr.To(lbName),
+			// ProvisioningStatus intentionally nil
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(nilStatusLB, nil, nil)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		_, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("has no provisioning status"))
+	})
+
+	t.Run("Treats create_pending with zero pools as transient, not an error", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		creatingLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateCreatePending)),
+			// Pools intentionally empty — LB not yet fully created
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(creatingLB, nil, nil)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		pendingUpdate, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		g.Expect(pendingUpdate).To(BeTrue())
+	})
+
+	t.Run("Issues at most one write per load balancer per pass", func(t *testing.T) {
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		pool2ID := "pool-id-2"
+		pool2Name := fmt.Sprintf("pool-2-%d", 22)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		activeLBTwoPools := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+			Pools: []vpcv1.LoadBalancerPoolReference{
+				{ID: ptr.To(poolID), Name: ptr.To(poolName)},
+				{ID: ptr.To(pool2ID), Name: ptr.To(pool2Name)},
+			},
+		}
+
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).Return(activeLBTwoPools, nil, nil)
+		// pool-1 is listed then written; pool-2 is never listed because break exits the loop after the write.
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).Return(
+			&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).Times(1)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{ID: ptr.To("member-id-1"), ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive))}, nil, nil).Times(1)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		pendingUpdate, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		// Wrote to pool-1; pool-2 deferred → pendingUpdate=true, only 1 POST issued (enforced by Times(1)).
+		g.Expect(pendingUpdate).To(BeTrue())
+	})
+
+	t.Run("Makes progress on active load balancer when other is busy", func(t *testing.T) {
+		// Two LBs in the cluster: lb-1 is update_pending (busy), lb-2 is active with an
+		// unregistered pool. The fix must write to lb-2 and return pendingUpdate=true
+		// (because lb-1 was skipped, not because lb-2 is incomplete).
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		lbID2 := "lb-id-2"
+		lbName2 := "lb-2"
+		poolID2 := "pool-id-2"
+		poolName2 := fmt.Sprintf("pool-2-%d", 6443)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		busyLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateUpdatePending)),
+		}
+		activeLB2 := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID2),
+			Name:               ptr.To(lbName2),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+			Pools:              []vpcv1.LoadBalancerPoolReference{{ID: ptr.To(poolID2), Name: ptr.To(poolName2)}},
+		}
+		registeredMember := &vpcv1.LoadBalancerPoolMember{
+			ID:                 ptr.To("member-id-2"),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+		}
+
+		// lb-1 is busy — one GetLoadBalancer call, no write.
+		mockClient.EXPECT().GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: ptr.To(lbID)}).
+			Return(busyLB, nil, nil).Times(1)
+		// lb-2 is active — proceeds through list+create.
+		mockClient.EXPECT().GetLoadBalancer(&vpcv1.GetLoadBalancerOptions{ID: ptr.To(lbID2)}).
+			Return(activeLB2, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).Times(1)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(registeredMember, nil, nil).Times(1)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					LoadBalancers: []infrav1.LoadBalancerSource{
+						{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+						{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID2, Name: lbName2}},
+					},
+				},
+				Status: infrav1.IBMPowerVSClusterStatus{
+					LoadBalancers: []infrav1.LoadBalancerStatus{
+						{Name: lbName, ID: lbID},
+						{Name: lbName2, ID: lbID2},
+					},
+				},
+			},
+		}
+
+		pendingUpdate, err := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err).To(BeNil())
+		// lb-1 was busy → pendingUpdate=true even though lb-2 made progress.
+		g.Expect(pendingUpdate).To(BeTrue())
+		// Exactly one POST was issued — to lb-2, not lb-1 (enforced by Times(1) above).
+	})
+
+	t.Run("Completes registration across multiple passes", func(t *testing.T) {
+		// Pass 1: pool is unregistered → POST, member returns active.
+		// Pass 2: pool already has machineIP → no write, pendingUpdate=false.
+		g := NewWithT(t)
+		setupSR(t)
+		t.Cleanup(teardownSR)
+
+		mockClient := vpcmock.NewMockVpc(mockCtrl)
+		activeLB := &vpcv1.LoadBalancer{
+			ID:                 ptr.To(lbID),
+			Name:               ptr.To(lbName),
+			ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+			Pools:              []vpcv1.LoadBalancerPoolReference{{ID: ptr.To(poolID), Name: ptr.To(poolName)}},
+		}
+
+		// Pass 1: empty pool → POST → active member.
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(activeLB, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMemberCollection{}, nil, nil).Times(1)
+		mockClient.EXPECT().CreateLoadBalancerPoolMember(gomock.AssignableToTypeOf(&vpcv1.CreateLoadBalancerPoolMemberOptions{})).
+			Return(&vpcv1.LoadBalancerPoolMember{
+				ID:                 ptr.To("member-id-1"),
+				ProvisioningStatus: ptr.To(string(infrav1.LoadBalancerStateActive)),
+			}, nil, nil).Times(1)
+
+		scope := MachineScope{
+			Machine:           cpMachine(),
+			IBMVPCClient:      mockClient,
+			IBMPowerVSMachine: machineWithIP(),
+			IBMPowerVSCluster: baseCluster(
+				infrav1.LoadBalancerSource{Type: infrav1.SourceTypeReference, Reference: infrav1.ResourceIdentifier{ID: lbID, Name: lbName}},
+				infrav1.LoadBalancerStatus{Name: lbName, ID: lbID},
+			),
+		}
+
+		pending1, err1 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err1).To(BeNil())
+		// Active member returned, pool written → pendingUpdate=false (all done).
+		g.Expect(pending1).To(BeFalse())
+
+		// Pass 2: pool already has machineIP registered → no POST, pendingUpdate=false.
+		registeredMembers := &vpcv1.LoadBalancerPoolMemberCollection{
+			Members: []vpcv1.LoadBalancerPoolMember{
+				{Target: &vpcv1.LoadBalancerPoolMemberTarget{Address: ptr.To(machineIP)}},
+			},
+		}
+		mockClient.EXPECT().GetLoadBalancer(gomock.AssignableToTypeOf(&vpcv1.GetLoadBalancerOptions{})).
+			Return(activeLB, nil, nil).Times(1)
+		mockClient.EXPECT().ListLoadBalancerPoolMembers(gomock.AssignableToTypeOf(&vpcv1.ListLoadBalancerPoolMembersOptions{})).
+			Return(registeredMembers, nil, nil).Times(1)
+
+		pending2, err2 := scope.CreateVPCLoadBalancerPoolMember(ctx)
+		g.Expect(err2).To(BeNil())
+		g.Expect(pending2).To(BeFalse())
 	})
 }


### PR DESCRIPTION
## What this fixes

Main-branch equivalent of #2883 (targeting release-0.13).

During PowerVS cluster provisioning, control-plane machines register into VPC load
balancer pools. Each registration briefly locks the load balancer while it applies the
change. The old code treated a locked LB as an error and gave up on the whole reconcile
pass — including any other LB that was free the whole time. It also waited a flat 60
seconds before trying again, no matter how quickly the LB actually settled.

Result: with 2 LBs × 2 pools per machine, registering 3 control-plane machines took
15–25 minutes in production, occasionally blowing past the installer's bootstrap timeout.

## What changed

- A load balancer in a transient state (`update_pending`, `create_pending`) is now
  skipped, not errored — the other LB still makes progress in the same pass.
- A genuinely broken LB (`delete_pending`, unknown/nil status) still returns an error, so
  real failures surface through conditions and events instead of retrying forever.
- At most one write per LB per pass. If a machine needs more than one pool on the same LB,
  the rest are picked up on the next pass rather than attempted against a now-locked LB.
- Requeue interval dropped from a fixed 1 minute to 15 seconds.

`CreateVPCLoadBalancerPoolMember` now returns `(pendingUpdate bool, err error)` instead of
`(*LoadBalancerPoolMember, error)` — the caller only ever needs to know whether more work
remains, not the specific member object.

## Differences from #2883

Same design, adapted to main's structure:

- Paths: `pkg/cloud/scope/powervs/` and `internal/controllers/powervs/`
- v1beta3 types: `LoadBalancerState*` instead of `VPCLoadBalancerState*`,
  `AdditionalListener` instead of `AdditionalListenerSpec`
- `IBMPowerVSCluster.Status.LoadBalancers` is a slice on main rather than a map, so the
  load balancer ID lookup keeps main's existing loop rather than a map index

All review feedback from #2883 is incorporated here.

## Testing

Full unit test coverage for the new behavior: busy-LB skip, parallel progress across two
LBs, one-write-per-LB-per-pass deferral, multi-pass completion, nil-status handling, the
busy-vs-broken distinction (including a `delete_pending` case that must still error), and
a `create_pending`-with-zero-pools case confirming the provisioning-status check must run
before the pool-count check.

The equivalent change was validated on release-0.13 against real IBM Cloud infrastructure —
3 control-plane machines, 2 LBs, 2 pools each, comparing the stock v0.12.2 controller
against the fix:

| | Before | After |
|---|---|---|
| Time to register all 3 machines | 15m 31s | 7m 56s |
| Mean gap between writes | 86s | 45s |
| Max gap | 120s | 84s |

~1.95× faster on identical infrastructure and manifest. Both runs had matching load
balancer configuration confirmed before timing started and were checked against live IBM
Cloud state before teardown. The logic here is equivalent, so the same improvement applies.



Related: #2839