### PR TITLE
adding support for DHCP flag

### DIFF
--- a/api/powervs/v1beta2/zz_generated.conversion.go
+++ b/api/powervs/v1beta2/zz_generated.conversion.go
@@ -485,6 +485,7 @@ func autoConvert_v1beta3_DHCPServer_To_v1beta2_DHCPServer(in *v1beta3.DHCPServer
 		return err
 	}
 	// WARNING: in.Snat requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-ibmcloud/api/powervs/v1beta3.DHCPSnatPolicy vs *bool)
+	// WARNING: in.CloudConnectionID requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/powervs/v1beta3/ibmpowervscluster_types.go
+++ b/api/powervs/v1beta3/ibmpowervscluster_types.go
@@ -577,6 +577,14 @@ type DHCPServer struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	Snat DHCPSnatPolicy `json:"snat,omitempty"`
+
+	// cloudConnectionID is the IBM Cloud Connection UUID to connect with the DHCP private network.
+	// When set, the created DHCP server's private network will be attached to the specified Cloud Connection.
+	// More information: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-cloud-connections
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=64
+	CloudConnectionID string `json:"cloudConnectionID,omitempty"`
 }
 
 // NetworkStatus defines the observed state of the PowerVS network and its associated components.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclusters.yaml
@@ -1669,6 +1669,14 @@ spec:
                             minLength: 1
                             pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}($|/[0-9]{1,2})$
                             type: string
+                          cloudConnectionID:
+                            description: |-
+                              cloudConnectionID is the IBM Cloud Connection UUID to connect with the DHCP private network.
+                              When set, the created DHCP server's private network will be attached to the specified Cloud Connection.
+                              More information: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-cloud-connections
+                            maxLength: 64
+                            minLength: 1
+                            type: string
                           dnsServer:
                             description: dnsServer is the DNS Server for the DHCP
                               service.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ibmpowervsclustertemplates.yaml
@@ -1431,6 +1431,14 @@ spec:
                                     minLength: 1
                                     pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}($|/[0-9]{1,2})$
                                     type: string
+                                  cloudConnectionID:
+                                    description: |-
+                                      cloudConnectionID is the IBM Cloud Connection UUID to connect with the DHCP private network.
+                                      When set, the created DHCP server's private network will be attached to the specified Cloud Connection.
+                                      More information: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-cloud-connections
+                                    maxLength: 64
+                                    minLength: 1
+                                    type: string
                                   dnsServer:
                                     description: dnsServer is the DNS Server for the
                                       DHCP service.

--- a/pkg/cloud/scope/powervs/powervs_cluster.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster.go
@@ -1034,6 +1034,12 @@ func (s *ClusterScope) createDHCPServer(ctx context.Context, dhcpName string) (s
 	}
 	params.SnatEnabled = &snatEnabled
 
+	if dhcpSpec.CloudConnectionID != "" {
+		// If the provided CloudConnectionID does not exist in IBM Cloud, the CreateDHCPServer
+		// API call below will fail and the error will be propagated to the caller.
+		params.CloudConnectionID = &dhcpSpec.CloudConnectionID
+	}
+
 	dhcpServer, err := s.IBMPowerVSClient.CreateDHCPServer(ctx, &params)
 	if err != nil {
 		return "", "", err

--- a/pkg/cloud/scope/powervs/powervs_cluster_test.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster_test.go
@@ -4977,6 +4977,38 @@ func TestCreateDHCPServer(t *testing.T) {
 		g.Expect(dhcpID).To(Equal("dhcp-id"))
 		g.Expect(netID).To(Equal("net-id"))
 	})
+
+	t.Run("When CreateDHCPServer succeeds with CloudConnectionID set", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+		cloudConnID := "cloud-conn-uuid-1234"
+		clusterScope := ClusterScope{
+			IBMPowerVSClient: mockPowerVS,
+			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{
+				Spec: infrav1.IBMPowerVSClusterSpec{
+					Network: infrav1.NetworkSource{
+						Provision: infrav1.NetworkProvisionConfig{
+							DHCPServer: infrav1.DHCPServer{
+								CloudConnectionID: cloudConnID,
+							},
+						},
+					},
+				},
+			},
+		}
+		dhcpServer := &models.DHCPServer{
+			ID:      ptr.To("dhcp-id-2"),
+			Network: &models.DHCPServerNetwork{ID: ptr.To("net-id-2"), Name: ptr.To("net-name-2")},
+		}
+		mockPowerVS.EXPECT().CreateDHCPServer(gomock.Any(), gomock.Cond(func(x *models.DHCPServerCreate) bool {
+			return x != nil && x.CloudConnectionID != nil && *x.CloudConnectionID == cloudConnID
+		})).Return(dhcpServer, nil)
+		dhcpID, netID, err := clusterScope.createDHCPServer(ctx, "my-dhcp-2")
+		g.Expect(err).To(BeNil())
+		g.Expect(dhcpID).To(Equal("dhcp-id-2"))
+		g.Expect(netID).To(Equal("net-id-2"))
+	})
 }
 
 func TestReconcileVPC(t *testing.T) {


### PR DESCRIPTION
WIP: Updating logic to target the enableDHCP flag
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Feature: Add DHCP flag (CloudConnectionID) to PowerVS subnets
The IBM Cloud PowerVS DHCP Server creation API (DHCPServerCreate) supports a CloudConnectionID field that associates the DHCP server's private network with a specific IBM Cloud Connection. This field was absent from the CAPI provider, which is need to allow users to attach their DHCP-managed network to a Cloud Connection at provision time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```