### PR TITLE
🐛 Skip VPC security group rule creation if rule already exists

### DIFF
--- a/pkg/cloud/scope/powervs/powervs_cluster.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster.go
@@ -74,6 +74,17 @@ var (
 	vpcNetworkConnectionType     = networkConnectionType("vpc")
 )
 
+// sgRuleKey is a comparable identity for a security group rule.
+type sgRuleKey struct {
+	direction string
+	protocol  string
+	portMin   int64
+	portMax   int64
+	cidrBlock string
+	address   string
+	crn       string
+}
+
 // powerEdgeRouter is identifier for PER.
 const (
 	// DEBUGLEVEL indicates the debug level of the logs.
@@ -2164,7 +2175,7 @@ func (s *ClusterScope) reconcileVPCSecurityGroupProvision(ctx context.Context, p
 	}
 
 	// 2. Reconcile Rules
-	ruleIDs, err := s.createVPCSecurityGroupRules(ctx, prov.Rules, *sg.ID)
+	ruleIDs, err := s.createVPCSecurityGroupRules(ctx, prov.Rules, *sg.ID, sg.Rules)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VPC security group rules for '%s': %w", targetName, err)
 	}
@@ -2204,12 +2215,111 @@ func (s *ClusterScope) createVPCSecurityGroup(ctx context.Context, name string) 
 	return securityGroup.ID, nil
 }
 
