### PR TITLE
🐛 Fix data race on v1beta1 conditions in IBMPowerVSCluster reconcile

### DIFF
--- a/internal/controllers/powervs/ibmpowervscluster_controller.go
+++ b/internal/controllers/powervs/ibmpowervscluster_controller.go
@@ -75,6 +75,14 @@ type IBMPowerVSClusterReconciler struct {
 	ClientFactory powervsscope.ClientFactory
 }
 
+// powerVSCluster wraps the IBMPowerVSCluster so that the PowerVS and VPC
+// reconcilers, which run concurrently, can record conditions on the same
+// object safely.
+//
+// Both the v1beta2 and the deprecated v1beta1 condition setters do a
+// read-modify-write on a slice hanging off the cluster status, so every write
+// has to go through mu. Use updateCondition and updateV1Beta1Condition, never
+// the conditions packages directly on cluster.
 type powerVSCluster struct {
 	cluster *infrav1.IBMPowerVSCluster
 	mu      sync.Mutex
@@ -227,7 +235,13 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 	// reconcile Transit Gateway
 	log.Info("Reconciling transit gateway")
 	if requeue, err := clusterScope.ReconcileTransitGateway(ctx); err != nil {
-		deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition, infrav1.TransitGatewayReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
+			Status:   corev1.ConditionFalse,
+			Type:     infrav1.TransitGatewayReadyV1Beta2Condition,
+			Reason:   infrav1.TransitGatewayReconciliationFailedV1Beta2Reason,
+			Severity: clusterv1.ConditionSeverityError,
+			Message:  err.Error(),
+		})
 		powerVSCluster.updateCondition(metav1.Condition{
 			Type:    infrav1.TransitGatewayReadyCondition,
 			Status:  metav1.ConditionFalse,
@@ -239,7 +253,10 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 		log.Info("Creating a transit gateway is pending, requeuing")
 		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
-	deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.TransitGatewayReadyV1Beta2Condition)
+	powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
+		Status: corev1.ConditionTrue,
+		Type:   infrav1.TransitGatewayReadyV1Beta2Condition,
+	})
 	powerVSCluster.updateCondition(metav1.Condition{
 		Type:   infrav1.TransitGatewayReadyCondition,
 		Status: metav1.ConditionTrue,
@@ -250,7 +267,13 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 	if clusterScope.IBMPowerVSCluster.Spec.Ignition != nil {
 		log.Info("Reconciling COS service instance")
 		if err := clusterScope.ReconcileCOSInstance(ctx); err != nil {
-			deprecatedv1beta1conditions.MarkFalse(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition, infrav1.COSInstanceReconciliationFailedV1Beta2Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
+			powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
+				Status:   corev1.ConditionFalse,
+				Type:     infrav1.COSInstanceReadyV1Beta2Condition,
+				Reason:   infrav1.COSInstanceReconciliationFailedV1Beta2Reason,
+				Severity: clusterv1.ConditionSeverityError,
+				Message:  err.Error(),
+			})
 			powerVSCluster.updateCondition(metav1.Condition{
 				Type:    infrav1.COSInstanceReadyCondition,
 				Status:  metav1.ConditionFalse,
@@ -259,7 +282,10 @@ func (r *IBMPowerVSClusterReconciler) reconcile(ctx context.Context, clusterScop
 			})
 			return reconcile.Result{}, fmt.Errorf("failed to reconcile COS instance: %w", err)
 		}
-		deprecatedv1beta1conditions.MarkTrue(powerVSCluster.cluster, infrav1.COSInstanceReadyV1Beta2Condition)
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
+			Status: corev1.ConditionTrue,
+			Type:   infrav1.COSInstanceReadyV1Beta2Condition,
+		})
 		powerVSCluster.updateCondition(metav1.Condition{
 			Type:   infrav1.COSInstanceReadyCondition,
 			Status: metav1.ConditionTrue,
@@ -311,7 +337,7 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 	// reconcile PowerVS service instance
 	log.Info("Reconciling PowerVS service instance")
 	if requeue, err := clusterScope.ReconcilePowerVSServiceInstance(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.ServiceInstanceReadyV1Beta2Condition,
 			Reason:   infrav1.ServiceInstanceReconciliationFailedV1Beta2Reason,
@@ -331,7 +357,7 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+	powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.ServiceInstanceReadyV1Beta2Condition,
 	})
@@ -346,7 +372,7 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 	// reconcile network
 	log.Info("Reconciling network")
 	if networkActive, err := clusterScope.ReconcileNetwork(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.NetworkReadyV1Beta2Condition,
 			Reason:   infrav1.NetworkReconciliationFailedV1Beta2Reason,
@@ -362,7 +388,7 @@ func (r *IBMPowerVSClusterReconciler) reconcilePowerVSResources(ctx context.Cont
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile network: %w", err)}
 		return
 	} else if networkActive {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status: corev1.ConditionTrue,
 			Type:   infrav1.NetworkReadyV1Beta2Condition,
 		})
@@ -387,7 +413,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	defer log.Info("Finished VPC reconciliation")
 
 	if requeue, err := clusterScope.ReconcileVPC(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCReadyV1Beta2Condition,
 			Reason:   infrav1.VPCReconciliationFailedV1Beta2Reason,
@@ -407,7 +433,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+	powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCReadyV1Beta2Condition,
 	})
@@ -420,7 +446,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile VPC Subnet
 	log.Info("Reconciling VPC subnets")
 	if requeue, err := clusterScope.ReconcileVPCSubnets(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCSubnetReadyV1Beta2Condition,
 			Reason:   infrav1.VPCSubnetReconciliationFailedV1Beta2Reason,
@@ -440,7 +466,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{RequeueAfter: 20 * time.Second}, nil}
 		return
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+	powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCSubnetReadyV1Beta2Condition,
 	})
