### PR TITLE
⚠️ Remove --provider-id-fmt flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,7 +75,6 @@ var (
 	webhookPort            int
 	webhookCertDir         string
 	watchFilterValue       string
-	providerIDFormat       string
 	disableHTTP2           bool
 	skipCRDMigrationPhases []string
 )
@@ -124,12 +123,6 @@ func initFlags(fs *pflag.FlagSet) {
 		10*time.Minute,
 		"The minimum interval at which watched resources are reconciled.",
 	)
-	fs.StringVar(
-		&providerIDFormat,
-		"provider-id-fmt",
-		"v2",
-		"ProviderID format is used set the Provider ID format for Machine",
-	)
 
 	fs.StringVar(
 		&endpoints.ServiceEndpointFormat,
@@ -168,12 +161,6 @@ func initFlags(fs *pflag.FlagSet) {
 }
 
 func validateFlags() error {
-	if providerIDFormat == "v2" {
-		setupLog.Info("Using v2 version of ProviderID format")
-	} else {
-		return fmt.Errorf("invalid value for flag provider-id-fmt: %s, Only supported value is v2", providerIDFormat)
-	}
-
 	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to validate and apply log options")
 		return err
@@ -278,7 +265,7 @@ func main() {
 
 	setupWebhooks(mgr)
 	setupChecks(mgr)
-	setupReconcilers(ctx, mgr, serviceEndpoint, watchFilterValue, providerIDFormat, skipCRDMigrationPhases)
+	setupReconcilers(ctx, mgr, serviceEndpoint, watchFilterValue, skipCRDMigrationPhases)
 
 	// +kubebuilder:scaffold:builder
 	setupLog.Info("starting manager")
@@ -299,7 +286,7 @@ func setupChecks(mgr ctrl.Manager) {
 	}
 }
 
-func setupReconcilers(ctx context.Context, mgr ctrl.Manager, serviceEndpoint []endpoints.ServiceEndpoint, watchFilterValue string, providerIDFormat string, skipCRDMigrationPhases []string) {
+func setupReconcilers(ctx context.Context, mgr ctrl.Manager, serviceEndpoint []endpoints.ServiceEndpoint, watchFilterValue string, skipCRDMigrationPhases []string) {
 	// Note: The kubebuilder RBAC markers above have to be kept in sync
 	// with the CRDs that should be migrated by this provider.
 	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
@@ -338,12 +325,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, serviceEndpoint []e
 	}
 
 	if err := (&vpccontroller.IBMVPCMachineReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("IBMVPCMachine"),
-		Recorder:         mgr.GetEventRecorderFor("ibmvpcmachine-controller"),
-		ServiceEndpoint:  serviceEndpoint,
-		Scheme:           mgr.GetScheme(),
-		ProviderIDFormat: providerIDFormat,
+		Client:          mgr.GetClient(),
+		Log:             ctrl.Log.WithName("controllers").WithName("IBMVPCMachine"),
+		Recorder:        mgr.GetEventRecorderFor("ibmvpcmachine-controller"),
+		ServiceEndpoint: serviceEndpoint,
+		Scheme:          mgr.GetScheme(),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IBMVPCMachine")
 		os.Exit(1)
@@ -375,7 +361,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, serviceEndpoint []e
 		ServiceEndpoint:  serviceEndpoint,
 		Scheme:           mgr.GetScheme(),
 		WatchFilterValue: watchFilterValue,
-		ProviderIDFormat: providerIDFormat,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IBMPowerVSMachine")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,6 @@ spec:
         - /manager
         args:
         - "--leader-elect"
-        - "--provider-id-fmt=${PROVIDER_ID_FORMAT:=v2}"
         - "--diagnostics-address=${CAPIBM_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPIBM_INSECURE_DIAGNOSTICS:=false}"
         - "--service-endpoint=${SERVICE_ENDPOINT:=none}"

--- a/docs/proposal/20260824-code-organization.md
+++ b/docs/proposal/20260824-code-organization.md
@@ -241,10 +241,10 @@ for future contributors.
 
 ---
 
-## Dependency Injection for Event Recorders and Provider ID Format
+## Dependency Injection for Event Recorders
 
-Two packages used global variables as a substitute for proper dependency injection into scope
-params — a pattern CAPI has moved away from entirely. Both were addressed in this PR.
+One package used a global variable as a substitute for proper dependency injection into scope
+params — a pattern CAPI has moved away from entirely.
 
 ### Recorder injection
 
@@ -257,12 +257,15 @@ Each reconciler struct already held a `Recorder record.EventRecorder` field; `se
 in `cmd/main.go` now passes `mgr.GetEventRecorderFor(...)` into scope params at construction
 time. All scope methods call `s.Recorder.Eventf(...)` directly. `pkg/util/record/` is deleted.
 
-### ProviderIDFormat injection
+### `--provider-id-fmt` flag removal
 
-**Before:** `pkg/cloud/options/` stored `ProviderIDFormat` as a global var set from the
-`--provider-id-fmt` CLI flag and read directly by machine scopes.
+Since `v2` was the only accepted value (any other value caused an immediate startup error), the
+flag provided no real configurability. It has been removed entirely:
 
-**After:** `MachineScopeParams` and `MachineScope` for both PowerVS and VPC gain a
-`ProviderIDFormat string` field. The machine reconciler structs gain the same field, populated
-from `cmd/main.go` `setupReconcilers`. Machine scopes read `s.ProviderIDFormat` directly.
-`pkg/cloud/options/` is deleted; the `"v2"` constant is inlined where needed.
+- The `--provider-id-fmt` CLI flag and the `PROVIDER_ID_FORMAT` env var shim in
+  `config/manager/manager.yaml` are deleted.
+- `ProviderIDFormat` fields are removed from `MachineScopeParams`, `MachineScope`,
+  `IBMVPCMachineReconciler`, and `IBMPowerVSMachineReconciler`.
+- `SetProviderID` in both machine scope files now always produces the v2 format directly,
+  with no runtime branch.
+- The `providerIDFormatV2 = "v2"` constants are removed.

--- a/hack/scripts/ci/ci-e2e.sh
+++ b/hack/scripts/ci/ci-e2e.sh
@@ -176,7 +176,6 @@ main(){
 
     # Set common variables
     export DOCKER_BUILDKIT=1
-    export PROVIDER_ID_FORMAT=v2
     export IBMACCOUNT_ID=${IBMACCOUNT_ID:-"7cfbd5381a434af7a09289e795840d4e"}
     export BASE64_API_KEY=$(tr -d '\n' <<<"$IBMCLOUD_API_KEY" | base64)
     export CUSTOM_KIND_NODE_IMAGE=${CUSTOM_KIND_NODE_IMAGE:-}

--- a/internal/controllers/powervs/ibmpowervsmachine_controller.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller.go
@@ -63,10 +63,9 @@ const loadBalancerSettleRequeueInterval = 15 * time.Second
 // IBMPowerVSMachineReconciler reconciles a IBMPowerVSMachine object.
 type IBMPowerVSMachineReconciler struct {
 	client.Client
-	Recorder         record.EventRecorder
-	ServiceEndpoint  []endpoints.ServiceEndpoint
-	Scheme           *runtime.Scheme
-	ProviderIDFormat string
+	Recorder        record.EventRecorder
+	ServiceEndpoint []endpoints.ServiceEndpoint
+	Scheme          *runtime.Scheme
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -190,7 +189,6 @@ func (r *IBMPowerVSMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		DHCPIPCacheStore:  dhcpCacheStore,
 		ClientBuilder:     r.ClientBuilder,
 		Recorder:          r.Recorder,
-		ProviderIDFormat:  r.ProviderIDFormat,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create IBMPowerVS machine scope: %w", err)

--- a/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
+++ b/internal/controllers/powervs/ibmpowervsmachine_controller_test.go
@@ -594,7 +594,6 @@ func TestIBMPowerVSMachineReconciler_reconcileNormal(t *testing.T) {
 				IBMPowerVSImage:   tc.image,
 				Machine:           tc.ownerMachine,
 				DHCPIPCacheStore:  cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
-				ProviderIDFormat:  "v2",
 			}
 			if tc.pvsCluster == nil {
 				scope.IBMPowerVSCluster = &infrav1.IBMPowerVSCluster{}
@@ -931,7 +930,6 @@ func TestHandleLoadBalancerPoolMemberConfiguration_PendingFlag(t *testing.T) {
 			IBMVPCClient:     mockvpc,
 			IBMPowerVSClient: mockpowervs,
 			DHCPIPCacheStore: cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
-			ProviderIDFormat: "v2",
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"powervs.cluster.x-k8s.io/create-infra": "true"},
@@ -1247,9 +1245,11 @@ func TestIBMPowerVSMachineReconciler_reconcileNormal_additionalBranches(t *testi
 				m.EXPECT().ListInstances(gomock.Any()).Return(instanceRef, nil)
 				m.EXPECT().GetInstance(gomock.Any(), "inst-id").Return(activeInstance(), nil)
 			},
-			// Override ProviderIDFormat to something invalid so SetProviderID fails
+			// Clear workspace ID on both machine spec and cluster status so all
+			// three GetWorkspaceID precedences fail, causing SetProviderID to error.
 			checkScope: func(_ *WithT, s *powervsscope.MachineScope) {
-				s.ProviderIDFormat = "v1" // invalid → SetProviderID returns error
+				s.IBMPowerVSMachine.Spec.Workspace.ID = ""
+				s.IBMPowerVSMachine.Spec.Workspace.Name = ""
 			},
 			expectedError: "failed to set provider ID",
 		},
@@ -1545,14 +1545,12 @@ func TestIBMPowerVSMachineReconciler_reconcileNormal_additionalBranches(t *testi
 				IBMPowerVSImage:   tc.image,
 				Machine:           tc.ownerMachine,
 				DHCPIPCacheStore:  cache.NewTTLStore(powervs.CacheKeyFunc, powervs.CacheTTL),
-				ProviderIDFormat:  "v2",
 			}
 			if scope.IBMPowerVSCluster == nil {
 				scope.IBMPowerVSCluster = &infrav1.IBMPowerVSCluster{}
 			}
 			scope.SetZone("us-south")
 
-			// allow test to mutate scope before reconcile (e.g. ProviderIDFormat)
 			if tc.checkScope != nil {
 				tc.checkScope(g, scope)
 			}

--- a/internal/controllers/vpc/ibmvpcmachine_controller.go
+++ b/internal/controllers/vpc/ibmvpcmachine_controller.go
@@ -57,11 +57,10 @@ import (
 // IBMVPCMachineReconciler reconciles a IBMVPCMachine object.
 type IBMVPCMachineReconciler struct {
 	client.Client
-	Log              logr.Logger
-	Recorder         record.EventRecorder
-	ServiceEndpoint  []endpoints.ServiceEndpoint
-	Scheme           *runtime.Scheme
-	ProviderIDFormat string
+	Log             logr.Logger
+	Recorder        record.EventRecorder
+	ServiceEndpoint []endpoints.ServiceEndpoint
+	Scheme          *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=ibmvpcmachines,verbs=get;list;watch;create;update;patch;delete
@@ -140,14 +139,13 @@ func (r *IBMVPCMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Create the machine scope.
 	machineScope, err := vpc.NewMachineScope(vpc.MachineScopeParams{
-		Client:           r.Client,
-		Cluster:          cluster,
-		IBMVPCCluster:    ibmVPCCluster,
-		Machine:          machine,
-		IBMVPCMachine:    ibmVPCMachine,
-		ServiceEndpoint:  r.ServiceEndpoint,
-		Recorder:         r.Recorder,
-		ProviderIDFormat: r.ProviderIDFormat,
+		Client:          r.Client,
+		Cluster:         cluster,
+		IBMVPCCluster:   ibmVPCCluster,
+		Machine:         machine,
+		IBMVPCMachine:   ibmVPCMachine,
+		ServiceEndpoint: r.ServiceEndpoint,
+		Recorder:        r.Recorder,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create scope: %w", err)

--- a/internal/controllers/vpc/ibmvpcmachine_controller_test.go
+++ b/internal/controllers/vpc/ibmvpcmachine_controller_test.go
@@ -334,7 +334,6 @@ func TestIBMVPCMachineLBReconciler_reconcile(t *testing.T) {
 			Cluster:             &clusterv1.Cluster{},
 			IBMVPCClient:        mockvpc,
 			GlobalTaggingClient: mockgt,
-			ProviderIDFormat:    "v2",
 			Recorder:            record.NewFakeRecorder(1000),
 		}
 		return gomock.NewController(t), mockvpc, mockgt, machineScope, reconciler

--- a/pkg/cloud/scope/powervs/powervs_machine.go
+++ b/pkg/cloud/scope/powervs/powervs_machine.go
@@ -65,9 +65,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/services/vpc"
 )
 
-// providerIDFormatV2 is the only supported provider ID format value.
-const providerIDFormatV2 = "v2"
-
 const cosURLDomain = "cloud-object-storage.appdomain.cloud"
 
 // presignExpiry is the lifetime of the pre-signed ignition URL embedded in user-data.
@@ -118,9 +115,8 @@ type MachineScopeParams struct {
 	ServiceEndpoint   []endpoints.ServiceEndpoint
 	DHCPIPCacheStore  cache.Store
 
-	ClientBuilder    ClientBuilder
-	Recorder         cgrecord.EventRecorder
-	ProviderIDFormat string
+	ClientBuilder ClientBuilder
+	Recorder      cgrecord.EventRecorder
 }
 
 // MachineScope defines a scope defined around a Power VS Machine.
@@ -134,8 +130,6 @@ type MachineScope struct {
 
 	// Recorder is the event recorder for emitting Kubernetes events.
 	Recorder cgrecord.EventRecorder
-	// ProviderIDFormat is the format used to set the provider ID on the machine.
-	ProviderIDFormat string
 
 	Cluster           *clusterv1.Cluster
 	Machine           *clusterv1.Machine
@@ -162,7 +156,6 @@ func NewMachineScope(ctx context.Context, params MachineScopeParams) (*MachineSc
 		ServiceEndpoint:   params.ServiceEndpoint,
 		DHCPIPCacheStore:  params.DHCPIPCacheStore,
 		Recorder:          params.Recorder,
-		ProviderIDFormat:  params.ProviderIDFormat,
 	}
 
 	if err := scope.initClients(ctx, &params); err != nil {
@@ -857,10 +850,6 @@ func (s *MachineScope) GetWorkspaceID() (string, error) {
 
 // SetProviderID will set the provider id for the machine.
 func (s *MachineScope) SetProviderID(instanceID string) error {
-	if s.ProviderIDFormat != providerIDFormatV2 {
-		return fmt.Errorf("invalid value for ProviderIDFormat")
-	}
-
 	workspaceID, err := s.GetWorkspaceID()
 	if err != nil {
 		return err

--- a/pkg/cloud/scope/powervs/powervs_machine_test.go
+++ b/pkg/cloud/scope/powervs/powervs_machine_test.go
@@ -1081,18 +1081,9 @@ func TestGetMachineInternalIP(t *testing.T) {
 func TestSetProviderID(t *testing.T) {
 	providerID := "foo-provider-id"
 
-	t.Run("error when ProviderIDFormat is invalid", func(t *testing.T) {
-		g := NewWithT(t)
-		scope := setupPowerVSMachineScope(clusterName, machineName, ptr.To(pvsImage), ptr.To(pvsNetwork), true, nil)
-		scope.ProviderIDFormat = "v1"
-		err := scope.SetProviderID(providerID)
-		g.Expect(err).To(HaveOccurred())
-	})
-
 	t.Run("error when workspace ID cannot be resolved", func(t *testing.T) {
 		g := NewWithT(t)
 		scope := MachineScope{
-			ProviderIDFormat: "v2",
 			IBMPowerVSMachine: &infrav1.IBMPowerVSMachine{
 				Spec: infrav1.IBMPowerVSMachineSpec{},
 			},
@@ -1112,10 +1103,9 @@ func TestSetProviderID(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 	})
 
-	t.Run("sets provider ID in v2 format", func(t *testing.T) {
+	t.Run("sets provider ID", func(t *testing.T) {
 		g := NewWithT(t)
 		scope := MachineScope{
-			ProviderIDFormat: "v2",
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
 				Status: infrav1.IBMPowerVSClusterStatus{
 					Workspace: infrav1.ResourceReference{ID: "foo-service-instance-id"},

--- a/pkg/cloud/scope/vpc/machine.go
+++ b/pkg/cloud/scope/vpc/machine.go
@@ -49,21 +49,17 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/util/paging"
 )
 
-// providerIDFormatV2 is the only supported provider ID format value.
-const providerIDFormatV2 = "v2"
-
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
 type MachineScopeParams struct {
-	IBMVPCClient     vpc.Vpc
-	Client           client.Client
-	Logger           logr.Logger
-	Cluster          *clusterv1.Cluster
-	Machine          *clusterv1.Machine
-	IBMVPCCluster    *infrav1.IBMVPCCluster
-	IBMVPCMachine    *infrav1.IBMVPCMachine
-	ServiceEndpoint  []endpoints.ServiceEndpoint
-	Recorder         cgrecord.EventRecorder
-	ProviderIDFormat string
+	IBMVPCClient    vpc.Vpc
+	Client          client.Client
+	Logger          logr.Logger
+	Cluster         *clusterv1.Cluster
+	Machine         *clusterv1.Machine
+	IBMVPCCluster   *infrav1.IBMVPCCluster
+	IBMVPCMachine   *infrav1.IBMVPCMachine
+	ServiceEndpoint []endpoints.ServiceEndpoint
+	Recorder        cgrecord.EventRecorder
 }
 
 // MachineScope defines a scope defined around a machine and its cluster.
@@ -80,8 +76,6 @@ type MachineScope struct {
 	ServiceEndpoint     []endpoints.ServiceEndpoint
 	// Recorder is the event recorder for emitting Kubernetes events.
 	Recorder cgrecord.EventRecorder
-	// ProviderIDFormat is the format used to set the provider ID on the machine.
-	ProviderIDFormat string
 }
 
 // NewMachineScope creates a new MachineScope from the supplied parameters.
@@ -145,7 +139,6 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		Machine:             params.Machine,
 		IBMVPCMachine:       params.IBMVPCMachine,
 		Recorder:            params.Recorder,
-		ProviderIDFormat:    params.ProviderIDFormat,
 	}, nil
 }
 
@@ -1107,16 +1100,11 @@ func (m *MachineScope) SetNotReady() {
 
 // SetProviderID will set the provider id for the machine.
 func (m *MachineScope) SetProviderID(id *string) error {
-	// Based on the ProviderIDFormat version the providerID format will be decided.
-	if m.ProviderIDFormat == providerIDFormatV2 {
-		accountID, err := accounts.GetAccountIDWrapper()
-		if err != nil {
-			return fmt.Errorf("failed to get cloud account id: %w", err)
-		}
-		m.IBMVPCMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("ibm://%s///%s/%s", accountID, m.Machine.Spec.ClusterName, *id))
-	} else {
-		return fmt.Errorf("invalid value for ProviderIDFormat")
+	accountID, err := accounts.GetAccountIDWrapper()
+	if err != nil {
+		return fmt.Errorf("failed to get cloud account id: %w", err)
 	}
+	m.IBMVPCMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("ibm://%s///%s/%s", accountID, m.Machine.Spec.ClusterName, *id))
 	return nil
 }
 

--- a/pkg/cloud/scope/vpc/machine_test.go
+++ b/pkg/cloud/scope/vpc/machine_test.go
@@ -140,18 +140,9 @@ func TestNewMachineScope(t *testing.T) {
 func TestSetVPCProviderID(t *testing.T) {
 	providerID := "foo-provider-id"
 
-	t.Run("Set Provider ID in invalid format", func(t *testing.T) {
+	t.Run("Set Provider ID succeeds", func(t *testing.T) {
 		g := NewWithT(t)
 		scope := setupMachineScope(clusterName, machineName, mock.NewMockVpc(gomock.NewController(t)))
-		scope.ProviderIDFormat = "v1"
-		err := scope.SetProviderID(ptr.To(providerID))
-		g.Expect(err).ToNot(BeNil())
-	})
-
-	t.Run("Set Provider ID in valid format", func(t *testing.T) {
-		g := NewWithT(t)
-		scope := setupMachineScope(clusterName, machineName, mock.NewMockVpc(gomock.NewController(t)))
-		scope.ProviderIDFormat = "v2"
 		accounts.GetAccountIDFunc = func() (string, error) {
 			return "dummy-account-id", nil // Return dummy value
 		}
@@ -162,7 +153,6 @@ func TestSetVPCProviderID(t *testing.T) {
 	t.Run("Set Provider ID returns error", func(t *testing.T) {
 		g := NewWithT(t)
 		scope := setupMachineScope(clusterName, machineName, mock.NewMockVpc(gomock.NewController(t)))
-		scope.ProviderIDFormat = "v2"
 		accounts.GetAccountIDFunc = func() (string, error) {
 			return "", errors.New("error getting accountID") // Return dummy error
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

v2 is the only accepted value for  --provider-id-fmt flag, it has no configuration value accepted other than that so its being removed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove --provider-id-fmt flag
```