-// createVPCSecurityGroupRules iterates through the provided rules and creates them in IBM Cloud.
-func (s *ClusterScope) createVPCSecurityGroupRules(ctx context.Context, rules []infrav1.VPCSecurityGroupRule, securityGroupID string) ([]string, error) {
+// getVPCSecurityGroupRuleID returns the rule ID from any concrete SG rule type, or "" if unrecognized.
+func getVPCSecurityGroupRuleID(ruleIntf vpcv1.SecurityGroupRuleIntf) string {
+	switch r := ruleIntf.(type) {
+	case *vpcv1.SecurityGroupRule:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	case *vpcv1.SecurityGroupRuleProtocolAny:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	case *vpcv1.SecurityGroupRuleProtocolIcmptcpudp:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	case *vpcv1.SecurityGroupRuleProtocolIndividual:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp:
+		if r != nil && r.ID != nil {
+			return *r.ID
+		}
+	}
+	return ""
+}
+
+// validateVPCSecurityGroupRuleKey builds an sgRuleKey from an existing SG rule.
+func validateVPCSecurityGroupRuleKey(ctx context.Context, ruleIntf vpcv1.SecurityGroupRuleIntf) (sgRuleKey, bool) {
+	if ruleIntf == nil {
+		return sgRuleKey{}, false
+	}
+	var key sgRuleKey
+	switch r := ruleIntf.(type) {
+	case *vpcv1.SecurityGroupRule:
+		key = buildSGRuleKey(r.Direction, r.Protocol, r.PortMin, r.PortMax, r.Remote)
+	case *vpcv1.SecurityGroupRuleProtocolAny:
+		key = buildSGRuleKey(r.Direction, r.Protocol, nil, nil, r.Remote)
+	case *vpcv1.SecurityGroupRuleProtocolIcmptcpudp:
+		key = buildSGRuleKey(r.Direction, r.Protocol, nil, nil, r.Remote)
+	case *vpcv1.SecurityGroupRuleProtocolIndividual:
+		key = buildSGRuleKey(r.Direction, r.Protocol, nil, nil, r.Remote)
+	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp:
+		key = buildSGRuleKey(r.Direction, r.Protocol, nil, nil, r.Remote)
+	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp:
+		key = buildSGRuleKey(r.Direction, r.Protocol, r.PortMin, r.PortMax, r.Remote)
+	default:
+		ctrl.LoggerFrom(ctx).V(4).Info("Skipping unrecognized security group rule type during deduplication", "type", fmt.Sprintf("%T", ruleIntf))
+		return sgRuleKey{}, false
+	}
+	return key, true
+}
+
+// buildSGRuleKey assembles an sgRuleKey from the fields common to all rule types.
+func buildSGRuleKey(direction, protocol *string, portMin, portMax *int64, remoteIntf vpcv1.SecurityGroupRuleRemoteIntf) sgRuleKey {
+	var key sgRuleKey
+	if direction != nil {
+		key.direction = *direction
+	}
+	if protocol != nil {
+		key.protocol = *protocol
+	}
+	if portMin != nil {
+		key.portMin = *portMin
+	}
+	if portMax != nil {
+		key.portMax = *portMax
+	}
+	if remote, ok := remoteIntf.(*vpcv1.SecurityGroupRuleRemote); ok && remote != nil {
+		if remote.CIDRBlock != nil {
+			key.cidrBlock = *remote.CIDRBlock
+		}
+		if remote.Address != nil {
+			key.address = *remote.Address
+		}
+		if remote.CRN != nil {
+			key.crn = *remote.CRN
+		}
+	}
+	return key
+}
+
+// createVPCSecurityGroupRules creates the given rules on the security group.
+// Rules already present on the SG are skipped.
+func (s *ClusterScope) createVPCSecurityGroupRules(ctx context.Context, rules []infrav1.VPCSecurityGroupRule, securityGroupID string, existingRules []vpcv1.SecurityGroupRuleIntf) ([]string, error) {
 	log := ctrl.LoggerFrom(ctx)
 	var ruleIDs []string
 
-	log.V(3).Info("Creating VPC security group rules", "securityGroupID", securityGroupID, "ruleCount", len(rules))
+	log.V(3).Info("Reconciling VPC security group rules", "securityGroupID", securityGroupID, "specRuleCount", len(rules), "existingRuleCount", len(existingRules))
+
+	// Index existing rules by key so we can skip ones already present.
+	existingByKey := make(map[sgRuleKey]string, len(existingRules))
+	for _, rule := range existingRules {
+		key, ok := validateVPCSecurityGroupRuleKey(ctx, rule)
+		if !ok {
+			continue
+		}
+		if id := getVPCSecurityGroupRuleID(rule); id != "" {
+			existingByKey[key] = id
+		}
+	}
 
 	for _, rule := range rules {
 		// Work on a copy with normalized prototypes so the deprecated 'all' protocol is
@@ -2255,7 +2365,7 @@ func (s *ClusterScope) createVPCSecurityGroupRules(ctx context.Context, rules []
 
 		// Create a distinct rule in IBM Cloud for every remote target specified
 		for _, remote := range remotes {
-			id, err := s.createVPCSecurityGroupRule(ctx, securityGroupID, direction, protocol, portMin, portMax, remote)
+			id, err := s.createVPCSecurityGroupRule(ctx, securityGroupID, direction, protocol, portMin, portMax, remote, existingByKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create %s VPC security group rule: %w", direction, err)
 			}
@@ -2266,33 +2376,42 @@ func (s *ClusterScope) createVPCSecurityGroupRules(ctx context.Context, rules []
 	return ruleIDs, nil
 }
 
-// createVPCSecurityGroupRule safely maps pointer-free CRD values to the pointer-heavy IBM SDK.
-func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityGroupID string, direction string, protocol string, portMin, portMax int64, remote infrav1.VPCSecurityGroupRuleRemote) (string, error) {
+// createVPCSecurityGroupRule creates a single rule. If a matching rule already exists in
+// existingByKey, it returns that ID without calling the API.
+func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityGroupID string, direction string, protocol string, portMin, portMax int64, remote infrav1.VPCSecurityGroupRuleRemote, existingByKey map[sgRuleKey]string) (string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	remoteOption := &vpcv1.SecurityGroupRuleRemotePrototype{}
 
 	// 1. Resolve Remote Target
-	switch remote.RemoteType {
-	case infrav1.VPCSecurityGroupRuleRemoteTypeCIDR:
-		cidrSubnet, err := s.IBMVPCClient.GetVPCSubnetByName(remote.CIDRSubnetName)
-		if err != nil || cidrSubnet == nil {
-			return "", fmt.Errorf("failed to find VPC subnet by name '%s': %w", remote.CIDRSubnetName, err)
-		}
-		remoteOption.CIDRBlock = cidrSubnet.Ipv4CIDRBlock
-	case infrav1.VPCSecurityGroupRuleRemoteTypeAddress:
-		remoteOption.Address = ptr.To(remote.Address)
-	case infrav1.VPCSecurityGroupRuleRemoteTypeSG:
-		sg, err := s.IBMVPCClient.GetSecurityGroupByName(remote.SecurityGroupName)
-		if err != nil || sg == nil {
-			return "", fmt.Errorf("failed to find VPC security group by name '%s': %w", remote.SecurityGroupName, err)
-		}
-		remoteOption.CRN = sg.CRN
-	default:
-		// Any/0.0.0.0 mapping
-		remoteOption.CIDRBlock = ptr.To("0.0.0.0/0")
+	remoteOption, err := s.resolveRuleRemote(remote)
+	if err != nil {
+		return "", err
 	}
 
-	// 2. Build Protocol Prototype (Injecting Pointers here for SDK)
+	// 2. Check whether this rule already exists.
+	key := sgRuleKey{
+		direction: direction,
+		protocol:  protocol,
+	}
+	if (protocol == string(infrav1.VPCSecurityGroupRuleProtocolTCP) || protocol == string(infrav1.VPCSecurityGroupRuleProtocolUDP)) && portMin > 0 {
+		key.portMin = portMin
+		key.portMax = portMax
+	}
+	if remoteOption.CIDRBlock != nil {
+		key.cidrBlock = *remoteOption.CIDRBlock
+	}
+	if remoteOption.Address != nil {
+		key.address = *remoteOption.Address
+	}
+	if remoteOption.CRN != nil {
+		key.crn = *remoteOption.CRN
+	}
+
+	if existingID, found := existingByKey[key]; found {
+		log.V(3).Info("Skipping duplicate VPC security group rule", "securityGroupID", securityGroupID, "existingRuleID", existingID)
+		return existingID, nil
+	}
+
+	// 3. Build Protocol Prototype (Injecting Pointers here for SDK)
 	prototype := &vpcv1.SecurityGroupRulePrototype{
 		Direction: ptr.To(direction),
 		Protocol:  ptr.To(protocol),
@@ -2312,31 +2431,50 @@ func (s *ClusterScope) createVPCSecurityGroupRule(ctx context.Context, securityG
 
 	log.V(3).Info("Creating VPC security group rule", "securityGroupID", securityGroupID, "direction", direction, "protocol", protocol)
 
-	// 3. Execute API Call
+	// 4. Execute API Call
 	ruleIntf, _, err := s.IBMVPCClient.CreateSecurityGroupRule(options)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute CreateSecurityGroupRule API: %w", err)
 	}
 
-	// 4. Extract Rule ID based on returned interface type
-	var ruleID string
-	switch rule := ruleIntf.(type) {
-	case *vpcv1.SecurityGroupRuleProtocolAny:
-		ruleID = *rule.ID
-	case *vpcv1.SecurityGroupRuleProtocolIcmptcpudp:
-		ruleID = *rule.ID
-	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp:
-		ruleID = *rule.ID
-	case *vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp:
-		ruleID = *rule.ID
-	case *vpcv1.SecurityGroupRuleProtocolIndividual:
-		ruleID = *rule.ID
-	default:
-		return "", fmt.Errorf("unrecognized rule type returned from API")
+	// 5. Extract Rule ID based on returned interface type
+	ruleID := getVPCSecurityGroupRuleID(ruleIntf)
+	if ruleID == "" {
+		return "", fmt.Errorf("unrecognized rule type returned from API: %T", ruleIntf)
+	}
+
+	// Record so identical remotes later in the same spec are also skipped.
+	if existingByKey != nil {
+		existingByKey[key] = ruleID
 	}
 
 	log.Info("Successfully created VPC security group rule", "ruleID", ruleID)
 	return ruleID, nil
+}
+
+// resolveRuleRemote resolves a CRD remote to the SDK prototype, looking up subnet CIDRs and SG CRNs as needed.
+func (s *ClusterScope) resolveRuleRemote(remote infrav1.VPCSecurityGroupRuleRemote) (*vpcv1.SecurityGroupRuleRemotePrototype, error) {
+	remoteOption := &vpcv1.SecurityGroupRuleRemotePrototype{}
+	switch remote.RemoteType {
+	case infrav1.VPCSecurityGroupRuleRemoteTypeCIDR:
+		cidrSubnet, err := s.IBMVPCClient.GetVPCSubnetByName(remote.CIDRSubnetName)
+		if err != nil || cidrSubnet == nil {
+			return nil, fmt.Errorf("failed to find VPC subnet by name '%s': %w", remote.CIDRSubnetName, err)
+		}
+		remoteOption.CIDRBlock = cidrSubnet.Ipv4CIDRBlock
+	case infrav1.VPCSecurityGroupRuleRemoteTypeAddress:
+		remoteOption.Address = ptr.To(remote.Address)
+	case infrav1.VPCSecurityGroupRuleRemoteTypeSG:
+		sg, err := s.IBMVPCClient.GetSecurityGroupByName(remote.SecurityGroupName)
+		if err != nil || sg == nil {
+			return nil, fmt.Errorf("failed to find VPC security group by name '%s': %w", remote.SecurityGroupName, err)
+		}
+		remoteOption.CRN = sg.CRN
+	default:
+		// Any/0.0.0.0 mapping
+		remoteOption.CIDRBlock = ptr.To("0.0.0.0/0")
+	}
+	return remoteOption, nil
 }
 
 // ReconcileCOSInstance evaluates the user's intent and reconciles the COS instance and bucket.

--- a/pkg/cloud/scope/powervs/powervs_cluster_test.go
+++ b/pkg/cloud/scope/powervs/powervs_cluster_test.go
@@ -3568,7 +3568,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
 		}
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(Equal("ruleID"))
 		g.Expect(err).To(BeNil())
 	})
@@ -3587,7 +3587,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 		}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(&vpcv1.Subnet{Ipv4CIDRBlock: ptr.To("192.168.1.1/24")}, nil)
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(Equal("ruleID"))
 		g.Expect(err).To(BeNil())
 	})
@@ -3605,7 +3605,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
 		}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, errors.New("failed to get VPC subnet"))
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(BeEmpty())
 		g.Expect(err).ToNot(BeNil())
 	})