@@ -453,7 +479,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile VPC security group
 	log.Info("Reconciling VPC security group")
 	if err := clusterScope.ReconcileVPCSecurityGroups(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.VPCSecurityGroupReadyV1Beta2Condition,
 			Reason:   infrav1.VPCSecurityGroupReconciliationFailedV1Beta2Reason,
@@ -469,7 +495,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC security groups: %w", err)}
 		return
 	}
-	deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+	powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 		Status: corev1.ConditionTrue,
 		Type:   infrav1.VPCSecurityGroupReadyV1Beta2Condition,
 	})
@@ -482,7 +508,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 	// reconcile LoadBalancer
 	log.Info("Reconciling VPC load balancers")
 	if loadBalancerReady, err := clusterScope.ReconcileLoadBalancers(ctx); err != nil {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status:   corev1.ConditionFalse,
 			Type:     infrav1.LoadBalancerReadyV1Beta2Condition,
 			Reason:   infrav1.LoadBalancerReconciliationFailedV1Beta2Reason,
@@ -498,7 +524,7 @@ func (r *IBMPowerVSClusterReconciler) reconcileVPCResources(ctx context.Context,
 		ch <- reconcileResult{reconcile.Result{}, fmt.Errorf("failed to reconcile VPC load balancers: %w", err)}
 		return
 	} else if loadBalancerReady {
-		deprecatedv1beta1conditions.Set(powerVSCluster.cluster, &clusterv1.Condition{
+		powerVSCluster.updateV1Beta1Condition(&clusterv1.Condition{
 			Status: corev1.ConditionTrue,
 			Type:   infrav1.LoadBalancerReadyV1Beta2Condition,
 		})
@@ -645,6 +671,14 @@ func (update *powerVSCluster) updateCondition(condition metav1.Condition) {
 	update.mu.Lock()
 	defer update.mu.Unlock()
 	conditions.Set(update.cluster, condition)
+}
+
+// updateV1Beta1Condition sets a deprecated v1beta1 condition under the same
+// lock as updateCondition.
+func (update *powerVSCluster) updateV1Beta1Condition(condition *clusterv1.Condition) {
+	update.mu.Lock()
+	defer update.mu.Unlock()
+	deprecatedv1beta1conditions.Set(update.cluster, condition)
 }
 
 func (r *IBMPowerVSClusterReconciler) deleteIBMPowerVSImage(ctx context.Context, clusterScope *powervsscope.ClusterScope) (ctrl.Result, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines:
       https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/CONTRIBUTING.md#contributing-a-patch

    2. Please add an emoji prefix to the title of this PR (see https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/main/CONTRIBUTING.md#contributing-a-patch):
       ⚠️ (:warning:)  — major or breaking changes
       ✨ (:sparkles:) — feature additions
       🐛 (:bug:)      — patch and bugfixes
       📖 (:book:)     — documentation or proposals
       🌱 (:seedling:) — minor or other
       The PR title emoji is validated by CI and will block merging if missing.

    3. If the PR is unfinished, prefix the title with "WIP" or open it as a Draft PR.

-->

**What this PR does / why we need it**:

`reconcilePowerVSResources` and `reconcileVPCResources` run concurrently on the same `IBMPowerVSCluster`. The v1beta2 conditions were already written under `powerVSCluster.mu` via `updateCondition`, but every deprecated v1beta1 write called `deprecatedv1beta1conditions.Set/MarkTrue/MarkFalse` directly on the shared object, outside the lock.

Those setters do a read-modify-write on `Status.Deprecated.V1Beta1.Conditions` (get slice, append, sort, set back), so two concurrent writers can both read the same slice and the second write drops the first condition.

This PR adds `updateV1Beta1Condition`, the v1beta1 counterpart of `updateCondition`, and routes all 16 v1beta1 condition writes through it so both condition lists are protected by the same mutex.

Note that `main` is not affected: the refactor to `componentResult` there already has the concurrent reconcilers return their conditions for the caller to apply sequentially. This is the equivalent minimal fix for `release-0.14`, which still carries both the goroutine design and the v1beta1 conditions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes the flake in `TestIBMPowerVSClusterReconciler_reconcile`, where `NetworkReady` or another condition is intermittently missing from the expected set. Seen on unrelated PRs, e.g. #2934 (otel bump) and #2913 (doc link change).

**Special notes for your reviewer**:

/area provider/ibmcloud

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a data race in the IBMPowerVSCluster controller
```