@@ -3620,7 +3620,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
 		}
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleProtocolIcmptcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "outbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(Equal("ruleID"))
 		g.Expect(err).To(BeNil())
 	})
@@ -3639,7 +3639,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 		}
 		mockVPC.EXPECT().GetSecurityGroupByName(gomock.Any()).Return(&vpcv1.SecurityGroup{CRN: ptr.To("crn"), Name: ptr.To("securityGroupName")}, nil)
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp{Direction: ptr.To("inbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(Equal("ruleID"))
 		g.Expect(err).To(BeNil())
 	})
@@ -3657,7 +3657,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
 		}
 		mockVPC.EXPECT().GetSecurityGroupByName(gomock.Any()).Return(nil, errors.New("failed to get security group"))
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(BeEmpty())
 		g.Expect(err).ToNot(BeNil())
 	})
@@ -3675,7 +3675,7 @@ func TestCreateVPCSecurityGroupRule(t *testing.T) {
 			IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{},
 		}
 		mockVPC.EXPECT().GetSecurityGroupByName(gomock.Any()).Return(nil, nil)
-		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote)
+		ruleID, err := clusterScope.createVPCSecurityGroupRule(ctx, securityGroupID, "inbound", protocol, portMin, portMax, remote, nil)
 		g.Expect(ruleID).To(BeEmpty())
 		g.Expect(err).ToNot(BeNil())
 	})
@@ -3711,7 +3711,7 @@ func TestCreateVPCSecurityGroupRules(t *testing.T) {
 		}
 		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{Direction: ptr.To("outbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID")
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID", nil)
 		g.Expect(ruleIDs).To(Equal([]string{"ruleID"}))
 		g.Expect(err).To(BeNil())
 	})
@@ -3731,7 +3731,7 @@ func TestCreateVPCSecurityGroupRules(t *testing.T) {
 		}
 		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
-		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID")
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID", nil)
 		g.Expect(ruleIDs).To(BeNil())
 		g.Expect(err).ToNot(BeNil())
 	})
@@ -3752,7 +3752,7 @@ func TestCreateVPCSecurityGroupRules(t *testing.T) {
 		}
 		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
 		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{Direction: ptr.To("inbound"), ID: ptr.To("ruleID")}, nil, nil)
-		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID")
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID", nil)
 		g.Expect(ruleIDs).To(Equal([]string{"ruleID"}))
 		g.Expect(err).To(BeNil())
 	})
@@ -3772,7 +3772,7 @@ func TestCreateVPCSecurityGroupRules(t *testing.T) {
 		}
 		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
 		mockVPC.EXPECT().GetVPCSubnetByName(gomock.Any()).Return(nil, nil)
-		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID")
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "securityGroupID", nil)
 		g.Expect(ruleIDs).To(BeNil())
 		g.Expect(err).ToNot(BeNil())
 	})
@@ -10135,7 +10135,7 @@ func TestCreateVPCSecurityGroupRulesErrors(t *testing.T) {
 				},
 			},
 		}
-		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id")
+		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id", nil)
 		g.Expect(err).To(MatchError(ContainSubstring("empty protocol")))
 	})
 
@@ -10157,7 +10157,7 @@ func TestCreateVPCSecurityGroupRulesErrors(t *testing.T) {
 				},
 			},
 		}
-		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id")
+		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id", nil)
 		g.Expect(err).To(MatchError(ContainSubstring("no remotes")))
 	})
 
@@ -10175,7 +10175,7 @@ func TestCreateVPCSecurityGroupRulesErrors(t *testing.T) {
 				Direction: "invalid-direction",
 			},
 		}
-		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id")
+		_, err := clusterScope.createVPCSecurityGroupRules(ctx, rules, "sg-id", nil)
 		g.Expect(err).To(MatchError(ContainSubstring("invalid rule direction")))
 	})
 }
@@ -11267,5 +11267,97 @@ func TestReconcileWorkspaceProvisionSuccessPath(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		g.Expect(requeue).To(BeTrue())
 		g.Expect(clusterScope.IBMPowerVSCluster.Status.Workspace.ID).To(Equal("new-ws-guid"))
+	})
+}
+
+func TestCreateVPCSecurityGroupRulesIdempotency(t *testing.T) {
+	var (
+		mockVPC  *mock.MockVpc
+		mockCtrl *gomock.Controller
+	)
+	setup := func(t *testing.T) {
+		t.Helper()
+		mockCtrl = gomock.NewController(t)
+		mockVPC = mock.NewMockVpc(mockCtrl)
+	}
+	teardown := func() { mockCtrl.Finish() }
+
+	specRules := []infrav1.VPCSecurityGroupRule{
+		{
+			Direction: infrav1.VPCSecurityGroupRuleDirectionInbound,
+			Source: infrav1.VPCSecurityGroupRulePrototype{
+				Protocol:  infrav1.VPCSecurityGroupRuleProtocolTCP,
+				PortRange: infrav1.VPCSecurityGroupPortRange{MinimumPort: 22, MaximumPort: 22},
+				Remotes:   []infrav1.VPCSecurityGroupRuleRemote{{RemoteType: infrav1.VPCSecurityGroupRuleRemoteTypeAny}},
+			},
+		},
+	}
+
+	t.Run("When rule already exists, no new rule is created", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		existingRules := []vpcv1.SecurityGroupRuleIntf{
+			&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{
+				ID:        ptr.To("rule-id"),
+				Direction: ptr.To("inbound"),
+				Protocol:  ptr.To("tcp"),
+				PortMin:   ptr.To(int64(22)),
+				PortMax:   ptr.To(int64(22)),
+				Remote:    &vpcv1.SecurityGroupRuleRemote{CIDRBlock: ptr.To("0.0.0.0/0")},
+			},
+		}
+		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, specRules, "sg-id", existingRules)
+		g.Expect(err).To(BeNil())
+		g.Expect(ruleIDs).To(Equal([]string{"rule-id"}))
+	})
+
+	t.Run("When existing rule is *SecurityGroupRule (SDK generic type), it is matched and skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		// The SDK emits *SecurityGroupRule via UnmarshalSecurityGroupRuleGeneric for unknown
+		// protocol values.
+		existingRules := []vpcv1.SecurityGroupRuleIntf{
+			&vpcv1.SecurityGroupRule{
+				ID:        ptr.To("rule-id"),
+				Direction: ptr.To("inbound"),
+				Protocol:  ptr.To("tcp"),
+				PortMin:   ptr.To(int64(22)),
+				PortMax:   ptr.To(int64(22)),
+				Remote:    &vpcv1.SecurityGroupRuleRemote{CIDRBlock: ptr.To("0.0.0.0/0")},
+			},
+		}
+		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, specRules, "sg-id", existingRules)
+		g.Expect(err).To(BeNil())
+		g.Expect(ruleIDs).To(Equal([]string{"rule-id"}))
+	})
+
+	t.Run("When existing rule has different port range, new rule is created", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t)
+		t.Cleanup(teardown)
+
+		existingRules := []vpcv1.SecurityGroupRuleIntf{
+			&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{
+				ID:        ptr.To("old-rule-id"),
+				Direction: ptr.To("inbound"),
+				Protocol:  ptr.To("tcp"),
+				PortMin:   ptr.To(int64(80)),
+				PortMax:   ptr.To(int64(80)),
+				Remote:    &vpcv1.SecurityGroupRuleRemote{CIDRBlock: ptr.To("0.0.0.0/0")},
+			},
+		}
+		clusterScope := ClusterScope{IBMVPCClient: mockVPC, IBMPowerVSCluster: &infrav1.IBMPowerVSCluster{}}
+		mockVPC.EXPECT().CreateSecurityGroupRule(gomock.Any()).Return(
+			&vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp{ID: ptr.To("new-rule-id")}, nil, nil,
+		)
+		ruleIDs, err := clusterScope.createVPCSecurityGroupRules(ctx, specRules, "sg-id", existingRules)
+		g.Expect(err).To(BeNil())
+		g.Expect(ruleIDs).To(Equal([]string{"new-rule-id"}))
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Every reconcile was calling the IBM Cloud API to create SG rules unconditionally.
Rules kept adding up, hit the 250-per-group limit after ~63 passes, and broke
the cluster. Fix builds a key (direction + protocol + ports + remote), checks
existing rules before creating, and skips if already there.

**Which issue(s) this PR fixes**:
Fixes #2937

**Special notes for your reviewer**:

/area provider/ibmcloud

**Release note**:
```release-note
Fix duplicate VPC security group rule creation on every reconcile.